### PR TITLE
Update scope list after changes in tag details ("dirty")

### DIFF
--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
@@ -57,6 +57,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const [displayFlyout, setDisplayFlyout] = useState<boolean>(false);
     const [flyoutTagId, setFlyoutTagId] = useState<number>(0);
+    const [scopeIsDirty, setScopeIsDirty] = useState<boolean>(false);
 
     const path = useRouteMatch();
 
@@ -150,6 +151,12 @@ const ScopeOverview: React.FC = (): JSX.Element => {
 
     const closeFlyout = (): void => {
         setDisplayFlyout(false);
+
+        // refresh scope list when flyout has updated a tag
+        if (scopeIsDirty) {
+            getTags();
+            setScopeIsDirty(false);
+        }
     };
 
     /**
@@ -334,8 +341,9 @@ const ScopeOverview: React.FC = (): JSX.Element => {
                     <Flyout
                         close={closeFlyout}>
                         <TagFlyout
-                            close={closeFlyout}
                             tagId={flyoutTagId}
+                            close={closeFlyout}
+                            setDirty={(): void => setScopeIsDirty(true)}
                         />
                     </Flyout>
                 )

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/PreservationTab.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/PreservationTab.tsx
@@ -11,11 +11,13 @@ import Spinner from '../../../../../../components/Spinner';
 interface PreservationTabProps {
     tagDetails: TagDetails;
     refreshTagDetails: () => void;
+    setDirty: () => void;
 }
 
 const PreservationTab = ({
     tagDetails,
-    refreshTagDetails
+    refreshTagDetails,
+    setDirty
 }: PreservationTabProps): JSX.Element => {
     const [tagRequirements, setTagRequirements] = useState<TagRequirement[] | null>(null);
     const { apiClient } = usePreservationContext();
@@ -56,8 +58,9 @@ const PreservationTab = ({
     const preserveRequirement = async (requirementId: number): Promise<void> => {
         try {
             setTagRequirements(null); // trigger the spinner
-
             await apiClient.preserveSingleRequirement(tagDetails.id, requirementId);
+
+            setDirty();
             showSnackbarNotification('The requirement has been preserved.', 5000, true);
         }
         catch (error) {

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/TagFlyout.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/TagFlyout.tsx
@@ -20,13 +20,15 @@ enum PreservationStatus {
 }
 
 interface TagFlyoutProps {
-    close: () => void;
     tagId: number;
+    close: () => void;
+    setDirty: () => void;
 }
 
 const TagFlyout = ({
+    tagId,
     close,
-    tagId
+    setDirty
 }: TagFlyoutProps): JSX.Element => {
     const [activeTab, setActiveTab] = useState<string>('preservation');
     const [tagDetails, setTagDetails] = useState<TagDetails | null>(null);
@@ -53,6 +55,8 @@ const TagFlyout = ({
         try {
             setIsPreservingTag(true);
             await apiClient.preserveSingleTag(tagId);
+
+            setDirty();
             showSnackbarNotification('This tag has been preserved.', 5000, true);
         }
         catch (error) {
@@ -69,6 +73,8 @@ const TagFlyout = ({
         try {
             setIsStartingPreservation(true);
             await apiClient.startPreservationForTag(tagId);
+
+            setDirty();
             showSnackbarNotification('Status was set to \'Active\' for this tag.', 5000, true);
         }
         catch (error) {
@@ -99,7 +105,7 @@ const TagFlyout = ({
                     return <div style={{margin: 'calc(var(--grid-unit) * 5) auto'}}><Spinner medium /></div>;
                 }
 
-                return <PreservationTab tagDetails={tagDetails} refreshTagDetails={getTagDetails} />;
+                return <PreservationTab tagDetails={tagDetails} refreshTagDetails={getTagDetails} setDirty={setDirty} />;
             }
             case 'actions':
                 return <ActionTab tagId={tagId} />;

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/TagFlyout.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/TagFlyout.tsx
@@ -170,7 +170,7 @@ const TagFlyout = ({
                 <a
                     className={activeTab === 'actions' ? 'active' : 'actions'}
                     onClick={(): void => setActiveTab('actions')}>
-                    Actions
+                    Preservation actions
                 </a>
                 <a
                     className={activeTab === 'attachments' ? 'active' : 'attachments'}


### PR DESCRIPTION
When dirty, update scope list when Flyout is closed.

@Cnordbo 
Ideally, I would like the dirty state handling to be contained within TagFlyout. However, the Flyout component/container has it's own close handling (by clicking in the "overlay" area), and is oblivious about what's going on in the child component(s). Therefore, to trigger on close, the Flyout component would need to hold the dirty state, and somehow pass it to child components, in addition to the child components own props (not very clean, especially with TS). 

I don't want the generic Flyout component to hold any of this logic. It could host "anything" and should not be concerned about an eventual dirty handling of it's children.