### PR TITLE
Feature/72392   show selected tags component on both pages

### DIFF
--- a/src/modules/Preservation/views/AddScope/AddScope.style.ts
+++ b/src/modules/Preservation/views/AddScope/AddScope.style.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { tokens } from '@equinor/eds-tokens';
 
-export const PropertiesContainer = styled.div`
+export const Container = styled.div`
     display: flex;
 `;
 

--- a/src/modules/Preservation/views/AddScope/AddScope.tsx
+++ b/src/modules/Preservation/views/AddScope/AddScope.tsx
@@ -262,16 +262,22 @@ const AddScope = (): JSX.Element => {
                 </Container>)
                 ;
             } else if (addScopeMethod === AddScopeMethod.AddTagsAutoscope) {
-                return <SelectTags
-                    nextStep={goToNextStep}
-                    setSelectedTags={setSelectedTags}
-                    searchTags={searchTags}
-                    selectedTags={selectedTags}
-                    scopeTableData={scopeTableData}
-                    isLoading={isLoading}
-                    addScopeMethod={addScopeMethod}
-                    removeTag={removeSelectedTag}
-                />;
+                return (<Container>
+                    <SelectTags
+                        nextStep={goToNextStep}
+                        setSelectedTags={setSelectedTags}
+                        searchTags={searchTags}
+                        selectedTags={selectedTags}
+                        scopeTableData={scopeTableData}
+                        isLoading={isLoading}
+                        addScopeMethod={addScopeMethod}
+                        removeTag={removeSelectedTag}
+                    />
+                    <Divider />
+                    <SelectedTags>
+                        <TagDetails selectedTags={selectedTags} removeTag={removeSelectedTag} />
+                    </SelectedTags>
+                </Container>);
             } else if (addScopeMethod === AddScopeMethod.CreateAreaTag) {
                 return <CreateAreaTag
                     nextStep={goToNextStep}

--- a/src/modules/Preservation/views/AddScope/AddScope.tsx
+++ b/src/modules/Preservation/views/AddScope/AddScope.tsx
@@ -312,7 +312,7 @@ const AddScope = (): JSX.Element => {
                     </TagProperties>
                     <Divider />
                     <SelectedTags>
-                        <TagDetails selectedTags={selectedTags} removeTag={removeSelectedTag} />
+                        <TagDetails selectedTags={selectedTags} removeTag={removeSelectedTag} creatingNewTag={addScopeMethod === AddScopeMethod.CreateAreaTag ? true : false}/>
                     </SelectedTags>
                 </Container>
             );

--- a/src/modules/Preservation/views/AddScope/CreateAreaTag/CreateAreaTag.style.js
+++ b/src/modules/Preservation/views/AddScope/CreateAreaTag/CreateAreaTag.style.js
@@ -14,7 +14,14 @@ export const Header = styled.header`
 export const Container = styled.div`
     display: grid;
     grid-template-columns: 1fr auto;
+`;
 
