### PR TITLE
Add scope: Tuning to table rendering and options

### DIFF
--- a/src/modules/Preservation/views/AddScope/SelectTags.style.ts
+++ b/src/modules/Preservation/views/AddScope/SelectTags.style.ts
@@ -50,3 +50,11 @@ export const LoadingContainer = styled.div`
     background-color: ${tokens.colors.ui.background__default.rgba};
     height: 100%
 `;
+
+export const Toolbar = styled.div`
+    font-size: calc(var(--grid-unit) * 2);
+    line-height: calc(var(--grid-unit) * 3);
+    margin-top: calc(var(--grid-unit) * 2);
+    margin-bottom: var(--grid-unit);
+    color: ${tokens.colors.text.static_icons__secondary.rgba};
+`;

--- a/src/modules/Preservation/views/AddScope/SelectTags.tsx
+++ b/src/modules/Preservation/views/AddScope/SelectTags.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Button, TextField } from '@equinor/eds-core-react';
-import CheckBoxIcon from '@material-ui/icons/Checkbox';
+import CheckBoxIcon from '@material-ui/icons/CheckBox';
 import { Tag, TagRow } from './types';
 import { Container, Header, Actions, Search, Next, Tags, TagsHeader, LoadingContainer, Toolbar } from './SelectTags.style';
 import { usePreservationContext } from '../../context/PreservationContext';

--- a/src/modules/Preservation/views/AddScope/SelectTags.tsx
+++ b/src/modules/Preservation/views/AddScope/SelectTags.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Button, TextField } from '@equinor/eds-core-react';
-import { CheckBox } from '@material-ui/icons';
+import CheckBoxIcon from '@material-ui/icons/Checkbox';
 import { Tag, TagRow } from './types';
 import { Container, Header, Actions, Search, Next, Tags, TagsHeader, LoadingContainer, Toolbar } from './SelectTags.style';
 import { usePreservationContext } from '../../context/PreservationContext';
@@ -27,7 +27,7 @@ const tableColumns = [
     { 
         title: 'Preserved', 
         field: 'isPreserved',
-        render: (rowData: TagRow): any => rowData.isPreserved && <CheckBox />
+        render: (rowData: TagRow): any => rowData.isPreserved && <CheckBoxIcon />
     },
     { title: 'MC pkg', field: 'mcPkgNo' }
 ];

--- a/src/modules/Preservation/views/AddScope/SelectTags.tsx
+++ b/src/modules/Preservation/views/AddScope/SelectTags.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
 import { Button, TextField } from '@equinor/eds-core-react';
+import { CheckBox } from '@material-ui/icons';
 import { Tag, TagRow } from './types';
-import { Container, Header, Actions, Search, Next, Tags, TagsHeader, LoadingContainer } from './SelectTags.style';
+import { Container, Header, Actions, Search, Next, Tags, TagsHeader, LoadingContainer, Toolbar } from './SelectTags.style';
 import { usePreservationContext } from '../../context/PreservationContext';
 import Table from './../../../../components/Table';
 import Loading from './../../../../components/Loading';
@@ -19,12 +20,16 @@ type SelectTagsProps = {
 const KEYCODE_ENTER = 13;
 
 const tableColumns = [
-    { title: 'Tag nr', field: 'tagNo' },
+    { title: 'Tag no', field: 'tagNo' },
     { title: 'Description', field: 'description' },
     { title: 'PO no', field: 'purchaseOrderNumber' },
     { title: 'Comm pkg', field: 'commPkgNo' },
-    { title: 'Preserved', field: 'isPreserved' },
-    { title: 'MC package nr', field: 'mcPkgNo' }
+    { 
+        title: 'Preserved', 
+        field: 'isPreserved',
+        render: (rowData: TagRow): any => rowData.isPreserved && <CheckBox />
+    },
+    { title: 'MC pkg', field: 'mcPkgNo' }
 ];
 
 const SelectTags = (props: SelectTagsProps): JSX.Element => {
@@ -67,8 +72,20 @@ const SelectTags = (props: SelectTagsProps): JSX.Element => {
                     data={props.scopeTableData} 
                     options={{
                         showTitle: false,
+                        search: false,
+                        draggable: false,
+                        pageSize: 10,
+                        pageSizeOptions: [10, 50, 100],
+                        headerStyle: {
+                            backgroundColor: '#f7f7f7'
+                        },
                         selection: true,
-                        search: false
+                        selectionProps: (data: TagRow): any => ({
+                            disabled: data.isPreserved,
+                            // Bug: 'Select all' will also select disabled checkboxes: https://github.com/mbrn/material-table/issues/686
+                            // Disabled checkbox should be hidden, but that would also hide the 'select all' problem
+                            // style: { display: rowData.isPreserved && 'none' }
+                        })
                     }} 
                     style={{
                         boxShadow: 'none' 
@@ -80,6 +97,9 @@ const SelectTags = (props: SelectTagsProps): JSX.Element => {
                             <LoadingContainer>
                                 <Loading title="Loading tags" />
                             </LoadingContainer>                            
+                        ),
+                        Toolbar: (data): any => (
+                            <Toolbar>{data.selectedRows.length} tags selected</Toolbar>
                         )
                     }}
                 />


### PR DESCRIPTION
- "Preserved" column with checkbox icon
- Table header style
- Toolbar component (number of rows selected)
- Disable selection of preserved tags (see bug comment)