### PR TITLE
use preservationApi setting

### DIFF
--- a/src/modules/PlantConfig/http/LibraryApiClient.ts
+++ b/src/modules/PlantConfig/http/LibraryApiClient.ts
@@ -57,8 +57,8 @@ class LibraryApiClient extends ApiClient {
     constructor(authService: IAuthService) {
         super(
             authService,
-            Settings.externalResources.libraryApi.scope.join(' '),
-            Settings.externalResources.libraryApi.url
+            Settings.externalResources.preservationApi.scope.join(' '),
+            Settings.externalResources.preservationApi.url
         );
         this.client.interceptors.request.use(
             config => {


### PR DESCRIPTION
Instead of using libraryAPI in setting.json, we use preservationAPI, as long as this is actually what we do. Then we don't need to do any changes in Azure, before we start using the library module.  