+export const MainContainer = styled.div`
+    display: flex;
+
+    #createAreaTag {
+        width: 70%;
+    }
 `;
 
 export const TopContainer = styled.div`
@@ -95,4 +102,77 @@ export const DropdownItem = styled.div`
 
 export const ErrorContainer = styled.div`
     min-height: 1rem;
+`;
+
+export const SelectedTag = styled.div`
+    width: 30%;
+    margin-left: var(--grid-unit);
+    margin-bottom: calc(var(--grid-unit) * 4);
+`;
+
+export const Divider = styled.div`
+    margin-top: calc(var(--margin-module--top) * -1);
+    margin-bottom: -1000px;
+    margin-right: calc(var(--grid-unit) * 2);
+    margin-left: calc(var(--grid-unit) * 5);
+    border-left: solid 1px ${tokens.colors.ui.background__medium.rgba};
+`;
+
+export const TagList = styled.div`
+    margin-top: calc(var(--grid-unit) * 4);
+    border-left: solid 2px ${tokens.colors.ui.background__medium.rgba};
+    border-top: solid 2px ${tokens.colors.ui.background__medium.rgba};
+    border-right: solid 2px ${tokens.colors.ui.background__medium.rgba};
+`;
+
+export const TagContainer = styled.div`
+    font-weight: 500;
+    font-size: calc(var(--grid-unit) * 2);
+    line-height: calc(var(--grid-unit) * 3);
+
+    button:hover {
+        background: ${tokens.colors.interactive.primary__hover_alt.rgba};
+    }
+
+    svg {
+        padding: calc(var(--grid-unit) * 2);
+    }
+
+    svg path {
+        color: ${tokens.colors.interactive.primary__resting.rgba};
+    }
+`;
+
+export const Collapse = styled.div`
+    display: flex;
+    border-bottom: solid 2px ${tokens.colors.ui.background__medium.rgba};
+`;
+
+export const CollapseInfo = styled.div`
+    flex-grow: 1;
+    padding-top: calc(var(--grid-unit) * 2 + 4px);
+    padding-right: calc(var(--grid-unit) * 2);
+    padding-bottom: calc(var(--grid-unit) * 2);
+    padding-left: calc(var(--grid-unit) * 2);
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+`;
+
+export const Expand = styled.div`
+    border-bottom: solid 2px ${tokens.colors.ui.background__medium.rgba};
+    padding-top: 0px;
+    padding-right: calc(var(--grid-unit) * 2);
+    padding-bottom: calc(var(--grid-unit) * 2);
+    padding-left: calc(var(--grid-unit) * 2);
+    font-weight: normal;
+`;
+
+export const ExpandHeader = styled.div`
+    font-size: calc(var(--grid-unit) + 4px);
+    line-height: calc(var(--grid-unit) * 2);
+`;
+
+export const ExpandSection = styled.div`
+    margin-top: calc(var(--grid-unit) * 2);
 `;

--- a/src/modules/Preservation/views/AddScope/CreateAreaTag/CreateAreaTag.tsx
+++ b/src/modules/Preservation/views/AddScope/CreateAreaTag/CreateAreaTag.tsx
@@ -1,4 +1,5 @@
-import { Container, FormFieldSpacer, Next, Header, InputContainer, DropdownItem, TopContainer, SuffixTextField, ErrorContainer } from './CreateAreaTag.style';
+import { Container, FormFieldSpacer, Next, Header, InputContainer, DropdownItem, TopContainer, SuffixTextField,
+    ErrorContainer, Divider, MainContainer, CollapseInfo, TagContainer, TagList, Collapse, Expand, ExpandSection, ExpandHeader, SelectedTag } from './CreateAreaTag.style';
 import React, { useEffect, useRef, useState } from 'react';
 import SelectInput, { SelectItem } from '../../../../../components/Select';
 import { Button, TextField, Typography } from '@equinor/eds-core-react';
@@ -9,6 +10,8 @@ import { showSnackbarNotification } from './../../../../../core/services/Notific
 import Dropdown from '../../../../../components/Dropdown';
 import EdsIcon from '../../../../../components/EdsIcon';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
+import IconButton from '@material-ui/core/IconButton';
+import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
 
 const invalidTagNoMessage = 'An area tag with this tag number already exists. Please adjust the parameters to create a unique tag number.';
 const spacesInTagNoMessage = 'The suffix cannot containt spaces.';
