### PR TITLE
Use library API instead of preservation API

### DIFF
--- a/src/modules/PlantConfig/http/LibraryApiClient.ts
+++ b/src/modules/PlantConfig/http/LibraryApiClient.ts
@@ -6,6 +6,15 @@ import {ErrorResponse, RegisterResponse, TagFunctionResponse} from './LibraryApi
 
 const Settings = require('../../../../settings.json');
 
+export interface AreaResponse {
+    code: string;
+    description: string;
+}
+
+export interface DisciplineResponse {
+    code: string;
+    description: string;
+}
 
 class LibraryApiError extends Error {
 
@@ -126,6 +135,44 @@ class LibraryApiClient extends ApiClient {
                 endpoint,
                 settings
             );
+            return result.data;
+        }
+        catch (error) {
+            throw getLibraryApiError(error);
+        }
+    }
+
+    /**
+     * Get areas
+     *
+     * @param setRequestCanceller Returns a function that can be called to cancel the request
+     */
+    async getAreas(setRequestCanceller?: RequestCanceler): Promise<AreaResponse[]> {
+        const endpoint = '/Areas';
+        const settings: AxiosRequestConfig = {};
+        this.setupRequestCanceler(settings, setRequestCanceller);
+
+        try {
+            const result = await this.client.get<AreaResponse[]>(endpoint, settings);
+            return result.data;
+        }
+        catch (error) {
+            throw getLibraryApiError(error);
+        }
+    }
+
+    /**
+     * Get disciplines
+     *
+     * @param setRequestCanceller Returns a function that can be called to cancel the request
+     */
+    async getDisciplines(setRequestCanceller?: RequestCanceler): Promise<DisciplineResponse[]> {
+        const endpoint = '/Disciplines';
+        const settings: AxiosRequestConfig = {};
+        this.setupRequestCanceler(settings, setRequestCanceller);
+
+        try {
+            const result = await this.client.get<DisciplineResponse[]>(endpoint, settings);
             return result.data;
         }
         catch (error) {

--- a/src/modules/Preservation/context/PreservationContext.tsx
+++ b/src/modules/Preservation/context/PreservationContext.tsx
@@ -8,12 +8,14 @@ import preservationCache from '../cache/PreservationCache';
 import propTypes from 'prop-types';
 import { useCurrentPlant } from '../../../core/PlantContext';
 import { useProcosysContext } from '../../../core/ProcosysContext';
+import LibraryApiClient from '@procosys/modules/PlantConfig/http/LibraryApiClient';
 
 const PreservationContext = React.createContext<PreservationContextProps>({} as PreservationContextProps);
 type PreservationContextProps = {
     project: ProjectDetails;
     setCurrentProject: (projectId: number) => void;
     apiClient: PreservationApiClient;
+    libraryApiClient: LibraryApiClient;
     availableProjects: ProjectDetails[];
 }
 
@@ -30,6 +32,7 @@ export const PreservationContextProvider: React.FC = ({children}): JSX.Element =
     const {procosysApiClient, auth} = useProcosysContext();
     const {plant} = useCurrentPlant();
     const preservationApiClient = useMemo(() => new PreservationApiClient(auth), [auth]);
+    const libraryApiClient = useMemo(() => new LibraryApiClient(auth), [auth]);
 
     const [availableProjects, setAvailableProjects] = useState<ProjectDetails[]>([]);
 
@@ -67,6 +70,7 @@ export const PreservationContextProvider: React.FC = ({children}): JSX.Element =
 
     useEffect(() => {
         preservationApiClient.setCurrentPlant(plant.id);
+        libraryApiClient.setCurrentPlant(plant.id);
     },[plant]);
 
     useEffect(() => {
@@ -97,7 +101,10 @@ export const PreservationContextProvider: React.FC = ({children}): JSX.Element =
 
     return (
         <PreservationContext.Provider value={{
-            project: currentProject, setCurrentProject, apiClient: preservationApiClient, availableProjects
+            project: currentProject,
+            libraryApiClient: libraryApiClient,
+            setCurrentProject, apiClient: preservationApiClient,
+            availableProjects
         }}>
             {children}
         </PreservationContext.Provider>

--- a/src/modules/Preservation/http/PreservationApiClient.ts
+++ b/src/modules/Preservation/http/PreservationApiClient.ts
@@ -172,16 +172,6 @@ interface AreaFilterEntity {
     description: string;
 }
 
-export interface DisciplineResponse {
-    code: string;
-    description: string;
-}
-
-export interface AreaResponse {
-    code: string;
-    description: string;
-}
-
 interface TagRequirementsResponse {
     id: number;
     intervalWeeks: number;
@@ -903,44 +893,6 @@ class PreservationApiClient extends ApiClient {
 
         try {
             const result = await this.client.get<RequirementTypeResponse>(endpoint, settings);
-            return result.data;
-        }
-        catch (error) {
-            throw getPreservationApiError(error);
-        }
-    }
-
-    /**
-     * Get disciplines
-     *
-     * @param setRequestCanceller Returns a function that can be called to cancel the request
-     */
-    async getDisciplines(setRequestCanceller?: RequestCanceler): Promise<DisciplineResponse[]> {
-        const endpoint = '/Disciplines';
-        const settings: AxiosRequestConfig = {};
-        this.setupRequestCanceler(settings, setRequestCanceller);
-
-        try {
-            const result = await this.client.get<DisciplineResponse[]>(endpoint, settings);
-            return result.data;
-        }
-        catch (error) {
-            throw getPreservationApiError(error);
-        }
-    }
-
-    /**
-     * Get areas
-     *
-     * @param setRequestCanceller Returns a function that can be called to cancel the request
-     */
-    async getAreas(setRequestCanceller?: RequestCanceler): Promise<AreaResponse[]> {
-        const endpoint = '/Areas';
-        const settings: AxiosRequestConfig = {};
-        this.setupRequestCanceler(settings, setRequestCanceller);
-
-        try {
-            const result = await this.client.get<AreaResponse[]>(endpoint, settings);
             return result.data;
         }
         catch (error) {

--- a/src/modules/Preservation/views/AddScope/CreateAreaTag/CreateAreaTag.tsx
+++ b/src/modules/Preservation/views/AddScope/CreateAreaTag/CreateAreaTag.tsx
@@ -40,7 +40,7 @@ type CreateAreaTagProps = {
 }
 
 const CreateAreaTag = (props: CreateAreaTagProps): JSX.Element => {
-    const { apiClient, project } = usePreservationContext();
+    const { apiClient, libraryApiClient, project } = usePreservationContext();
 
     const [mappedDisciplines, setMappedDisciplines] = useState<SelectItem[]>([]);
     const suffixInputRef = useRef<HTMLInputElement>(null);
@@ -61,7 +61,7 @@ const CreateAreaTag = (props: CreateAreaTagProps): JSX.Element => {
         let requestCancellor: Canceler | null = null;
         (async (): Promise<void> => {
             try {
-                const response = await apiClient.getAreas((cancel: Canceler) => { requestCancellor = cancel; });
+                const response = await libraryApiClient.getAreas((cancel: Canceler) => { requestCancellor = cancel; });
                 const areas = response.map(area => ({
                     text: area.code + ' - ' + area.description,
                     value: area.code,
@@ -107,7 +107,7 @@ const CreateAreaTag = (props: CreateAreaTagProps): JSX.Element => {
         let requestCancellor: Canceler | null = null;
         (async (): Promise<void> => {
             try {
-                const data = await apiClient.getDisciplines((cancel: Canceler) => requestCancellor = cancel);
+                const data = await libraryApiClient.getDisciplines((cancel: Canceler) => requestCancellor = cancel);
 
                 setDisciplines(data);
             } catch (error) {


### PR DESCRIPTION
 Use library API instead of preservation API to get area and disciplines. These will be deprecated in preservation API