### PR TITLE
Remove sorting from table when sorting on status. This is done in API

### DIFF
--- a/src/modules/Preservation/views/ScopeOverview/ScopeTable.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeTable.tsx
@@ -133,7 +133,7 @@ class ScopeTable extends React.Component<ScopeTableProps, {}> {
                         // @ts-ignore
                         { title: 'Disc', field: 'disciplineCode', width: '5%'},
                         // @ts-ignore
-                        { title: 'Status', field: 'status', width: '7%'},
+                        { title: 'Status', field: 'status', width: '7%', customSort: (a, b): any => a.status - b.status },
                         // @ts-ignore
                         { title: 'Req type', render: this.getRequirementColumn, sorting: false, width: '10%'}
                     ]}

--- a/src/modules/Preservation/views/ScopeOverview/ScopeTable.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeTable.tsx
@@ -133,7 +133,7 @@ class ScopeTable extends React.Component<ScopeTableProps, {}> {
                         // @ts-ignore
                         { title: 'Disc', field: 'disciplineCode', width: '5%'},
                         // @ts-ignore
-                        { title: 'Status', field: 'status', width: '7%', customSort: (a, b): any => a.status - b.status },
+                        { title: 'Status', field: 'status', width: '7%', customSort: (): any => null },
                         // @ts-ignore
                         { title: 'Req type', render: this.getRequirementColumn, sorting: false, width: '10%'}
                     ]}


### PR DESCRIPTION
Sorting on status is discarded in table, because it is handled in the API.
Asc: Not started, Active, Completed
Desc: Completed, Active, Not started