@@ -54,6 +57,14 @@ const CreateAreaTag = (props: CreateAreaTagProps): JSX.Element => {
     const [tagNoValid, setTagNoValid] = useState<boolean>(false);
 
     const [icon, setIcon] = useState<JSX.Element | null>(null);
+    const [displayTagNo, setDisplayTagNo] = useState<string>(() => {
+        if(!props.description) {
+            return 'type-discipline-area-suffix';
+        } else {
+            return '';
+        }
+    });
+    const [expanded, setExpanded] = useState<boolean>(true);
 
     /** Load areas */
     useEffect(() => {
@@ -177,6 +188,7 @@ const CreateAreaTag = (props: CreateAreaTagProps): JSX.Element => {
                 discipline,
                 area,
                 suffix);
+            setDisplayTagNo(response.tagNo);
             return !response.exists;
         } catch (error) {
             console.error('Get tag nos failed: ', error.messsage, error.data);
@@ -218,92 +230,134 @@ const CreateAreaTag = (props: CreateAreaTagProps): JSX.Element => {
         }
     };
 
+    const toggleDetails = (): void => {
+        if(expanded) {
+            setExpanded(false);
+        } else {
+            setExpanded(true);
+        }
+    };
+
     return (
-        <div>
-            <Header>
-                <h1>Create Area Tag</h1>
-                <div>{project.description}</div>
-            </Header>
-            <TopContainer>
-                <ErrorContainer>
-                    {tagNoValidationError && (<Typography variant="caption">{tagNoValidationError}</Typography>)}
-                </ErrorContainer>
-                <Container>
-                    <InputContainer>
-                        <FormFieldSpacer>
-                            <SelectInput
-                                onChange={setAreaTypeForm}
-                                data={areaTypes}
-                                label={'Area type'}
-                            >
-                                {(props.areaType && props.areaType.text) || 'Select'}
-                            </SelectInput>
-                        </FormFieldSpacer>
-                        <FormFieldSpacer>
-                            <SelectInput
-                                onChange={setDisciplineForm}
-                                data={mappedDisciplines}
-                                label={'Discipline'}
-                            >
-                                {(props.discipline && props.discipline.description) || 'Select'}
-                            </SelectInput>
-                        </FormFieldSpacer>
-                        <FormFieldSpacer>
-                            <Dropdown
-                                label={'Area'}
-                                variant='form'
-                                meta="Optional"
-                                Icon={(props.area && props.area.description)
-                                    ? <div id='dropdownIcon' onClick={clearArea}><EdsIcon name='close' /></div>
-                                    : <KeyboardArrowDownIcon />}
-                                text={(props.area && props.area.description) || 'Type to select'}
-                                onFilter={setFilterForAreas}
-                            >
-                                {filteredAreas.map((areaItem, index) => {
-                                    return (
-                                        <DropdownItem
-                                            key={index}
-                                            onClick={(event): void =>
-                                                changeArea(event, index)
-                                            }
-                                        >
-                                            {areaItem.text}
-                                        </DropdownItem>
-                                    );
-                                })}
-                            </Dropdown>
-                        </FormFieldSpacer>
-                        <Next>
-                            <Button onClick={nextStep} disabled={newTagNo === '' || !tagNoValid}>Next</Button>
-                        </Next>
-                    </InputContainer>
-                </Container >
-            </TopContainer>
-            <InputContainer>
-                <SuffixTextField
-                    id={'Suffix'}
-                    label="Tag number suffix"
-                    inputRef={suffixInputRef}
-                    placeholder="Write Here"
-                    helperText="Spaces are not allowed"
-                    helperIcon={icon}
-                    variant={icon ? 'error': 'default' }
-                    meta="Optional"
-                    onChange={checkSuffix}
-                />
-            </InputContainer>
-            <InputContainer>
-                <TextField
-                    id={'Description'}
-                    style={{ maxWidth: '350px' }}
-                    label="Description"
-                    inputRef={descriptionInputRef}
-                    multiline={true}
-                    placeholder="Write Here"
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>): void => props.setDescription(e.target.value)}
-                />
-            </InputContainer>
-        </div >
+        <MainContainer>
+            <div id='createAreaTag'>
+                <Header>
+                    <h1>Create Area Tag</h1>
+                    <div>{project.description}</div>
+                </Header>
+                <TopContainer>
+                    <ErrorContainer>
+                        {tagNoValidationError && (<Typography variant="caption">{tagNoValidationError}</Typography>)}
+                    </ErrorContainer>
+                    <Container>
+                        <InputContainer>
+                            <FormFieldSpacer>
+                                <SelectInput
+                                    onChange={setAreaTypeForm}
+                                    data={areaTypes}
+                                    label={'Area type'}
+                                >
+                                    {(props.areaType && props.areaType.text) || 'Select'}
+                                </SelectInput>
+                            </FormFieldSpacer>
+                            <FormFieldSpacer>
+                                <SelectInput
+                                    onChange={setDisciplineForm}
+                                    data={mappedDisciplines}
+                                    label={'Discipline'}
+                                >
+                                    {(props.discipline && props.discipline.description) || 'Select'}
+                                </SelectInput>
+                            </FormFieldSpacer>
+                            <FormFieldSpacer>
+                                <Dropdown
+                                    label={'Area'}
+                                    variant='form'
+                                    meta="Optional"
+                                    Icon={(props.area && props.area.description)
+                                        ? <div id='dropdownIcon' onClick={clearArea}><EdsIcon name='close' /></div>
+                                        : <KeyboardArrowDownIcon />}
+                                    text={(props.area && props.area.description) || 'Type to select'}
+                                    onFilter={setFilterForAreas}
+                                >
+                                    {filteredAreas.map((areaItem, index) => {
+                                        return (
+                                            <DropdownItem
+                                                key={index}
+                                                onClick={(event): void =>
+                                                    changeArea(event, index)
+                                                }
+                                            >
+                                                {areaItem.text}
+                                            </DropdownItem>
+                                        );
+                                    })}
+                                </Dropdown>
+                            </FormFieldSpacer>
+                            <Next>
+                                <Button onClick={nextStep} disabled={newTagNo === '' || !tagNoValid}>Next</Button>
+                            </Next>
+                        </InputContainer>
+                    </Container >
+                </TopContainer>
+                <InputContainer>
+                    <SuffixTextField
+                        id={'Suffix'}
+                        label="Tag number suffix"
+                        inputRef={suffixInputRef}
+                        placeholder="Write Here"
+                        helperText="Spaces are not allowed"
+                        helperIcon={icon}
+                        variant={icon ? 'error': 'default' }
+                        meta="Optional"
+                        onChange={checkSuffix}
+                    />
+                </InputContainer>
+                <InputContainer>
+                    <TextField
+                        id={'Description'}
+                        style={{ maxWidth: '350px' }}
+                        label="Description"
+                        inputRef={descriptionInputRef}
+                        multiline={true}
+                        placeholder="Write Here"
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>): void => props.setDescription(e.target.value)}
+                    />
+                </InputContainer>
+            </div>
+            <Divider />
+            <SelectedTag>
+                <Header>
+                    <h1>Selected tag</h1>
+                </Header>
+                <TagList>
+                    <TagContainer>
+                        <Collapse>
+                            <IconButton size='small' onClick={toggleDetails}>
+                                {
+                                    expanded
+                                        ? <KeyboardArrowUpIcon />
+                                        : <KeyboardArrowDownIcon />
+                                }
+                            </IconButton>
+                            <CollapseInfo>
+                                {displayTagNo}
+                            </CollapseInfo>
+                        </Collapse>
+                        {
+                            expanded && (
+                                <Expand>
+                                    <ExpandSection>
+                                        <ExpandHeader>Tag description</ExpandHeader>
+                                        <div>{props.description}</div>
+                                    </ExpandSection>
+                                </Expand>
+                            )
+                        }
+                    </TagContainer>
+                </TagList>
+            </SelectedTag>
+        </MainContainer>
     );
 };
 

