### PR TITLE
Tag Requirements - Save

### DIFF
--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -4,19 +4,26 @@ import { Container, Checkmark } from './style';
 
 interface CheckboxProps {
     children?: ReactNode;
+    onChange?: (event: React.FormEvent<HTMLInputElement>) => void;
     checked?: boolean;
     disabled?: boolean;
 }
 
 const Checkbox = ({
     children,
+    onChange,
     checked = false,
     disabled = false
 }: CheckboxProps): JSX.Element => {
     return (
         <Container disabled={disabled}>
             { children }
-            <input type="checkbox" defaultChecked={checked} disabled={disabled} />
+            <input 
+                type="checkbox" 
+                defaultChecked={checked} 
+                disabled={disabled} 
+                onChange={onChange} 
+            />
             <Checkmark className="checkmark" disabled={disabled} />
         </Container>
     );

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -4,7 +4,7 @@ import { Container, Checkmark } from './style';
 
 interface CheckboxProps {
     children?: ReactNode;
-    onChange?: (event: React.FormEvent<HTMLInputElement>) => void;
+    onChange?: (checked: boolean) => void;
     checked?: boolean;
     disabled?: boolean;
 }
@@ -15,6 +15,11 @@ const Checkbox = ({
     checked = false,
     disabled = false
 }: CheckboxProps): JSX.Element => {
+
+    const handleOnChange = (event: React.FormEvent<HTMLInputElement>): void => {
+        onChange && onChange(event.currentTarget.checked);
+    };
+
     return (
         <Container disabled={disabled}>
             { children }
@@ -22,7 +27,7 @@ const Checkbox = ({
                 type="checkbox" 
                 defaultChecked={checked} 
                 disabled={disabled} 
-                onChange={onChange} 
+                onChange={handleOnChange} 
             />
             <Checkmark className="checkmark" disabled={disabled} />
         </Container>

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -5,17 +5,19 @@ import { Container, Checkmark } from './style';
 interface CheckboxProps {
     children?: ReactNode;
     checked?: boolean;
+    disabled?: boolean;
 }
 
 const Checkbox = ({
     children,
-    checked = false
+    checked = false,
+    disabled = false
 }: CheckboxProps): JSX.Element => {
     return (
-        <Container>
+        <Container disabled={disabled}>
             { children }
-            <input type="checkbox" defaultChecked={checked} />
-            <Checkmark className="checkmark" />
+            <input type="checkbox" defaultChecked={checked} disabled={disabled} />
+            <Checkmark className="checkmark" disabled={disabled} />
         </Container>
     );
 };

--- a/src/components/Checkbox/style.ts
+++ b/src/components/Checkbox/style.ts
@@ -1,12 +1,17 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { tokens } from '@equinor/eds-tokens';
 
-export const Container = styled.label`
+interface CheckboxStyleProps {
+    disabled: boolean;
+}
+
+export const Container = styled.label<CheckboxStyleProps>`
     /* The container */
     display: block;
     position: relative;
     padding-left: calc(var(--grid-unit) * 4);
-    cursor: pointer;
+    
+    cursor: ${(props): string => props.disabled ? 'not-allowed' : 'pointer'};
 
     /* Hide the browser's default checkbox */
     input {
@@ -18,9 +23,11 @@ export const Container = styled.label`
     }
 
     /* On mouse-over, add a background color */
-    :hover input ~ .checkmark {
-        background-color: ${tokens.colors.interactive.primary__selected_highlight.rgba};
-    }
+    ${(props): any => !props.disabled && css`
+        :hover input ~ .checkmark {
+            background-color: ${tokens.colors.interactive.primary__selected_highlight.rgba};
+        }
+    `}
 
     /* When the checkbox is checked, add a fill background */
     input:checked ~ .checkmark {
@@ -46,7 +53,7 @@ export const Container = styled.label`
     }
 `;
 
-export const Checkmark = styled.span`
+export const Checkmark = styled.span<CheckboxStyleProps>`
     /* Create a custom checkbox */
     position: absolute;
     top: 0;
@@ -55,7 +62,10 @@ export const Checkmark = styled.span`
     width: calc(var(--grid-unit) * 2);
     background-color: ${tokens.colors.ui.background__default.rgba};
     border-radius: 3px;
-    border: solid 2px ${tokens.colors.interactive.primary__resting.rgba};
+
+    border: solid 2px ${(props): string => props.disabled
+        ? tokens.colors.interactive.disabled__fill.rgba
+        : tokens.colors.interactive.primary__resting.rgba};
 
     /* Create the checkmark/indicator (hidden when not checked) */
     :after {

--- a/src/core/services/NotificationService/index.tsx
+++ b/src/core/services/NotificationService/index.tsx
@@ -29,7 +29,7 @@ const Notification = (props: NotificationProps): JSX.Element => {
  */
 export const showSnackbarNotification = (
     message: string,
-    duration: number,
+    duration = 5000,
     displayRight = false
 ): any => {
     clearTimeout(lastTimeoutId);

--- a/src/core/services/NotificationService/index.tsx
+++ b/src/core/services/NotificationService/index.tsx
@@ -9,11 +9,14 @@ document.body.appendChild(snackbarContainer);
 
 interface NotificationProps {
     message?: string;
+    displayRight: boolean;
 }
 
 const Notification = (props: NotificationProps): JSX.Element => {
     return (
-        <StyledSnackbarNotification>{props.message}</StyledSnackbarNotification>
+        <StyledSnackbarNotification displayRight={props.displayRight}>
+            {props.message}
+        </StyledSnackbarNotification>
     );
 };
 
@@ -26,10 +29,11 @@ const Notification = (props: NotificationProps): JSX.Element => {
  */
 export const showSnackbarNotification = (
     message: string,
-    duration: number
+    duration: number,
+    displayRight = false
 ): any => {
     clearTimeout(lastTimeoutId);
-    render(<Notification message={message} />, snackbarContainer);
+    render(<Notification message={message} displayRight={displayRight} />, snackbarContainer);
 
     lastTimeoutId = setTimeout(() => {
         render(<></>, snackbarContainer);

--- a/src/core/services/NotificationService/style.ts
+++ b/src/core/services/NotificationService/style.ts
@@ -1,6 +1,10 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-export const StyledSnackbarNotification = styled.div`
+interface NotificationProps {
+    displayRight: boolean;
+}
+
+export const StyledSnackbarNotification = styled.div<NotificationProps>`
     min-width: 250px;
     box-shadow: 0px 3px 5px rgba(0, 0, 0, 0.2), 0px 1px 18px rgba(0, 0, 0, 0.12),
         0px 6px 10px rgba(0, 0, 0, 0.14);
@@ -9,6 +13,15 @@ export const StyledSnackbarNotification = styled.div`
     color: #ffffff;
     padding: calc(var(--grid-unit) * 2);
     position: fixed;
-    left: calc(var(--grid-unit) * 4);
+    z-index: 999;
+
     bottom: calc(var(--grid-unit) * 4);
+
+    ${(props): any => props.displayRight && css`
+        right: calc(var(--grid-unit) * 4);
+    `}
+
+    ${(props): any => !props.displayRight && css`
+        left: calc(var(--grid-unit) * 4);
+    `}
 `;

--- a/src/modules/Preservation/http/PreservationApiClient.ts
+++ b/src/modules/Preservation/http/PreservationApiClient.ts
@@ -480,7 +480,7 @@ class PreservationApiClient extends ApiClient {
         }
     }
 
-    async recordTagRequirementValues(tagId: number | null, recordValues: TagRequirementRecordValues, setRequestCanceller?: RequestCanceler): Promise<void> {
+    async recordTagRequirementValues(tagId: number, recordValues: TagRequirementRecordValues, setRequestCanceller?: RequestCanceler): Promise<void> {
         const endpoint = `/Tags/${tagId}/Requirement/${recordValues.requirementId}/RecordValues`;
         const settings: AxiosRequestConfig = {};
         this.setupRequestCanceler(settings, setRequestCanceller);

--- a/src/modules/Preservation/http/PreservationApiClient.ts
+++ b/src/modules/Preservation/http/PreservationApiClient.ts
@@ -151,7 +151,6 @@ interface PreserveTagRequirement {
 }
 
 interface TagRequirementRecordValues {
-    tagId: number | null;
     requirementId: number;
     comment: string | null;
     fieldValues: RecordFieldValue[];
@@ -481,8 +480,8 @@ class PreservationApiClient extends ApiClient {
         }
     }
 
-    async recordTagRequirementValues(recordValues: TagRequirementRecordValues, setRequestCanceller?: RequestCanceler): Promise<void> {
-        const endpoint = `/Tags/${recordValues.tagId}/Requirement/${recordValues.requirementId}/RecordValues`;
+    async recordTagRequirementValues(tagId: number | null, recordValues: TagRequirementRecordValues, setRequestCanceller?: RequestCanceler): Promise<void> {
+        const endpoint = `/Tags/${tagId}/Requirement/${recordValues.requirementId}/RecordValues`;
         const settings: AxiosRequestConfig = {};
         this.setupRequestCanceler(settings, setRequestCanceller);
 

--- a/src/modules/Preservation/http/PreservationApiClient.ts
+++ b/src/modules/Preservation/http/PreservationApiClient.ts
@@ -149,6 +149,18 @@ interface PreserveTagRequirement {
     intervalWeeks: number;
 }
 
+interface TagRequirementRecordValues {
+    tagId: number | null;
+    requirementId: number;
+    comment: string | null;
+    fieldValues: RecordFieldValue[];
+}
+
+interface RecordFieldValue {
+    fieldId: number;
+    value: string;
+}
+
 interface ErrorResponse {
     ErrorCount: number;
     Errors: {
@@ -464,6 +476,25 @@ class PreservationApiClient extends ApiClient {
             return result.data;
         }
         catch (error) {
+            throw getPreservationApiError(error);
+        }
+    }
+
+    async recordTagRequirementValues(recordValues: TagRequirementRecordValues, setRequestCanceller?: RequestCanceler): Promise<void> {
+        const endpoint = `/Tags/${recordValues.tagId}/Requirement/${recordValues.requirementId}/RecordValues`;
+        const settings: AxiosRequestConfig = {};
+        this.setupRequestCanceler(settings, setRequestCanceller);
+
+        try {
+            await this.client.post(
+                endpoint,
+                {
+                    fieldValues: recordValues.fieldValues,
+                    comment: recordValues.comment
+                },
+                settings
+            );
+        } catch (error) {
             throw getPreservationApiError(error);
         }
     }

--- a/src/modules/Preservation/http/PreservationApiClient.ts
+++ b/src/modules/Preservation/http/PreservationApiClient.ts
@@ -142,6 +142,7 @@ interface TagRequirementsResponse {
             };
         }
     ];
+    comment: string;
 }
 
 interface PreserveTagRequirement {

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/PreservationTab.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/PreservationTab.tsx
@@ -32,18 +32,18 @@ const PreservationTab = ({
     };
 
     const recordTagRequirementValues = async (values: TagRequirementRecordValues): Promise<void> => {
-        try {
-            setTagRequirements(undefined); // trigger the spinner
-
-            await apiClient.recordTagRequirementValues(tagId, values);            
-            showSnackbarNotification('Requirement values saved', 4000, true);
-        }
-        catch (error) {
-            console.error(`Record TagRequirement values failed: ${error.message}`);
-            showSnackbarNotification(error.message, 6000, true);
-        }
-        finally {
-            if (tagId !== null) {
+        if (tagId !== null) {
+            try {
+                setTagRequirements(undefined); // trigger the spinner
+    
+                await apiClient.recordTagRequirementValues(tagId, values);            
+                showSnackbarNotification('Requirement values saved', 4000, true);
+            }
+            catch (error) {
+                console.error(`Record TagRequirement values failed: ${error.message}`);
+                showSnackbarNotification(error.message, 6000, true);
+            }
+            finally {
                 getTagRequirements(tagId);
             }
         }

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/PreservationTab.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/PreservationTab.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 
 import { Container, TagDetailsContainer, Details, GridFirstRow, GridSecondRow, RemarkContainer } from './PreservationTab.style';
 import { TextField, Typography } from '@equinor/eds-core-react';
-import { TagDetails, TagRequirement } from './../types';
+import { TagDetails, TagRequirement, TagRequirementRecordValues } from './../types';
 import Requirements from './Requirements';
 import Spinner from '../../../../../../components/Spinner';
 import { usePreservationContext } from '../../../../context/PreservationContext';
@@ -27,6 +27,27 @@ const PreservationTab = ({
         }
         catch (error) {
             console.error(`Get TagRequirements failed: ${error.message}`);
+            showSnackbarNotification(error.message, 5000);
+        }
+    };
+
+    const recordTagRequirementValues = async (values: TagRequirementRecordValues): Promise<void> => {
+        try {
+            setTagRequirements(undefined);
+            values.tagId = tagId;
+
+            apiClient.recordTagRequirementValues(values)
+                .then(() => {
+                    if (tagId !== null) {
+                        getTagRequirements(tagId);
+                    }
+
+                    // TODO: Snackbar message inside flyout
+                });
+        }
+        catch (error) {
+            // TODO: error is not properly thrown... (bad request)
+            console.error(`Record TagRequirement values failed: ${error.message}`);
             showSnackbarNotification(error.message, 5000);
         }
     };
@@ -79,7 +100,11 @@ const PreservationTab = ({
             <RemarkContainer>
                 <TextField id='remark' label='Remark' disabled />
             </RemarkContainer>
-            <Requirements requirements={tagRequirements} readonly={isReadOnly()} />
+            <Requirements 
+                requirements={tagRequirements} 
+                readonly={isReadOnly()} 
+                recordTagRequirementValues={recordTagRequirementValues} 
+            />
         </Container>
     );
 };

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/PreservationTab.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/PreservationTab.tsx
@@ -34,9 +34,8 @@ const PreservationTab = ({
     const recordTagRequirementValues = async (values: TagRequirementRecordValues): Promise<void> => {
         try {
             setTagRequirements(undefined); // trigger the spinner
-            values.tagId = tagId; // provide tagId
 
-            await apiClient.recordTagRequirementValues(values);  
+            await apiClient.recordTagRequirementValues(tagId, values);  
             
             // TODO: notification inside Flyout..
             showSnackbarNotification('Requirement values saved', 4000);

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/PreservationTab.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/PreservationTab.tsx
@@ -35,14 +35,12 @@ const PreservationTab = ({
         try {
             setTagRequirements(undefined); // trigger the spinner
 
-            await apiClient.recordTagRequirementValues(tagId, values);  
-            
-            // TODO: notification inside Flyout..
-            showSnackbarNotification('Requirement values saved', 4000);
+            await apiClient.recordTagRequirementValues(tagId, values);            
+            showSnackbarNotification('Requirement values saved', 4000, true);
         }
         catch (error) {
             console.error(`Record TagRequirement values failed: ${error.message}`);
-            showSnackbarNotification(error.message, 6000);
+            showSnackbarNotification(error.message, 6000, true);
         }
         finally {
             if (tagId !== null) {

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/PreservationTab.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/PreservationTab.tsx
@@ -31,6 +31,12 @@ const PreservationTab = ({
         }
     };
 
+    const isReadOnly = (): boolean => {
+        return tagDetails 
+            ? tagDetails.status.toLowerCase() !== 'active' 
+            : false;
+    };
+
     useEffect(() => {
         if (tagId !== null) {
             getTagRequirements(tagId);
@@ -73,7 +79,7 @@ const PreservationTab = ({
             <RemarkContainer>
                 <TextField id='remark' label='Remark' disabled />
             </RemarkContainer>
-            <Requirements requirements={tagRequirements} />
+            <Requirements requirements={tagRequirements} readonly={isReadOnly()} />
         </Container>
     );
 };

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/PreservationTab.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/PreservationTab.tsx
@@ -33,22 +33,22 @@ const PreservationTab = ({
 
     const recordTagRequirementValues = async (values: TagRequirementRecordValues): Promise<void> => {
         try {
-            setTagRequirements(undefined);
-            values.tagId = tagId;
+            setTagRequirements(undefined); // trigger the spinner
+            values.tagId = tagId; // provide tagId
 
-            apiClient.recordTagRequirementValues(values)
-                .then(() => {
-                    if (tagId !== null) {
-                        getTagRequirements(tagId);
-                    }
-
-                    // TODO: Snackbar message inside flyout
-                });
+            await apiClient.recordTagRequirementValues(values);  
+            
+            // TODO: notification inside Flyout..
+            showSnackbarNotification('Requirement values saved', 4000);
         }
         catch (error) {
-            // TODO: error is not properly thrown... (bad request)
             console.error(`Record TagRequirement values failed: ${error.message}`);
-            showSnackbarNotification(error.message, 5000);
+            showSnackbarNotification(error.message, 6000);
+        }
+        finally {
+            if (tagId !== null) {
+                getTagRequirements(tagId);
+            }
         }
     };
 

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/RequirementCheckboxField.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/RequirementCheckboxField.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { TagRequirementField } from './../types';
+import { Typography } from '@equinor/eds-core-react';
+import Checkbox from './../../../../../../components/Checkbox';
+
+interface RequirementCheckboxFieldProps {
+    requirementId: number;
+    field: TagRequirementField;
+    readonly: boolean;
+    setFieldValue: (requirementId: number, fieldId: number, value: string) => void;
+}
+
+const RequirementCheckBoxField = ({
+    requirementId,
+    field,
+    readonly,
+    setFieldValue
+}: RequirementCheckboxFieldProps): JSX.Element => {
+
+    const isChecked = field.currentValue && field.currentValue.isChecked;
+
+    return (
+        <Checkbox 
+            checked={isChecked} 
+            disabled={readonly}
+            onChange={(checked: boolean): void => {
+                setFieldValue(requirementId, field.id, checked.toString());
+            }}
+        >
+            <Typography variant='body_long'>{field.label}</Typography>
+        </Checkbox>
+    );
+};
+
+export default RequirementCheckBoxField;

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/RequirementNumberField.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/RequirementNumberField.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import { TagRequirementField } from './../types';
+import { TextField } from '@equinor/eds-core-react';
+
+interface RequirementNumberFieldProps {
+    requirementId: number;
+    field: TagRequirementField;
+    readonly: boolean;
+    setFieldValue: (requirementId: number, fieldId: number, value: string) => void;
+}
+
+const RequirementNumberField = ({
+    requirementId,
+    field,
+    readonly,
+    setFieldValue
+}: RequirementNumberFieldProps): JSX.Element => {
+
+    let currentValue: string | number | null = '';
+    if (field.currentValue) {
+        currentValue = field.currentValue.isNA ? 'N/A' : field.currentValue.value;
+    }
+
+    let previousValue: string | number | null = '';
+    if (field.previousValue) {
+        previousValue = field.previousValue.isNA ? 'N/A' : field.previousValue.value;
+    }
+
+    return (
+        <div style={{display: 'flex', alignItems: 'flex-end'}}>
+            <div style={{maxWidth: '25%'}}>
+                <TextField
+                    id={`field${field.id}`}
+                    label={field.label}
+                    meta={`(${field.unit})`}
+                    defaultValue={currentValue}
+                    disabled={readonly}
+                    onChange={(event: React.FormEvent<HTMLInputElement>): void => {
+                        setFieldValue(requirementId, field.id, event.currentTarget.value);
+                    }}
+                />
+            </div>
+            {
+                field.showPrevious &&
+                <div style={{maxWidth: '25%', marginLeft: 'calc(var(--grid-unit) * 3)'}}>
+                    <TextField
+                        id={`fieldPrevious${field.id}`}
+                        label='Previous value'
+                        meta={`(${field.unit})`}
+                        defaultValue={previousValue}
+                        disabled
+                    />
+                </div>                            
+            }
+        </div>
+    );
+};
+
+export default RequirementNumberField;

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
@@ -26,7 +26,7 @@ const Requirements = ({
         const requirement = newRequirementValues.find(value => value.requirementId == requirementId);
 
         if (requirement) {
-            const fieldIndex =  requirement.fieldValues.findIndex(field => field.fieldId == fieldId);
+            const fieldIndex = requirement.fieldValues.findIndex(field => field.fieldId == fieldId);
 
             if (fieldIndex > -1) {
                 requirement.fieldValues[fieldIndex].value = value;
@@ -91,6 +91,19 @@ const Requirements = ({
         }
 
         return requirementValues.findIndex(requirement => requirement.requirementId == requirementId) > -1;
+    };
+
+    const isPreserveButtonEnabled = (requirementId: number, isReadyToBePreserved: boolean): boolean => {
+        if (readonly) {
+            return false;
+        }
+
+        // has unsaved changes
+        if (requirementValues.findIndex(requirement => requirement.requirementId == requirementId) > -1) {
+            return false;
+        }
+
+        return isReadyToBePreserved;
     };
 
     const getNumberField = (requirementId: number, field: TagRequirementField): JSX.Element => {
@@ -238,7 +251,8 @@ const Requirements = ({
                                         Save
                                     </Button>
                                     <Button 
-                                        disabled 
+                                        disabled={!isPreserveButtonEnabled(requirement.id, requirement.readyToBePreserved)}
+                                        onClick={(): void => console.log('TODO: PBI #71519')}
                                         style={{marginLeft: 'calc(var(--grid-unit) * 2)'}}
                                     >
                                         Preserved this week

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
@@ -9,10 +9,12 @@ import { Container, Section, Field, NextInfo } from './Requirements.style';
 
 interface RequirementProps {
     requirements: TagRequirement[] | undefined;
+    readonly: boolean;
 }
 
 const Requirements = ({
-    requirements
+    requirements,
+    readonly
 }: RequirementProps): JSX.Element => {
 
     const getNumberField = (field: TagRequirementField): JSX.Element => {
@@ -34,6 +36,7 @@ const Requirements = ({
                         label={field.label}
                         meta={`(${field.unit})`}
                         defaultValue={currentValue}
+                        disabled={readonly}
                     />
                 </div>
                 {
@@ -56,7 +59,7 @@ const Requirements = ({
         const isChecked = field.currentValue && field.currentValue.isChecked;
 
         return (
-            <Checkbox checked={isChecked}>
+            <Checkbox checked={isChecked} disabled={readonly}>
                 <Typography variant='body_long'>{field.label}</Typography>
             </Checkbox>
         );
@@ -134,6 +137,7 @@ const Requirements = ({
                                     id={`requirementComment${requirement.id}`}
                                     label='Comment for this preservation period (optional)'
                                     placeholder='Write here'
+                                    disabled={readonly}
                                 />
                             </Section>
                             <Section>

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
@@ -13,17 +13,6 @@ interface RequirementProps {
     recordTagRequirementValues: (values: TagRequirementRecordValues) => void;
 }
 
-interface FieldValue {
-    fieldId: number;
-    value: string;
-}
-
-interface RequirementValues {
-    requirementId: number;
-    comment: string | null;
-    fieldValues: FieldValue[];
-}
-
 const Requirements = ({
     requirements,
     readonly,
@@ -49,7 +38,7 @@ const Requirements = ({
             }
         } else {
             newRequirementValues.push({
-                tagId: null,
+                tagId: null, // will be provided by PreservationTab
                 requirementId: requirementId,
                 comment: null,
                 fieldValues: [
@@ -72,7 +61,7 @@ const Requirements = ({
             requirement.comment = comment;
         } else {
             newRequirementValues.push({
-                tagId: null,
+                tagId: null, // will be provided by PreservationTab
                 requirementId: requirementId,
                 comment: comment,
                 fieldValues: []
@@ -89,6 +78,9 @@ const Requirements = ({
             console.error(`No values to record found for requirementId ${requirementId}`);
             return;
         }
+
+        // reset values before save (prepare for subsequent edits)
+        setRequirementValues([]);
 
         recordTagRequirementValues(requirement);
     };
@@ -231,6 +223,7 @@ const Requirements = ({
                                     label='Comment for this preservation period (optional)'
                                     placeholder='Write here'
                                     disabled={readonly}
+                                    defaultValue={requirement.comment}
                                     onChange={(event: React.FormEvent<HTMLInputElement>): void => {
                                         setComment(requirement.id, event.currentTarget.value);
                                     }}

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 
 import { Button, TextField, Typography } from '@equinor/eds-core-react';
 import { TagRequirement, TagRequirementField, TagRequirementRecordValues } from './../types';
-import Checkbox from './../../../../../../components/Checkbox';
+import RequirementNumberField from './RequirementNumberField';
+import RequirementCheckboxField from './RequirementCheckboxField';
 import PreservationIcon from '../../../PreservationIcon';
 import Spinner from '../../../../../../components/Spinner';
 import { Container, Section, Field, NextInfo } from './Requirements.style';
@@ -104,71 +105,28 @@ const Requirements = ({
         return isReadyToBePreserved;
     };
 
-    const getNumberField = (requirementId: number, field: TagRequirementField): JSX.Element => {
-        let currentValue: string | number | null = '';
-        if (field.currentValue) {
-            currentValue = field.currentValue.isNA ? 'N/A' : field.currentValue.value;
-        }
-
-        let previousValue: string | number | null = '';
-        if (field.previousValue) {
-            previousValue = field.previousValue.isNA ? 'N/A' : field.previousValue.value;
-        }
-
-        return (
-            <div style={{display: 'flex', alignItems: 'flex-end'}}>
-                <div style={{maxWidth: '25%'}}>
-                    <TextField
-                        id={`field${field.id}`}
-                        label={field.label}
-                        meta={`(${field.unit})`}
-                        defaultValue={currentValue}
-                        disabled={readonly}
-                        onChange={(event: React.FormEvent<HTMLInputElement>): void => {
-                            setFieldValue(requirementId, field.id, event.currentTarget.value);
-                        }}
-                    />
-                </div>
-                {
-                    field.showPrevious &&
-                    <div style={{maxWidth: '25%', marginLeft: 'calc(var(--grid-unit) * 3)'}}>
-                        <TextField
-                            id={`fieldPrevious${field.id}`}
-                            label='Previous value'
-                            meta={`(${field.unit})`}
-                            defaultValue={previousValue}
-                            disabled
-                        />
-                    </div>                            
-                }
-            </div>
-        );
-    };
-
-    const getCheckboxField = (requirementId: number, field: TagRequirementField): JSX.Element => {
-        const isChecked = field.currentValue && field.currentValue.isChecked;
-
-        return (
-            <Checkbox 
-                checked={isChecked} 
-                disabled={readonly}
-                onChange={(checked: boolean): void => {
-                    setFieldValue(requirementId, field.id, checked.toString());
-                }}
-            >
-                <Typography variant='body_long'>{field.label}</Typography>
-            </Checkbox>
-        );
-    };
-
     const getRequirementField = (requirementId: number, field: TagRequirementField): JSX.Element => {
         switch (field.fieldType.toLowerCase()) {
             case 'info':
                 return <Typography variant='body_long'>{field.label}</Typography>;
             case 'checkbox':
-                return getCheckboxField(requirementId, field);
+                return (
+                    <RequirementCheckboxField 
+                        requirementId={requirementId} 
+                        field={field} 
+                        readonly={readonly} 
+                        setFieldValue={setFieldValue} 
+                    />
+                );
             case 'number':
-                return getNumberField(requirementId, field);
+                return (
+                    <RequirementNumberField 
+                        requirementId={requirementId} 
+                        field={field} 
+                        readonly={readonly} 
+                        setFieldValue={setFieldValue} 
+                    />
+                );
             default:
                 return <div>Unknown field type</div>;
         }

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
@@ -38,7 +38,6 @@ const Requirements = ({
             }
         } else {
             newRequirementValues.push({
-                tagId: null, // will be provided by PreservationTab
                 requirementId: requirementId,
                 comment: null,
                 fieldValues: [
@@ -61,7 +60,6 @@ const Requirements = ({
             requirement.comment = comment;
         } else {
             newRequirementValues.push({
-                tagId: null, // will be provided by PreservationTab
                 requirementId: requirementId,
                 comment: comment,
                 fieldValues: []

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
@@ -152,8 +152,8 @@ const Requirements = ({
             <Checkbox 
                 checked={isChecked} 
                 disabled={readonly}
-                onChange={(event: React.FormEvent<HTMLInputElement>): void => {
-                    setFieldValue(requirementId, field.id, event.currentTarget.checked.toString());
+                onChange={(checked: boolean): void => {
+                    setFieldValue(requirementId, field.id, checked.toString());
                 }}
             >
                 <Typography variant='body_long'>{field.label}</Typography>

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { Button, TextField, Typography } from '@equinor/eds-core-react';
-import { TagRequirement, TagRequirementField } from './../types';
+import { TagRequirement, TagRequirementField, TagRequirementRecordValues } from './../types';
 import Checkbox from './../../../../../../components/Checkbox';
 import PreservationIcon from '../../../PreservationIcon';
 import Spinner from '../../../../../../components/Spinner';
@@ -10,6 +10,7 @@ import { Container, Section, Field, NextInfo } from './Requirements.style';
 interface RequirementProps {
     requirements: TagRequirement[] | undefined;
     readonly: boolean;
+    recordTagRequirementValues: (values: TagRequirementRecordValues) => void;
 }
 
 interface FieldValue {
@@ -25,10 +26,11 @@ interface RequirementValues {
 
 const Requirements = ({
     requirements,
-    readonly
+    readonly,
+    recordTagRequirementValues
 }: RequirementProps): JSX.Element => {
 
-    const [requirementValues, setRequirementValues] = useState<RequirementValues[]>([]);
+    const [requirementValues, setRequirementValues] = useState<TagRequirementRecordValues[]>([]);
 
     const setFieldValue = (requirementId: number, fieldId: number, value: string): void => {
         const newRequirementValues = [...requirementValues];
@@ -47,6 +49,7 @@ const Requirements = ({
             }
         } else {
             newRequirementValues.push({
+                tagId: null,
                 requirementId: requirementId,
                 comment: null,
                 fieldValues: [
@@ -69,6 +72,7 @@ const Requirements = ({
             requirement.comment = comment;
         } else {
             newRequirementValues.push({
+                tagId: null,
                 requirementId: requirementId,
                 comment: comment,
                 fieldValues: []
@@ -78,7 +82,7 @@ const Requirements = ({
         setRequirementValues(newRequirementValues);
     };    
 
-    const recordRequirementValues = (requirementId: number): void => {
+    const saveRequirement = (requirementId: number): void => {
         const requirement = requirementValues.find(req => req.requirementId == requirementId);
 
         if (!requirement) {
@@ -86,7 +90,7 @@ const Requirements = ({
             return;
         }
 
-        console.log('TODO: save', requirement);
+        recordTagRequirementValues(requirement);
     };
 
     const isSaveButtonEnabled = (requirementId: number): boolean => {
@@ -94,8 +98,7 @@ const Requirements = ({
             return false;
         }
 
-        const requirementHasValue = requirementValues.findIndex(requirement => requirement.requirementId == requirementId) > -1;
-        return requirementHasValue;
+        return requirementValues.findIndex(requirement => requirement.requirementId == requirementId) > -1;
     };
 
     const getNumberField = (requirementId: number, field: TagRequirementField): JSX.Element => {
@@ -237,7 +240,7 @@ const Requirements = ({
                                 <div style={{display: 'flex', marginTop: 'var(--grid-unit)', justifyContent: 'flex-end'}}>
                                     <Button 
                                         disabled={!isSaveButtonEnabled(requirement.id)} 
-                                        onClick={(): void => recordRequirementValues(requirement.id)}
+                                        onClick={(): void => saveRequirement(requirement.id)}
                                     >
                                         Save
                                     </Button>

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/TagFlyout.style.ts
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/TagFlyout.style.ts
@@ -27,8 +27,8 @@ export const HeaderNotification = styled.div`
 `;
 
 export const NotificationIcon = styled.div`
-    border-radius: 100px;
-    padding: 8px 10px;
+    border-radius: 50%;
+    padding: var(--grid-unit) calc(var(--grid-unit) + 2px);
     background: ${tokens.colors.infographic.primary__energy_red_13.rgba};
 
     svg path {

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/TagFlyout.style.ts
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/TagFlyout.style.ts
@@ -19,6 +19,23 @@ export const Header = styled.div`
     }
 `;
 
+export const HeaderNotification = styled.div`
+    display: flex;
+    align-items: center;
+    padding: calc(var(--grid-unit) * 2);
+    border-bottom: 2px solid ${tokens.colors.infographic.primary__energy_red_13.rgba};
+`;
+
+export const NotificationIcon = styled.div`
+    border-radius: 100px;
+    padding: 8px 10px;
+    background: ${tokens.colors.infographic.primary__energy_red_13.rgba};
+
+    svg path {
+        color: ${tokens.colors.interactive.danger__resting.rgba}
+    }
+`;
+
 export const StatusLabel = styled.div<{ status?: string }>`
     margin-left: calc(var(--grid-unit) * 3);
     padding: var(--grid-unit);

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/TagFlyout.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/TagFlyout.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from 'react';
 
-import { Container, Header, Tabs, StatusLabel, HeaderActions } from './TagFlyout.style';
+import { Container, Header, Tabs, StatusLabel, HeaderActions, HeaderNotification, NotificationIcon } from './TagFlyout.style';
 import PreservationTab from './PreservationTab/PreservationTab';
 import CloseIcon from '@material-ui/icons/Close';
-import { Button } from '@equinor/eds-core-react';
+import NotificationsOutlinedIcon from '@material-ui/icons/NotificationsOutlined';
+import { Button, Typography } from '@equinor/eds-core-react';
 import { usePreservationContext } from '../../../context/PreservationContext';
 import { showSnackbarNotification } from './../../../../../core/services/NotificationService';
 import { TagDetails } from './types';
@@ -53,8 +54,27 @@ const TagFlyout = ({
         }
     };
 
+    const showHeaderNotification = (): boolean => {
+        if (tagDetails) {
+            return tagDetails.status.toLowerCase() === 'notstarted';
+        }
+
+        return false;
+    };
+
     return (
         <Container style={{display: 'flex', flexDirection: 'column'}}>
+            {
+                showHeaderNotification() &&
+                <HeaderNotification>
+                    <NotificationIcon>
+                        <NotificationsOutlinedIcon />
+                    </NotificationIcon>
+                    <Typography variant='body_long' style={{marginLeft: 'calc(var(--grid-unit) * 2)'}}>
+                        This tag is not being preserved yet. Click start preservation to enable writing preservation records.
+                    </Typography>                
+                </HeaderNotification>
+            }
             <Header>
                 <h1>
                     {tagDetails ? tagDetails.tagNo : '-'}

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/types.d.ts
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/types.d.ts
@@ -23,6 +23,7 @@ export interface TagRequirement {
     nextDueAsYearAndWeek: string;
     readyToBePreserved: boolean;
     fields: TagRequirementField[];
+    comment: string;
 }
 
 export interface TagRequirementField {

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/types.d.ts
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/types.d.ts
@@ -45,3 +45,15 @@ export interface TagRequirementField {
         value: number | null;
     };
 }
+
+export interface TagRequirementRecordValues {
+    tagId: number | null;
+    requirementId: number;
+    comment: string | null;
+    fieldValues: RecordFieldValue[];
+}
+
+interface RecordFieldValue {
+    fieldId: number;
+    value: string;
+}

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/types.d.ts
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/types.d.ts
@@ -48,7 +48,6 @@ export interface TagRequirementField {
 }
 
 export interface TagRequirementRecordValues {
-    tagId: number | null;
     requirementId: number;
     comment: string | null;
     fieldValues: RecordFieldValue[];


### PR DESCRIPTION
* Save user input on tag requirements (number + checkbox) and comments.
* Enable/disable logic on buttons.
* Readonly logic when preservation has not started.
* Preservation not started notification in header.
* Allow snackbar notification to display on right-hand side (via props, for Flyout).
