### PR TITLE
Dropdown and Select - auto calc open to the left or right

### DIFF
--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -1,5 +1,5 @@
 import { Container, DropdownButton, DropdownIcon, DropdownItem, FilterContainer } from './style';
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import { useClickOutsideNotifier } from './../../hooks';
@@ -9,7 +9,6 @@ type DropdownProps = {
     text?: string;
     children?: React.ReactNode;
     Icon?: JSX.Element;
-    openLeft?: boolean;
     onFilter?: (input: string) => void;
     label?: string;
     variant?: string;
@@ -22,13 +21,13 @@ const Select: React.FC<DropdownProps> = ({
     text = '',
     Icon = <KeyboardArrowDownIcon />,
     children,
-    openLeft,
     onFilter,
     label,
     variant,
 }: DropdownProps): JSX.Element => {
     const [isOpen, setIsOpen] = useState(false);
     const containerRef = useRef<HTMLDivElement>(null);
+    const listRef = useRef<HTMLUListElement>(null);
     children = children ? React.Children.toArray(children) : [];
 
     useClickOutsideNotifier(() => {
@@ -42,8 +41,25 @@ const Select: React.FC<DropdownProps> = ({
         setIsOpen(!isOpen);
     };
 
+    /**
+     * Open dropdown to the left:
+     * When there is not enough space on the right-hand side of the viewport, relative to the dropdown.
+     * Calculates using: (window width - dropdown position) < (dropdown size + margin)
+     */
+    useEffect(() => {
+        if (isOpen && listRef.current) {
+            const listWidth = listRef.current.offsetWidth;
+            const listLeftPosition = listRef.current.offsetLeft;
+            const windowWidth = window.innerWidth;                
+
+            if ((windowWidth - listLeftPosition) < (listWidth + 5)) {
+                listRef.current.style.right = '2px';                    
+            }
+        }
+    }, [isOpen]);
+
     return (
-        <Container ref={containerRef} openLeft={openLeft || false}>
+        <Container ref={containerRef}>
             {label}
             <DropdownButton
                 onClick={toggleDropdown}
@@ -59,7 +75,7 @@ const Select: React.FC<DropdownProps> = ({
                 <DropdownIcon>{Icon}</DropdownIcon>
             </DropdownButton>
             {isOpen && (
-                <ul
+                <ul ref={listRef}
                     onKeyDown={(e): void => {
                         e.keyCode === KEYCODE_ESCAPE && toggleDropdown();
                     }}

--- a/src/components/Dropdown/style.ts
+++ b/src/components/Dropdown/style.ts
@@ -2,11 +2,7 @@ import styled, { css } from 'styled-components';
 
 import { tokens } from '@equinor/eds-tokens';
 
-type ContainerProps = {
-    openLeft?: boolean;
-}
-
-export const Container = styled.div<ContainerProps>`
+export const Container = styled.div`
     display: inline-block;
     ul {
         position: absolute;
@@ -16,9 +12,6 @@ export const Container = styled.div<ContainerProps>`
         border-radius: 4px;
         box-shadow: ${tokens.elevation.raised};
         overflow-y: scroll;
-        ${(props): any => props.openLeft && css`
-            right: 0px;
-        `}
         z-index: 100;
     }
     :hover {

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,5 +1,5 @@
 import { CascadingItem, Container, DropdownButton, DropdownIcon, ItemContent, SelectableItem } from './style';
-import React, { ReactNode, useRef, useState } from 'react';
+import React, { ReactNode, useRef, useState, useEffect } from 'react';
 
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
@@ -17,7 +17,6 @@ type SelectProps = {
     data: SelectItem[];
     disabled?: boolean;
     onChange?: (newValue: any) => void;
-    openLeft?: boolean;
     children: ReactNode;
     label?: string;
 };
@@ -31,12 +30,12 @@ const Select = ({
     onChange = (): void => {
         /*eslint-disable-line no-empty */
     },
-    openLeft,
     children,
     label,
 }: SelectProps): JSX.Element => {
     const [isOpen, setIsOpen] = useState(false);
     const containerRef = useRef<HTMLDivElement>(null);
+    const listRef = useRef<HTMLUListElement>(null);
 
     useClickOutsideNotifier(() => {
         setIsOpen(false);
@@ -50,6 +49,23 @@ const Select = ({
         onChange(value);
         setIsOpen(false);
     };
+
+    /**
+     * Open dropdown to the left:
+     * When there is not enough space on the right-hand side of the viewport, relative to the dropdown.
+     * Calculates using: (window width - dropdown position) < (dropdown size + margin)
+     */
+    useEffect(() => {
+        if (isOpen && listRef.current) {
+            const listWidth = listRef.current.offsetWidth;
+            const listLeftPosition = listRef.current.offsetLeft;
+            const windowWidth = window.innerWidth;                
+
+            if ((windowWidth - listLeftPosition) < (listWidth + 5)) {
+                listRef.current.style.right = '2px';                    
+            }
+        }
+    }, [isOpen]);    
 
     const createNodesForItems = (items: SelectItem[]): JSX.Element[] => {
 
@@ -104,7 +120,7 @@ const Select = ({
     };
 
     return (
-        <Container ref={containerRef} openLeft={openLeft || false}>
+        <Container ref={containerRef}>
             {label}
             <DropdownButton
                 onClick={toggleDropdown}
@@ -121,7 +137,7 @@ const Select = ({
                 </DropdownIcon>
             </DropdownButton>
             {isOpen && data.length > 0 && !disabled && (
-                <ul
+                <ul ref={listRef}
                     className='container'
                     onKeyDown={(e): void => {
                         e.keyCode === KEYCODE_ESCAPE && setIsOpen(false);

--- a/src/components/Select/style.ts
+++ b/src/components/Select/style.ts
@@ -2,20 +2,11 @@ import styled, { css } from 'styled-components';
 
 import { tokens } from '@equinor/eds-tokens';
 
-type ContainerProps = {
-    openLeft?: boolean;
-};
-
-export const Container = styled.div<ContainerProps>`
+export const Container = styled.div`
     ul {
         position: absolute;
         background-color: transparent;
         border-radius: 4px;
-        ${(props): any =>
-        props.openLeft &&
-        css`
-                right: 0px;
-            `}
         z-index: 100;
 
         li div {

--- a/src/modules/Header/index.tsx
+++ b/src/modules/Header/index.tsx
@@ -255,7 +255,7 @@ const Header: React.FC = (): JSX.Element => {
                         <LockOutlinedIcon />
                     </MenuItem>
                     <MenuItem>
-                        <Dropdown Icon={<AccountCircleOutlinedIcon />} openLeft>
+                        <Dropdown Icon={<AccountCircleOutlinedIcon />}>
                             <DropdownItem title="Logout" onClick={logout}>
                                 Logout
                             </DropdownItem>


### PR DESCRIPTION
Logic to open dropdown and select to the left when there is not enough space on the right-hand side to display the list contents.