--- a/src/modules/Preservation/views/AddScope/CreateAreaTag/CreateAreaTag.tsx
+++ b/src/modules/Preservation/views/AddScope/CreateAreaTag/CreateAreaTag.tsx
@@ -1,5 +1,4 @@
-import { Container, FormFieldSpacer, Next, Header, InputContainer, DropdownItem, TopContainer, SuffixTextField,
-    ErrorContainer, Divider, MainContainer, CollapseInfo, TagContainer, TagList, Collapse, Expand, ExpandSection, ExpandHeader, SelectedTag } from './CreateAreaTag.style';
+import { Container, FormFieldSpacer, Next, Header, InputContainer, DropdownItem, TopContainer, SuffixTextField, ErrorContainer, Divider, MainContainer, CollapseInfo, TagContainer, TagList, Collapse, Expand, ExpandSection, ExpandHeader, SelectedTag } from './CreateAreaTag.style';
 import React, { useEffect, useRef, useState } from 'react';
 import SelectInput, { SelectItem } from '../../../../../components/Select';
 import { Button, TextField, Typography } from '@equinor/eds-core-react';
@@ -222,7 +221,7 @@ const CreateAreaTag = (props: CreateAreaTagProps): JSX.Element => {
     }, [props.discipline, props.area, props.areaType, props.suffix]);
 
     const checkSuffix = (e: React.ChangeEvent<HTMLInputElement>): void => {
-        props.setSuffix(e.target.value);
+        props.setSuffix(e.target.value.toUpperCase());
         if(e.target.value.includes(' ')) {
             setIcon(errorIcon);
         } else {

--- a/src/modules/Preservation/views/AddScope/CreateAreaTag/__tests__/CreateAreaTag.test.jsx
+++ b/src/modules/Preservation/views/AddScope/CreateAreaTag/__tests__/CreateAreaTag.test.jsx
@@ -24,12 +24,10 @@ const mockAreas = [
     },
 ];
 
-const mockValidTagNo = [
-    {
-        tagNo: '100',
-        exists: false,
-    }
-];
+const mockValidTagNo = {
+    tagNo: '#PRE-E',
+    exists: false,
+};
 
 const spacesInTagNoMessage = 'The suffix cannot containt spaces.';
 
@@ -93,6 +91,14 @@ describe('<CreateAreaTag />', () => {
             /** For testing purposes this is considered a valid tagNo */
             const { getByText } = render(<CreateAreaTag areaType='PreArea' discipline='E' description='description text' />);
             await waitFor(() => expect(getByText('Next')).toHaveProperty('disabled', false));
+        });
+    });
+
+    it('Shows tag number when fields are passed', async () => {
+        await act(async () => {
+            const { getByText } = render(<CreateAreaTag areaType='PreArea' discipline='E' description='description text' />);
+            await waitFor(() => expect(getByText('description text')).toBeInTheDocument);
+            await waitFor(() => expect(getByText('#PRE-E')).toBeInTheDocument);
         });
     });
 

