### PR TITLE
Add ProCoSys module aliases

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,6 +22,13 @@ module.exports = {
         '\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
             '<rootDir>/__mocks__/fileMock.js',
         '\\.(css|less|scss)$': '<rootDir>/__mocks__/fileMock.js',
+        "^@procosys/core/(.*)$": ["<rootDir>/src/core/$1"],
+        "^@procosys/modules/(.*)$": ["<rootDir>/src/modules/$1"],
+        "^@procosys/hooks/(.*)$": ["<rootDir>/src/hooks/$1"],
+        "^@procosys/components/(.*)$": ["<rootDir>/src/components/$1"],
+        "^@procosys/assets/(.*)$": ["<rootDir>/src/assets/$1"],
+        "^@procosys/http/(.*)$": ["<rootDir>/src/http/$1"],
+        "^@procosys/util/(.*)$": ["<rootDir>/src/util/$1"],
     },
     testPathIgnorePatterns: ['/node_modules/', '/build/'],
     setupFilesAfterEnv: ['./jest.setup.js'],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,17 @@
         "module": "esnext",
         "moduleResolution": "node",
         "strict": true,
-        "jsx": "react"
+        "jsx": "react",
+        "baseUrl": "./",
+        "paths": {
+            "@procosys/core/*": ["src/core/*"],
+            "@procosys/modules/*": ["src/modules/*"],
+            "@procosys/hooks/*": ["src/hooks/*"],
+            "@procosys/components/*": ["src/components/*"],
+            "@procosys/assets/*": ["src/assets/*"],
+            "@procosys/http/*": ["src/http/*"],
+            "@procosys/util/*": ["src/util/*"],
+        }
     },
     "include": [
         "src/**/*"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,14 @@ module.exports = {
     resolve: {
         extensions: ['.ts', '.tsx', '.js', '.jsx', '.css'],
         alias: {
-            'react-dom': '@hot-loader/react-dom'
+            'react-dom': '@hot-loader/react-dom',
+            '@procosys/core': path.resolve(__dirname, 'src/core/'),
+            '@procosys/modules': path.resolve(__dirname, 'src/modules/'),
+            '@procosys/hooks': path.resolve(__dirname, 'src/hooks/'),
+            '@procosys/components': path.resolve(__dirname, 'src/components/'),
+            '@procosys/assets': path.resolve(__dirname, 'src/assets/'),
+            '@procosys/http': path.resolve(__dirname, 'src/http/'),
+            '@procosys/util': path.resolve(__dirname, 'src/util/'),
         }
     },
     output: {


### PR DESCRIPTION
Allows us to reference core modules using aliases, instead of relative paths: 
            "@procosys/core/*"
            "@procosys/modules/*"
            "@procosys/hooks/*"
            "@procosys/components/*"
            "@procosys/assets/*"
            "@procosys/util/*"

Before:
```js
import Dropdown from '../../../../../../components/Dropdown'
```

After:
```js
import Dropdown from '@procosys/components/Dropdown'
```