### PR TITLE
Remove toolbar text. Not necessary, all selected tags show to right.

### DIFF
--- a/src/modules/Preservation/views/AddScope/SelectTags/SelectTags.style.ts
+++ b/src/modules/Preservation/views/AddScope/SelectTags/SelectTags.style.ts
@@ -6,9 +6,10 @@ export const Container = styled.div`
     flex-direction: column;
 `;
 
-export const NoFilterContainer = styled.div`
+export const InformationContainer = styled.div`
     display: flex;
     align-items: center;
+    padding-bottom: calc(var(--grid-unit) * 3);
 `;
 
 export const Header = styled.header`
@@ -62,12 +63,4 @@ export const LoadingContainer = styled.div`
     h1 {
         font-size: calc(var(--grid-unit) * 3);
     }
-`;
-
-export const Toolbar = styled.div`
-    font-size: calc(var(--grid-unit) * 2);
-    line-height: calc(var(--grid-unit) * 3);
-    margin-top: calc(var(--grid-unit) * 2);
-    margin-bottom: var(--grid-unit);
-    color: ${tokens.colors.text.static_icons__secondary.rgba};
 `;

--- a/src/modules/Preservation/views/AddScope/SelectTags/SelectTags.tsx
+++ b/src/modules/Preservation/views/AddScope/SelectTags/SelectTags.tsx
@@ -3,7 +3,7 @@ import { tokens } from '@equinor/eds-tokens';
 import { Button, TextField } from '@equinor/eds-core-react';
 import CheckBoxIcon from '@material-ui/icons/CheckBox';
 import { Tag, TagRow } from '../types';
-import { Container, Header, Actions, Search, Next, Tags, TagsHeader, LoadingContainer, Toolbar, NoFilterContainer } from './SelectTags.style';
+import { Container, Header, Actions, Search, Next, Tags, TagsHeader, LoadingContainer, InformationContainer } from './SelectTags.style';
 import { usePreservationContext } from '../../../context/PreservationContext';
 import Table from '../../../../../components/Table';
 import Loading from '../../../../../components/Loading';
@@ -89,12 +89,6 @@ const SelectTags = (props: SelectTagsProps): JSX.Element => {
         }
     };
 
-    const getTableToolbar = (selectedRows: TagRow[]): JSX.Element => {
-        // exclude any preserved tags from the count
-        const selectedCount = selectedRows.filter(row => !row.isPreserved).length;
-        return <Toolbar>{selectedCount} tags selected</Toolbar>;
-    };
-
     return (
         <Container>
             <Header>
@@ -125,7 +119,7 @@ const SelectTags = (props: SelectTagsProps): JSX.Element => {
                 )
             }
             <Tags>
-                <NoFilterContainer>
+                <InformationContainer>
                     <TagsHeader>Select the tags that should be added to the preservation scope and click &apos;next&apos;</TagsHeader>
                     {
                         props.addScopeMethod !== AddScopeMethod.AddTagsManually && (
@@ -134,11 +128,12 @@ const SelectTags = (props: SelectTagsProps): JSX.Element => {
                             </Next>
                         )
                     }
-                </NoFilterContainer>
+                </InformationContainer>
                 <Table
                     columns={tableColumns}
                     data={props.scopeTableData}
                     options={{
+                        toolbar: false,
                         showTitle: false,
                         filtering: true,
                         search: false,
@@ -173,8 +168,7 @@ const SelectTags = (props: SelectTagsProps): JSX.Element => {
                             <LoadingContainer>
                                 <Loading title="Loading tags" />
                             </LoadingContainer>
-                        ),
-                        Toolbar: (data): JSX.Element => getTableToolbar(data.selectedRows)
+                        )
                     }}
                 />
             </Tags>

--- a/src/modules/Preservation/views/AddScope/SelectTags/__tests__/SelectTags.test.jsx
+++ b/src/modules/Preservation/views/AddScope/SelectTags/__tests__/SelectTags.test.jsx
@@ -56,7 +56,7 @@ describe('Module: <SelectTags />', () => {
     it('Should update selected tags when clicking checkbox in table', () => {
         const selectedTags = [];
 
-        const { container, getByText } = render(
+        const { container } = render(
             <SelectTags 
                 selectedTags={selectedTags} 
                 scopeTableData={tableData}
@@ -67,8 +67,6 @@ describe('Module: <SelectTags />', () => {
 
         const checkboxes = container.querySelectorAll('input[type="checkbox"]');
         fireEvent.click(checkboxes[1]); // fist checkbox after "select all"
-
-        expect(getByText('1 tags selected')).toBeInTheDocument();
         expect(selectedTags.length).toBe(1);
     });
 


### PR DESCRIPTION
Reason for fix:
Number of selected tags displayed on top of table showed only number of selected tags on that search. Could be confusing for user. Lotte says just remove toolbar text, as number of selected tags is show on right,