--- a/src/modules/Preservation/views/AddScope/SelectTags/SelectTags.style.ts
+++ b/src/modules/Preservation/views/AddScope/SelectTags/SelectTags.style.ts
@@ -6,6 +6,11 @@ export const Container = styled.div`
     flex-direction: column;
 `;
 
+export const NoFilterContainer = styled.div`
+    display: flex;
+    align-items: center;
+`;
+
 export const Header = styled.header`
     display: flex;
     align-items: baseline;
@@ -48,7 +53,6 @@ export const Tags = styled.div`
 
 export const TagsHeader = styled.div`
     font-weight: bold;
-    margin-bottom: calc(var(--grid-unit));
 `;
 
 export const LoadingContainer = styled.div`

--- a/src/modules/Preservation/views/AddScope/SelectTags/SelectTags.tsx
+++ b/src/modules/Preservation/views/AddScope/SelectTags/SelectTags.tsx
@@ -17,6 +17,7 @@ type SelectTagsProps = {
     nextStep: () => void;
     isLoading: boolean;
     addScopeMethod: AddScopeMethod;
+    removeTag: (tagNo: string) => void;
 }
 
 const KEYCODE_ENTER = 13;
@@ -40,19 +41,21 @@ const tableColumns = [
 const SelectTags = (props: SelectTagsProps): JSX.Element => {
     const { project } = usePreservationContext();
 
-    const rowSelectionChanged = (selectedRows: TagRow[]): void => {
+    const rowSelectionChanged = (rowData: TagRow[], row: TagRow): void => {
         // exclude any preserved tags (material-table bug)
-        const tagsToSelect = selectedRows
-            .filter(row => !row.isPreserved)
-            .map(row => {
-                return {
-                    tagNo: row.tagNo,
-                    description: row.description,
-                    mcPkgNo: row.mcPkgNo
-                };
-            });
-
-        props.setSelectedTags(tagsToSelect);
+        if (!row.isPreserved) {
+            const newSelectedTag = {
+                tagNo: row.tagNo,
+                description: row.description,
+                mcPkgNo: row.mcPkgNo
+            };
+            if (!rowData.includes(row)) {
+                props.removeTag(row.tagNo);
+            } else {
+                const updatedList = props.selectedTags.concat(newSelectedTag);
+                props.setSelectedTags(updatedList);
+            }
+        }
     };
 
     const getTableToolbar = (selectedRows: TagRow[]): JSX.Element => {
@@ -120,7 +123,9 @@ const SelectTags = (props: SelectTagsProps): JSX.Element => {
                     style={{
                         boxShadow: 'none'
                     }}
-                    onSelectionChange={rowSelectionChanged}
+                    onSelectionChange={(rowData, row): void => {
+                        rowSelectionChanged(rowData, row);
+                    }}
                     isLoading={props.isLoading}
                     components={{
                         OverlayLoading: (): JSX.Element => (

--- a/src/modules/Preservation/views/AddScope/SelectTags/SelectTags.tsx
+++ b/src/modules/Preservation/views/AddScope/SelectTags/SelectTags.tsx
@@ -3,7 +3,7 @@ import { tokens } from '@equinor/eds-tokens';
 import { Button, TextField } from '@equinor/eds-core-react';
 import CheckBoxIcon from '@material-ui/icons/CheckBox';
 import { Tag, TagRow } from '../types';
-import { Container, Header, Actions, Search, Next, Tags, TagsHeader, LoadingContainer, Toolbar } from './SelectTags.style';
+import { Container, Header, Actions, Search, Next, Tags, TagsHeader, LoadingContainer, Toolbar, NoFilterContainer } from './SelectTags.style';
 import { usePreservationContext } from '../../../context/PreservationContext';
 import Table from '../../../../../components/Table';
 import Loading from '../../../../../components/Loading';
@@ -70,10 +70,10 @@ const SelectTags = (props: SelectTagsProps): JSX.Element => {
                 <h1>Add preservation scope</h1>
                 <div>{project.description}</div>
             </Header>
-            <Actions>
-                {
-                    props.addScopeMethod === AddScopeMethod.AddTagsManually && (
-                        < Search >
+            {
+                props.addScopeMethod === AddScopeMethod.AddTagsManually && (
+                    <Actions>
+                        <Search>
                             <TextField
                                 id="tagSearch"
                                 placeholder="Search by tag number"
@@ -86,14 +86,24 @@ const SelectTags = (props: SelectTagsProps): JSX.Element => {
                                 }}
                             />
                         </Search>
-                    )
-                }
-                < Next >
-                    <Button onClick={props.nextStep} disabled={props.selectedTags.length === 0}>Next</Button>
-                </Next>
-            </Actions>
+
+                        <Next>
+                            <Button onClick={props.nextStep} disabled={props.selectedTags.length === 0}>Next</Button>
+                        </Next>
+                    </Actions>
+                )
+            }
             <Tags>
-                <TagsHeader>Select the tags that should be added to the preservation scope and click &apos;next&apos;</TagsHeader>
+                <NoFilterContainer>
+                    <TagsHeader>Select the tags that should be added to the preservation scope and click &apos;next&apos;</TagsHeader>
+                    {
+                        props.addScopeMethod !== AddScopeMethod.AddTagsManually && (
+                            <Next>
+                                <Button onClick={props.nextStep} disabled={props.selectedTags.length === 0}>Next</Button>
+                            </Next>
+                        )
+                    }
+                </NoFilterContainer>
                 <Table
                     columns={tableColumns}
                     data={props.scopeTableData}

--- a/src/modules/Preservation/views/AddScope/TagDetails/TagDetails.tsx
+++ b/src/modules/Preservation/views/AddScope/TagDetails/TagDetails.tsx
@@ -45,9 +45,11 @@ const TagDetails = ({
                     <CollapseInfo>
                         {tag.tagNo}
                     </CollapseInfo>
-                    <IconButton size='small' title='Remove' onClick={(): void => removeTag(tag.tagNo)}>
-                        <DeleteOutlineIcon />
-                    </IconButton>
+                    { !creatingNewTag &&
+                        <IconButton size='small' title='Remove' onClick={(): void => removeTag(tag.tagNo)}>
+                            <DeleteOutlineIcon />
+                        </IconButton>
+                    }
                 </Collapse>
                 {
                     isExpanded && (

--- a/src/modules/Preservation/views/AddScope/TagDetails/TagDetails.tsx
+++ b/src/modules/Preservation/views/AddScope/TagDetails/TagDetails.tsx
@@ -19,7 +19,13 @@ const TagDetails = ({
     creatingNewTag = false
 }: TagDetailsProps): JSX.Element => {
 
-    const [expandedTagNo, setExpandedTagNo] = useState<string | null>();
+    const [expandedTagNo, setExpandedTagNo] = useState<string | null>(() => {
+        if (creatingNewTag) {
+            return selectedTags[0].tagNo;
+        } else {
+            return null;
+        }
+    });
 
     const toggleDetails = (tagNo: string): void => {
         if (tagNo === expandedTagNo) {
@@ -30,7 +36,7 @@ const TagDetails = ({
     };
 
     const createTagSection = (tag: Tag): JSX.Element => {
-        const isExpanded = tag.tagNo === expandedTagNo || creatingNewTag;
+        const isExpanded = tag.tagNo === expandedTagNo;
 
         return (
             <TagContainer key={tag.tagNo}>

--- a/src/modules/Preservation/views/AddScope/TagDetails/TagDetails.tsx
+++ b/src/modules/Preservation/views/AddScope/TagDetails/TagDetails.tsx
@@ -30,7 +30,7 @@ const TagDetails = ({
     };
 
     const createTagSection = (tag: Tag): JSX.Element => {
-        const isExpanded = tag.tagNo === expandedTagNo;
+        const isExpanded = tag.tagNo === expandedTagNo || creatingNewTag;
 
         return (
             <TagContainer key={tag.tagNo}>
@@ -58,10 +58,12 @@ const TagDetails = ({
                                 <ExpandHeader>Tag description</ExpandHeader>
                                 <div>{tag.description}</div>
                             </ExpandSection>
-                            <ExpandSection>
-                                <ExpandHeader>MC pkg</ExpandHeader>
-                                <div>{tag.mcPkgNo}</div>
-                            </ExpandSection>
+                            { !creatingNewTag &&
+                                <ExpandSection>
+                                    <ExpandHeader>MC pkg</ExpandHeader>
+                                    <div>{tag.mcPkgNo}</div>
+                                </ExpandSection>
+                            }
                         </Expand>
                     )
                 }
@@ -74,9 +76,11 @@ const TagDetails = ({
             <Header>
                 <h1>Selected {creatingNewTag ? 'tag' : 'tags'}</h1>
             </Header>
-            <div>
-                {selectedTags.length} tags selected
-            </div>
+            { !creatingNewTag &&
+                <div>
+                    {selectedTags.length} tag(s) selected
+                </div>
+            }
             <TagList>
                 {
                     selectedTags.map(tag => createTagSection(tag))

--- a/src/modules/Preservation/views/AddScope/TagDetails/TagDetails.tsx
+++ b/src/modules/Preservation/views/AddScope/TagDetails/TagDetails.tsx
@@ -34,18 +34,18 @@ const TagDetails = ({
             <TagContainer key={tag.tagNo}>
                 <Collapse>
                     <IconButton size='small' onClick={(): void => toggleDetails(tag.tagNo)}>
-                        {                        
+                        {
                             isExpanded
                                 ? <KeyboardArrowUpIcon />
                                 : <KeyboardArrowDownIcon />
                         }
                     </IconButton>
                     <CollapseInfo>
-                        {tag.tagNo} - {tag.description}
+                        {tag.tagNo}
                     </CollapseInfo>
                     <IconButton size='small' title='Remove' onClick={(): void => removeTag(tag.tagNo)}>
                         <DeleteOutlineIcon />
-                    </IconButton>                        
+                    </IconButton>
                 </Collapse>
                 {
                     isExpanded && (

--- a/src/modules/Preservation/views/AddScope/TagDetails/TagDetails.tsx
+++ b/src/modules/Preservation/views/AddScope/TagDetails/TagDetails.tsx
@@ -10,11 +10,13 @@ import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
 interface TagDetailsProps {
     selectedTags: Tag[];
     removeTag: (tagNo: string) => void;
+    creatingNewTag?: boolean;
 }
 
 const TagDetails = ({
     selectedTags,
-    removeTag
+    removeTag,
+    creatingNewTag = false
 }: TagDetailsProps): JSX.Element => {
 
     const [expandedTagNo, setExpandedTagNo] = useState<string | null>();
@@ -68,7 +70,7 @@ const TagDetails = ({
     return (
         <div>
             <Header>
-                <h1>Selected tags</h1>
+                <h1>Selected {creatingNewTag ? 'tag' : 'tags'}</h1>
             </Header>
             <div>
                 {selectedTags.length} tags selected

--- a/src/modules/Preservation/views/AddScope/TagDetails/__tests__/TagDetails.test.jsx
+++ b/src/modules/Preservation/views/AddScope/TagDetails/__tests__/TagDetails.test.jsx
@@ -25,25 +25,30 @@ describe('Module: <TagDetails />', () => {
 
     it('Should render all selected tags', () => {
         const { getByText } = render(<TagDetails selectedTags={selectedTags} />);
-        expect(getByText('tagno-1 - description-1')).toBeInTheDocument();
-        expect(getByText('tagno-2 - description-2')).toBeInTheDocument();
-        expect(getByText('tagno-3 - description-3')).toBeInTheDocument();
+        expect(getByText('tagno-1')).toBeInTheDocument();
+        expect(getByText('tagno-2')).toBeInTheDocument();
+        expect(getByText('tagno-3')).toBeInTheDocument();
     });
 
     it('Should show and hide tag details when expand button is clicked', () => {
         const { container, queryByText } = render(<TagDetails selectedTags={selectedTags} />);
-        
+
         const expandButton = container.querySelector('button');
 
         // collapsed by default
         expect(queryByText('mcpkgno-1')).toBeNull();
-        
+        expect(queryByText('description-1')).toBeNull();
+
+
         // expand
-        expandButton.click();        
+        expandButton.click();
         expect(queryByText('mcpkgno-1')).not.toBeNull();
+        expect(queryByText('description-1')).not.toBeNull();
 
         // collapse
         expandButton.click();
         expect(queryByText('mcpkgno-1')).toBeNull();
+        expect(queryByText('description-1')).toBeNull();
+
     });
 });


### PR DESCRIPTION
-Added 'Selected tags' (tag details) component to first page of all wizards.
-Custom 'Select tags' view for createAreaTag first step
-Common 'Select tags' component has some small adjustmenst for createAreaTag (singe tag reflected in header. Removed delete icon - this created weird logic - can be discussed)