### PR TITLE
Feature/71669 support paging for preservation scope

### DIFF
--- a/src/modules/Preservation/http/PreservationApiClient.ts
+++ b/src/modules/Preservation/http/PreservationApiClient.ts
@@ -398,8 +398,8 @@ class PreservationApiClient extends ApiClient {
         projectName: string,
         page: number,
         size: number,
-        sortProperty: string,
-        sortDirection: string,
+        sortProperty: string | null,
+        sortDirection: string | null,
         setRequestCanceller?: RequestCanceler
     ): Promise<PreservedTagResponse> {
         const endpoint = '/Tags';

--- a/src/modules/Preservation/http/PreservationApiClient.ts
+++ b/src/modules/Preservation/http/PreservationApiClient.ts
@@ -394,7 +394,12 @@ class PreservationApiClient extends ApiClient {
      *
      * @param setRequestCanceller Returns a function that can be called to cancel the request
      */
-    async getPreservedTags(projectName: string,
+    async getPreservedTags(
+        projectName: string,
+        page: number,
+        size: number,
+        sortProperty: string,
+        sortDirection: string,
         setRequestCanceller?: RequestCanceler
     ): Promise<PreservedTagResponse> {
         const endpoint = '/Tags';
@@ -402,10 +407,10 @@ class PreservationApiClient extends ApiClient {
         const settings: AxiosRequestConfig = {
             params: {
                 projectName: projectName,
-                page: 0, //temporary
-                size: 10000,   //temporary
-                property: 'Due',  //temporary
-                direction: 'Asc'
+                page: page,
+                size: size,
+                property: sortProperty,
+                direction: sortDirection,
             },
         };
         this.setupRequestCanceler(settings, setRequestCanceller);

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
@@ -35,7 +35,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
     const [startPreservationDisabled, setStartPreservationDisabled] = useState(true);
     const [preservedThisWeekDisabled, setPreservedThisWeekDisabled] = useState(true);
     const [selectedTags, setSelectedTags] = useState<PreservedTag[]>([]);
-    const [isLoading, setIsLoading] = useState<boolean>(false);
+    //const [isLoading, setIsLoading] = useState<boolean>(false);     Is removed temporary. Causes problems with setting size of table.
     const [displayFlyout, setDisplayFlyout] = useState<boolean>(false);
     const [flyoutTagId, setFlyoutTagId] = useState<number>(0);
     const [scopeIsDirty, setScopeIsDirty] = useState<boolean>(false);
@@ -55,12 +55,10 @@ const ScopeOverview: React.FC = (): JSX.Element => {
         refreshScopeList = callback;
     };
 
-    const getTags = async (page: number, pageSize: number): Promise<PreservedTags | null> => {
-        setIsLoading(true);
+    const getTags = async (page: number, pageSize: number, orderBy: string | null, orderDirection: string | null): Promise<PreservedTags | null> => {
         try {
-            return await apiClient.getPreservedTags(project.name, page, pageSize, 'Due', 'Asc').then(
+            return await apiClient.getPreservedTags(project.name, page, pageSize, orderBy, orderDirection).then(
                 (response) => {
-                    setIsLoading(false);
                     return response;
                 }
             );
@@ -266,7 +264,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
 
             <ScopeTable
                 getTags={getTags}
-                isLoading={isLoading}
+                //isLoading={isLoading}
                 setSelectedTags={setSelectedTags}
                 showTagDetails={openFlyout}
                 setRefreshScopeListCallback={setRefreshScopeListCallback}

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
@@ -81,6 +81,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
             await apiClient.startPreservation(selectedTags.map(t => t.id));
             refreshScopeList();
             setSelectedTags([]);
+            showSnackbarNotification('Status was set to \'Active\' for selected tags.', 5000);
         } catch (error) {
             console.error('Start preservation failed: ', error.messsage, error.data);
             showSnackbarNotification(error.message, 5000);
@@ -93,6 +94,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
             await apiClient.transfer(selectedTags.map(t => t.id));
             refreshScopeList();
             setSelectedTags([]);
+            showSnackbarNotification(`${selectedTags.length} tags has been transferd successfully.`, 5000);
         } catch (error) {
             console.error('Transfer failed: ', error.messsage, error.data);
             showSnackbarNotification(error.message, 5000);
@@ -132,6 +134,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
             await apiClient.preserve(selectedTags.map(t => t.id));
             refreshScopeList();
             setSelectedTags([]);
+            showSnackbarNotification('Selected tags have been preserved for this week.', 5000);
         } catch (error) {
             console.error('Preserve failed: ', error.messsage, error.data);
             showSnackbarNotification(error.message, 5000);

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
@@ -1,3 +1,4 @@
+
 import React, { useEffect, useState } from 'react';
 import { Link, useRouteMatch } from 'react-router-dom';
 import { Button } from '@equinor/eds-core-react';
@@ -13,7 +14,7 @@ import Dropdown from '../../../../components/Dropdown';
 import Flyout from './../../../../components/Flyout';
 import TagFlyout from './TagFlyout/TagFlyout';
 import { showModalDialog } from '../../../../core/services/ModalDialogService';
-import { PreservedTag, Requirement } from './types';
+import { PreservedTag, Requirement, PreservedTags } from './types';
 import ScopeTable from './ScopeTable';
 import TransferDialog from './TransferDialog';
 
@@ -33,7 +34,6 @@ export const isTagOverdue = (tag: PreservedTag): boolean => {
 const ScopeOverview: React.FC = (): JSX.Element => {
     const [startPreservationDisabled, setStartPreservationDisabled] = useState(true);
     const [preservedThisWeekDisabled, setPreservedThisWeekDisabled] = useState(true);
-    const [tags, setTags] = useState<PreservedTag[]>([]);
     const [selectedTags, setSelectedTags] = useState<PreservedTag[]>([]);
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const [displayFlyout, setDisplayFlyout] = useState<boolean>(false);
@@ -49,23 +49,27 @@ const ScopeOverview: React.FC = (): JSX.Element => {
         apiClient,
     } = usePreservationContext();
 
-    const getTags = async (): Promise<void> => {
+    let refreshScopeList: () => void;
+
+    const setRefreshScopeListCallback = (callback: () => void): void => {
+        refreshScopeList = callback;
+    };
+
+    const getTags = async (page: number, pageSize: number): Promise<PreservedTags | null> => {
         setIsLoading(true);
         try {
-            const response = await apiClient.getPreservedTags(project.name);
-            setTags(response.tags);
+            return await apiClient.getPreservedTags(project.name, page, pageSize, 'Due', 'Asc').then(
+                (response) => {
+                    setIsLoading(false);
+                    return response;
+                }
+            );
         } catch (error) {
             console.error('Get tags failed: ', error.messsage, error.data);
             showSnackbarNotification(error.message, 5000);
         }
-        setIsLoading(false);
+        return null;
     };
-
-    useEffect(() => {
-        (async (): Promise<void> => {
-            getTags();
-        })();
-    }, [project]);
 
     const changeProject = (event: React.MouseEvent, index: number): void => {
         event.preventDefault();
@@ -75,10 +79,8 @@ const ScopeOverview: React.FC = (): JSX.Element => {
     const startPreservation = async (): Promise<void> => {
         try {
             await apiClient.startPreservation(selectedTags.map(t => t.id));
+            refreshScopeList();
             setSelectedTags([]);
-            getTags().then(() => {
-                showSnackbarNotification('Status was set to \'Active\' for selected tags.', 5000);
-            });
         } catch (error) {
             console.error('Start preservation failed: ', error.messsage, error.data);
             showSnackbarNotification(error.message, 5000);
@@ -87,18 +89,14 @@ const ScopeOverview: React.FC = (): JSX.Element => {
     };
 
     const transfer = async (): Promise<void> => {
-        setIsLoading(true);
         try {
             await apiClient.transfer(selectedTags.map(t => t.id));
+            refreshScopeList();
             setSelectedTags([]);
-            getTags().then(() => {
-                showSnackbarNotification(`${selectedTags.length} tags has been transferd successfully.`, 5000);
-            });
         } catch (error) {
             console.error('Transfer failed: ', error.messsage, error.data);
             showSnackbarNotification(error.message, 5000);
         }
-        setIsLoading(false);
         return Promise.resolve();
     };
 
@@ -132,10 +130,8 @@ const ScopeOverview: React.FC = (): JSX.Element => {
     const preservedThisWeek = async (): Promise<void> => {
         try {
             await apiClient.preserve(selectedTags.map(t => t.id));
+            refreshScopeList();
             setSelectedTags([]);
-            getTags().then(() => {
-                showSnackbarNotification('Selected tags have been preserved for this week.', 5000);
-            });
         } catch (error) {
             console.error('Preserve failed: ', error.messsage, error.data);
             showSnackbarNotification(error.message, 5000);
@@ -153,7 +149,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
 
         // refresh scope list when flyout has updated a tag
         if (scopeIsDirty) {
-            getTags();
+            refreshScopeList();
             setScopeIsDirty(false);
         }
     };
@@ -168,7 +164,8 @@ const ScopeOverview: React.FC = (): JSX.Element => {
                 selectedTags.length === 0 ||
                 selectedTags.findIndex((t) => t.status !== 'NotStarted') !== -1
             );
-        }, [selectedTags]);
+        }, [selectedTags]
+    );
 
     /**
      * 'Preserved this week' button is set to disabled if no rows are selected or
@@ -180,7 +177,8 @@ const ScopeOverview: React.FC = (): JSX.Element => {
                 selectedTags.length === 0 ||
                 selectedTags.findIndex((t) => t.readyToBePreserved !== true) !== -1
             );
-        }, [selectedTags]);
+        }, [selectedTags]
+    );
 
     return (
         <Container>
@@ -262,12 +260,13 @@ const ScopeOverview: React.FC = (): JSX.Element => {
                     </StyledButton>
                 </IconBar>
             </HeaderContainer>
-            <ScopeTable
-                tags={tags}
 
+            <ScopeTable
+                getTags={getTags}
                 isLoading={isLoading}
                 setSelectedTags={setSelectedTags}
                 showTagDetails={openFlyout}
+                setRefreshScopeListCallback={setRefreshScopeListCallback}
             />
             {
                 displayFlyout && (

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
@@ -39,6 +39,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
     const [displayFlyout, setDisplayFlyout] = useState<boolean>(false);
     const [flyoutTagId, setFlyoutTagId] = useState<number>(0);
     const [scopeIsDirty, setScopeIsDirty] = useState<boolean>(false);
+    const [pageSize, setPageSize] = useState<number>(50);
 
     const path = useRouteMatch();
 
@@ -268,6 +269,8 @@ const ScopeOverview: React.FC = (): JSX.Element => {
                 setSelectedTags={setSelectedTags}
                 showTagDetails={openFlyout}
                 setRefreshScopeListCallback={setRefreshScopeListCallback}
+                pageSize={pageSize}
+                setPageSize={setPageSize}
             />
             {
                 displayFlyout && (

--- a/src/modules/Preservation/views/ScopeOverview/ScopeTable.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeTable.tsx
@@ -8,8 +8,8 @@ import RequirementIcons from './RequirementIcons';
 import { isTagOverdue, getFirstUpcomingRequirement } from './ScopeOverview';
 
 interface ScopeTableProps {
-    getTags: (page: number, pageSize: number) => Promise<PreservedTags | null>;
-    isLoading: boolean;
+    getTags: (page: number, pageSize: number, orderBy: string | null, orderDirection: string | null) => Promise<PreservedTags | null>;
+    //isLoading: boolean;
     setSelectedTags: (tags: PreservedTag[]) => void;
     showTagDetails: (tag: PreservedTag) => void;
     setRefreshScopeListCallback: (callback: () => void) => void;
@@ -17,7 +17,7 @@ interface ScopeTableProps {
 
 const ScopeTable = ({
     getTags,
-    isLoading,
+    //isLoading,
     setSelectedTags,
     showTagDetails,
     setRefreshScopeListCallback,
@@ -69,6 +69,19 @@ const ScopeTable = ({
         );
     };
 
+    const sortFieldMap: { [key: string]: string } = {
+        'Tag nr': 'TagNo',
+        'Description': 'Description',
+        'Due': 'Due',
+        'Next': 'Due',
+        'PO nr': 'PO',
+        'Resp': 'Responsible',
+        'Status': 'Status',
+        'Area': 'Area',
+        'Disc': 'Discipline',
+        'Mode': 'Mode'
+    };
+
     return (
         <Table
             tableRef={ref} //reference will be used by parent, to trigger rendering
@@ -76,7 +89,8 @@ const ScopeTable = ({
                 { title: 'Tag nr', render: getTagNoColumn },
                 { title: 'Description', render: getDescriptionColumn },
                 { title: 'Next', render: getNextColumn },
-                { title: 'Due', render: getDueColumn },
+                { title: 'Due', render: getDueColumn, defaultSort: 'asc' },
+                { title: 'Mode', field: 'mode' },
                 { title: 'PO nr', field: 'purchaseOrderNo' },
                 { title: 'Area', field: 'areaCode' },
                 { title: 'Resp', field: 'responsibleCode' },
@@ -86,12 +100,16 @@ const ScopeTable = ({
             ]}
             data={(query: any): any =>
                 new Promise((resolve) => {
-                    getTags(query.page, query.pageSize).then((result) => {
-                        resolve({
-                            data: result?.tags,
-                            page: query.page,
-                            totalCount: result?.maxAvailable
-                        });
+                    const orderByField: string | null = query.orderBy ? sortFieldMap[query.orderBy.title] : null;
+                    const orderDirection: string | null = orderByField ? query.orderDirection ? query.orderDirection : 'Asc' : null;
+
+                    getTags(query.page, query.pageSize, orderByField, orderDirection).then((result) => {
+                        result ?
+                            resolve({
+                                data: result.tags,
+                                page: query.page,
+                                totalCount: result.maxAvailable
+                            }) : null;
                     });
                 })
             }
@@ -117,7 +135,7 @@ const ScopeTable = ({
                     </Toolbar>
                 )
             }}
-            isLoading={isLoading}
+            //isLoading={isLoading}
             onSelectionChange={setSelectedTags}
             style={{ boxShadow: 'none' }}
         />

--- a/src/modules/Preservation/views/ScopeOverview/ScopeTable.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeTable.tsx
@@ -26,12 +26,11 @@ const ScopeTable = ({
 
     const ref = React.createRef();
 
-    const refreshScopeList = (): void => {
-        const referanse: any = ref.current;
-        referanse?.onQueryChange();
-    };
-
-    setRefreshScopeListCallback(refreshScopeList);
+    setRefreshScopeListCallback(() => {
+        if (ref.current) {
+            (ref as any).onQueryChange();
+        }
+    });
 
     const getTagNoColumn = (tag: PreservedTag): JSX.Element => {
         return (
@@ -117,7 +116,7 @@ const ScopeTable = ({
                 showTitle: false,
                 draggable: false,
                 selection: true,
-                pageSize: 10,
+                pageSize: 50,
                 emptyRowsWhenPaging: false,
                 pageSizeOptions: [10, 50, 100],
                 headerStyle: {

--- a/src/modules/Preservation/views/ScopeOverview/ScopeTable.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeTable.tsx
@@ -13,6 +13,8 @@ interface ScopeTableProps {
     setSelectedTags: (tags: PreservedTag[]) => void;
     showTagDetails: (tag: PreservedTag) => void;
     setRefreshScopeListCallback: (callback: () => void) => void;
+    pageSize: number;
+    setPageSize: (pageSize: number) => void;
 }
 
 const ScopeTable = ({
@@ -21,7 +23,8 @@ const ScopeTable = ({
     setSelectedTags,
     showTagDetails,
     setRefreshScopeListCallback,
-
+    pageSize,
+    setPageSize
 }: ScopeTableProps): JSX.Element => {
 
     const ref = React.createRef();
@@ -81,6 +84,8 @@ const ScopeTable = ({
         'Mode': 'Mode'
     };
 
+
+
     return (
         <Table
             tableRef={ref} //reference will be used by parent, to trigger rendering
@@ -116,7 +121,7 @@ const ScopeTable = ({
                 showTitle: false,
                 draggable: false,
                 selection: true,
-                pageSize: 50,
+                pageSize: pageSize,
                 emptyRowsWhenPaging: false,
                 pageSizeOptions: [10, 50, 100],
                 headerStyle: {
@@ -137,6 +142,7 @@ const ScopeTable = ({
             //isLoading={isLoading}
             onSelectionChange={setSelectedTags}
             style={{ boxShadow: 'none' }}
+            onChangeRowsPerPage={setPageSize}
         />
     );
 };

--- a/src/modules/Preservation/views/ScopeOverview/TransferDialog.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TransferDialog.tsx
@@ -43,11 +43,12 @@ const TransferTable = ({
         data={tags}
         options={{
             search: false,
-            pageSize: numTags > 5 ? 5 : numTags,
+            pageSize: 5,
             pageSizeOptions: [5, 10, 50, 100],
             showTitle: false,
             draggable: false,
             selection: false,
+            emptyRowsWhenPaging: false,
             headerStyle: {
                 backgroundColor: tokens.colors.interactive.table__header__fill_resting.rgba
             },


### PR DESCRIPTION
The solution here might seem a bit strange. Because the data viewed by material-table is not given by a state property, we don't get a rerender of the table unless material-table believe it is necessary. To trigger this, i got the recommendation to use a reference to the table, and call onQueryChange. 

I have also added sorting here. 

I have temporary commented out the isLoading feature. It does not work properly, when we use remote data for the scope list. I will add a new PBI to figure out this. 