### PR TITLE
Feature/72397   library framework should support url that will bring up the page

### DIFF
--- a/src/modules/Header/index.tsx
+++ b/src/modules/Header/index.tsx
@@ -281,7 +281,7 @@ const Header: React.FC = (): JSX.Element => {
                 <a href={`/${params.plant}/Hookup`}>Hookup</a>
                 <NavLink
                     activeClassName={'active'}
-                    to={`/${params.plant}/PlantConfig`}
+                    to={`/${params.plant}/PlantConfig/Library/`}
                 >
                     Plant Configuration
                 </NavLink>

--- a/src/modules/PlantConfig/index.tsx
+++ b/src/modules/PlantConfig/index.tsx
@@ -17,7 +17,7 @@ const Preservation = (): JSX.Element => {
                     <BrowserRouter basename={url}>
                         <Switch>
                             <Route
-                                path={'/Library/:path/:libraryType/:libraryItem'}
+                                path={'/Library/:path?/:libraryType?/:libraryItem?'}
                                 component={Library}
                             />
                             <Route

--- a/src/modules/PlantConfig/views/Library/Library.tsx
+++ b/src/modules/PlantConfig/views/Library/Library.tsx
@@ -29,12 +29,14 @@ const Library = (): JSX.Element => {
     const [selectedLibraryItem, setSelectedLibraryItem] = useState<string>(params.libraryItem);
 
     useEffect(() => {
-        setSelectedLibraryType(params.libraryType);
-    }, []);
+        if(path) {
+            history.replace(`/Library/${path}/${selectedLibraryType}/${selectedLibraryItem}`);
+        }
+    }, [path]);
 
     useEffect(() => {
-        history.replace('/Library/' + (path ? path + '/' + (selectedLibraryType ? selectedLibraryType + '/' + (selectedLibraryItem ? selectedLibraryItem : '' ) : '') : '')); //+ '/' + selectedLibraryType + '/' + selectedLibraryItem);
-    }, [path]);
+        history.replace('/Library/');
+    }, []);
 
     return (
         <Container>

--- a/src/modules/PlantConfig/views/Library/Library.tsx
+++ b/src/modules/PlantConfig/views/Library/Library.tsx
@@ -3,10 +3,8 @@ import React, { useEffect, useState } from 'react';
 //import withAccessControl from '../../../../core/security/withAccessControl';
 import LibraryItemDetails from './LibraryItemDetails';
 import LibraryTreeview from './LibraryTreeview/LibraryTreeview';
-import { useRouteMatch } from 'react-router-dom';
 import { Container, Divider } from './Library.style';
 import { useHistory } from 'react-router-dom';
-
 
 export enum LibraryType {
     TAG_FUNCTION = 'TagFunction',
@@ -19,20 +17,10 @@ export enum LibraryType {
 
 const Library = (): JSX.Element => {
 
-    const match = useRouteMatch();
-    const params: any = match.params;
-
     const history = useHistory();
 
-    const [path, setPath] = useState<string>(params.path);
-    const [selectedLibraryType, setSelectedLibraryType] = useState<string>(params.libraryType);
-    const [selectedLibraryItem, setSelectedLibraryItem] = useState<string>(params.libraryItem);
-
-    useEffect(() => {
-        if(path && selectedLibraryType && selectedLibraryItem) {
-            history.replace(`/Library/${path}/${selectedLibraryType}/${selectedLibraryItem}`);
-        }
-    }, [path]);
+    const [selectedLibraryType, setSelectedLibraryType] = useState<string>('');
+    const [selectedLibraryItem, setSelectedLibraryItem] = useState<string>('');
 
     useEffect(() => {
         history.replace('/Library/');
@@ -40,7 +28,7 @@ const Library = (): JSX.Element => {
 
     return (
         <Container>
-            <LibraryTreeview setSelectedLibraryType={setSelectedLibraryType} setSelectedLibraryItem={setSelectedLibraryItem} setPath={setPath} />
+            <LibraryTreeview setSelectedLibraryType={setSelectedLibraryType} setSelectedLibraryItem={setSelectedLibraryItem} />
 
             <Divider />
 

--- a/src/modules/PlantConfig/views/Library/Library.tsx
+++ b/src/modules/PlantConfig/views/Library/Library.tsx
@@ -33,7 +33,7 @@ const Library = (): JSX.Element => {
     }, []);
 
     useEffect(() => {
-        history.push('/Library/' + (path ? path + '/' + (selectedLibraryType ? selectedLibraryType + '/' + (selectedLibraryItem ? selectedLibraryItem : '' ) : '') : '')); //+ '/' + selectedLibraryType + '/' + selectedLibraryItem);
+        history.replace('/Library/' + (path ? path + '/' + (selectedLibraryType ? selectedLibraryType + '/' + (selectedLibraryItem ? selectedLibraryItem : '' ) : '') : '')); //+ '/' + selectedLibraryType + '/' + selectedLibraryItem);
     }, [path]);
 
     return (

--- a/src/modules/PlantConfig/views/Library/Library.tsx
+++ b/src/modules/PlantConfig/views/Library/Library.tsx
@@ -29,7 +29,7 @@ const Library = (): JSX.Element => {
     const [selectedLibraryItem, setSelectedLibraryItem] = useState<string>(params.libraryItem);
 
     useEffect(() => {
-        if(path) {
+        if(path && selectedLibraryType && selectedLibraryItem) {
             history.replace(`/Library/${path}/${selectedLibraryType}/${selectedLibraryItem}`);
         }
     }, [path]);

--- a/src/modules/PlantConfig/views/Library/Library.tsx
+++ b/src/modules/PlantConfig/views/Library/Library.tsx
@@ -5,6 +5,7 @@ import LibraryItemDetails from './LibraryItemDetails';
 import LibraryTreeview from './LibraryTreeview/LibraryTreeview';
 import { useRouteMatch } from 'react-router-dom';
 import { Container, Divider } from './Library.style';
+import { useHistory } from 'react-router-dom';
 
 
 export enum LibraryType {
@@ -18,19 +19,26 @@ export enum LibraryType {
 
 const Library = (): JSX.Element => {
 
-    const [selectedLibraryType, setSelectedLibraryType] = useState('');
-    const [selectedLibraryItem, setSelectedLibraryItem] = useState('');
-
     const match = useRouteMatch();
     const params: any = match.params;
+
+    const history = useHistory();
+
+    const [path, setPath] = useState<string>(params.path);
+    const [selectedLibraryType, setSelectedLibraryType] = useState<string>(params.libraryType);
+    const [selectedLibraryItem, setSelectedLibraryItem] = useState<string>(params.libraryItem);
 
     useEffect(() => {
         setSelectedLibraryType(params.libraryType);
     }, []);
 
+    useEffect(() => {
+        history.push('/Library/' + (path ? path + '/' + (selectedLibraryType ? selectedLibraryType + '/' + (selectedLibraryItem ? selectedLibraryItem : '' ) : '') : '')); //+ '/' + selectedLibraryType + '/' + selectedLibraryItem);
+    }, [path]);
+
     return (
         <Container>
-            <LibraryTreeview setSelectedLibraryType={setSelectedLibraryType} setSelectedLibraryItem={setSelectedLibraryItem} />
+            <LibraryTreeview setSelectedLibraryType={setSelectedLibraryType} setSelectedLibraryItem={setSelectedLibraryItem} setPath={setPath} />
 
             <Divider />
 

--- a/src/modules/PlantConfig/views/Library/LibraryTreeview/LibraryTreeview.style.ts
+++ b/src/modules/PlantConfig/views/Library/LibraryTreeview/LibraryTreeview.style.ts
@@ -2,5 +2,5 @@ import styled from 'styled-components';
 
 export const Container = styled.div`
     display: flex;
+    min-width: 250px;
 `;
-

--- a/src/modules/PlantConfig/views/Library/LibraryTreeview/LibraryTreeview.tsx
+++ b/src/modules/PlantConfig/views/Library/LibraryTreeview/LibraryTreeview.tsx
@@ -6,6 +6,7 @@ import { showSnackbarNotification } from '../../../../../core/services/Notificat
 import { Container } from './LibraryTreeview.style';
 
 type LibraryTreeviewProps = {
+    setPath: (path: string) => void;
     setSelectedLibraryType: (libraryType: string) => void;
     setSelectedLibraryItem: (libraryItem: string) => void;
 };
@@ -17,8 +18,8 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
         preservationApiClient
     } = usePlantConfigContext();
 
-
-    const handleTreeviewClick = (libraryType: LibraryType, libraryItem: string): void => {
+    const handleTreeviewClick = (libraryType: LibraryType, libraryItem: string, path: string): void => {
+        props.setPath(path);
         props.setSelectedLibraryType(libraryType);
         props.setSelectedLibraryItem(libraryItem);
     };
@@ -33,7 +34,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                             {
                                 id: mode.id,
                                 name: mode.title,
-                                onClick: (): void => handleTreeviewClick(LibraryType.MODE, mode.id.toString())
+                                onClick: (): void => handleTreeviewClick(LibraryType.MODE, mode.id.toString(), `${LibraryType.MODE}|${mode.title.replace(/\s/g, '')}`)
                             }));
                     }
                     return children;
@@ -56,7 +57,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                             {
                                 id: journey.id,
                                 name: journey.title,
-                                onClick: (): void => handleTreeviewClick(LibraryType.PRES_JOURNEY, journey.id.toString()),
+                                onClick: (): void => handleTreeviewClick(LibraryType.PRES_JOURNEY, journey.id.toString(), `${LibraryType.PRES_JOURNEY}|${journey.title.replace(/\s/g, '')}`),
                             }));
                     }
                     return children;
@@ -78,7 +79,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                     {
                         id: `rt_${requirementType.id}`,
                         name: requirementType.title,
-                        onClick: (): void => handleTreeviewClick(LibraryType.PRES_REQUIREMENT_TYPE, requirementType.id.toString()),
+                        onClick: (): void => handleTreeviewClick(LibraryType.PRES_REQUIREMENT_TYPE, requirementType.id.toString(), `${LibraryType.PRES_REQUIREMENT_TYPE}|${requirementType.title.replace(/\s/g, '')}`),
                         getChildren: (): Promise<TreeViewNode[]> => {
                             const withInputNodes = requirementType.requirementDefinitions
                                 .filter((itm) => itm.needsUserInput)
@@ -86,7 +87,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                                     return {
                                         id: `field_withinput_${itm.id}`,
                                         name: itm.title,
-                                        onClick: (): void => handleTreeviewClick(LibraryType.PRES_REQUIREMENT_DEFINITION, itm.id.toString())
+                                        onClick: (): void => handleTreeviewClick(LibraryType.PRES_REQUIREMENT_DEFINITION, itm.id.toString(), `${LibraryType.PRES_REQUIREMENT_TYPE}|${LibraryType.PRES_REQUIREMENT_DEFINITION}|${requirementType.title.replace(/\s/g, '')}|${itm.title}`)
                                     };
                                 });
                             const withoutInput = requirementType.requirementDefinitions
@@ -95,7 +96,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                                     return {
                                         id: `field_withoutinput_${itm.id}`,
                                         name: itm.title,
-                                        onClick: (): void => handleTreeviewClick(LibraryType.PRES_REQUIREMENT_DEFINITION, itm.id.toString())
+                                        onClick: (): void => handleTreeviewClick(LibraryType.PRES_REQUIREMENT_DEFINITION, itm.id.toString(), `${LibraryType.PRES_REQUIREMENT_TYPE}|${LibraryType.PRES_REQUIREMENT_DEFINITION}|${requirementType.title.replace(/\s/g, '')}|${itm.title}`)
                                     };
                                 });
                             const nodes: TreeViewNode[] = [];
@@ -137,7 +138,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                 children.push({
                     id: `tf_register_${registerCode}_${tf.code}`,
                     name: `${tf.code}, ${tf.description}`,
-                    onClick: (): void => handleTreeviewClick(LibraryType.TAG_FUNCTION, `${registerCode}|${tf.code}`)
+                    onClick: (): void => handleTreeviewClick(LibraryType.TAG_FUNCTION, `${registerCode}|${tf.code}`, `${LibraryType.TAG_FUNCTION}|${registerCode}|${tf.code}`)
                 });
             });
         } catch (error) {
@@ -174,23 +175,26 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
         {
             id: LibraryType.TAG_FUNCTION,
             name: 'Tag Functions',
+            onClick: (): void => { handleTreeviewClick(LibraryType.TAG_FUNCTION, '', LibraryType.TAG_FUNCTION); },
             getChildren: getRegisterNodes
         },
         {
             id: LibraryType.MODE,
             name: 'Modes',
+            onClick: (): void => { handleTreeviewClick(LibraryType.MODE, '', LibraryType.MODE); },
             getChildren: getModes
         },
         {
             id: LibraryType.PRES_JOURNEY,
             name: 'Preservation Journeys',
-            getChildren: getPresJourneyTreeNodes,
-            onClick: (): void => { handleTreeviewClick(LibraryType.PRES_JOURNEY, ''); }
+            onClick: (): void => { handleTreeviewClick(LibraryType.PRES_JOURNEY, '', LibraryType.PRES_JOURNEY); },
+            getChildren: getPresJourneyTreeNodes
         },
         {
             id: LibraryType.PRES_REQUIREMENT_TYPE,
             name: 'Preservation requirements',
-            getChildren: getRequirementTreeNodes
+            onClick: (): void => { handleTreeviewClick(LibraryType.PRES_REQUIREMENT_TYPE, '', LibraryType.PRES_REQUIREMENT_TYPE); },
+            getChildren: getRequirementTreeNodes,
         }
     ];
 

--- a/src/modules/PlantConfig/views/Library/LibraryTreeview/LibraryTreeview.tsx
+++ b/src/modules/PlantConfig/views/Library/LibraryTreeview/LibraryTreeview.tsx
@@ -19,7 +19,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
     } = usePlantConfigContext();
 
     const handleTreeviewClick = (libraryType: LibraryType, libraryItem: string, path: string): void => {
-        props.setPath(path);
+        props.setPath(path.replace(/\s/g, ''));
         props.setSelectedLibraryType(libraryType);
         props.setSelectedLibraryItem(libraryItem);
     };
@@ -34,7 +34,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                             {
                                 id: mode.id,
                                 name: mode.title,
-                                onClick: (): void => handleTreeviewClick(LibraryType.MODE, mode.id.toString(), `${LibraryType.MODE}|${mode.title.replace(/\s/g, '')}`)
+                                onClick: (): void => handleTreeviewClick(LibraryType.MODE, mode.id.toString(), `${LibraryType.MODE}${mode.title}`)
                             }));
                     }
                     return children;
@@ -57,7 +57,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                             {
                                 id: journey.id,
                                 name: journey.title,
-                                onClick: (): void => handleTreeviewClick(LibraryType.PRES_JOURNEY, journey.id.toString(), `${LibraryType.PRES_JOURNEY}|${journey.title.replace(/\s/g, '')}`),
+                                onClick: (): void => handleTreeviewClick(LibraryType.PRES_JOURNEY, journey.id.toString(), `${LibraryType.PRES_JOURNEY}|${journey.title}`),
                             }));
                     }
                     return children;
@@ -79,7 +79,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                     {
                         id: `rt_${requirementType.id}`,
                         name: requirementType.title,
-                        onClick: (): void => handleTreeviewClick(LibraryType.PRES_REQUIREMENT_TYPE, requirementType.id.toString(), `${LibraryType.PRES_REQUIREMENT_TYPE}|${requirementType.title.replace(/\s/g, '')}`),
+                        onClick: (): void => handleTreeviewClick(LibraryType.PRES_REQUIREMENT_TYPE, requirementType.id.toString(), `${LibraryType.PRES_REQUIREMENT_TYPE}|${requirementType.code}`),
                         getChildren: (): Promise<TreeViewNode[]> => {
                             const withInputNodes = requirementType.requirementDefinitions
                                 .filter((itm) => itm.needsUserInput)
@@ -87,7 +87,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                                     return {
                                         id: `field_withinput_${itm.id}`,
                                         name: itm.title,
-                                        onClick: (): void => handleTreeviewClick(LibraryType.PRES_REQUIREMENT_DEFINITION, itm.id.toString(), `${LibraryType.PRES_REQUIREMENT_TYPE}|${LibraryType.PRES_REQUIREMENT_DEFINITION}|${requirementType.title.replace(/\s/g, '')}|${itm.title}`)
+                                        onClick: (): void => handleTreeviewClick(LibraryType.PRES_REQUIREMENT_DEFINITION, itm.id.toString(), `${LibraryType.PRES_REQUIREMENT_TYPE}|${requirementType.code}|withInput|${itm.title}`)
                                     };
                                 });
                             const withoutInput = requirementType.requirementDefinitions
@@ -96,7 +96,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                                     return {
                                         id: `field_withoutinput_${itm.id}`,
                                         name: itm.title,
-                                        onClick: (): void => handleTreeviewClick(LibraryType.PRES_REQUIREMENT_DEFINITION, itm.id.toString(), `${LibraryType.PRES_REQUIREMENT_TYPE}|${LibraryType.PRES_REQUIREMENT_DEFINITION}|${requirementType.title.replace(/\s/g, '')}|${itm.title}`)
+                                        onClick: (): void => handleTreeviewClick(LibraryType.PRES_REQUIREMENT_DEFINITION, itm.id.toString(), `${LibraryType.PRES_REQUIREMENT_TYPE}|${requirementType.code}|withoutInput|${itm.title}`)
                                     };
                                 });
                             const nodes: TreeViewNode[] = [];

--- a/src/modules/PlantConfig/views/Library/LibraryTreeview/LibraryTreeview.tsx
+++ b/src/modules/PlantConfig/views/Library/LibraryTreeview/LibraryTreeview.tsx
@@ -4,9 +4,9 @@ import TreeView, { TreeViewNode } from '../../../../../components/TreeView';
 import { usePlantConfigContext } from '../../../context/PlantConfigContext';
 import { showSnackbarNotification } from '../../../../../core/services/NotificationService';
 import { Container } from './LibraryTreeview.style';
+import { useHistory } from 'react-router-dom';
 
 type LibraryTreeviewProps = {
-    setPath: (path: string) => void;
     setSelectedLibraryType: (libraryType: string) => void;
     setSelectedLibraryItem: (libraryItem: string) => void;
 };
@@ -17,9 +17,11 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
         libraryApiClient,
         preservationApiClient
     } = usePlantConfigContext();
+    const history = useHistory();
 
     const handleTreeviewClick = (libraryType: LibraryType, libraryItem: string, path: string): void => {
-        props.setPath(path.replace(/\s/g, ''));
+        history.replace(`/Library/${path.replace(/\s/g, '')}/${libraryType.toUpperCase()}/${libraryItem}`);
+
         props.setSelectedLibraryType(libraryType);
         props.setSelectedLibraryItem(libraryItem);
     };
@@ -34,7 +36,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                             {
                                 id: mode.id,
                                 name: mode.title,
-                                onClick: (): void => handleTreeviewClick(LibraryType.MODE, mode.id.toString(), `${LibraryType.MODE}${mode.title}`)
+                                onClick: (): void => handleTreeviewClick(LibraryType.MODE, mode.id.toString(), `${LibraryType.MODE}s|${mode.title.toUpperCase()}`)
                             }));
                     }
                     return children;
@@ -57,7 +59,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                             {
                                 id: journey.id,
                                 name: journey.title,
-                                onClick: (): void => handleTreeviewClick(LibraryType.PRES_JOURNEY, journey.id.toString(), `${LibraryType.PRES_JOURNEY}|${journey.title}`),
+                                onClick: (): void => handleTreeviewClick(LibraryType.PRES_JOURNEY, journey.id.toString(), `${LibraryType.PRES_JOURNEY}s|${journey.title.toUpperCase()}`),
                             }));
                     }
                     return children;
@@ -79,7 +81,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                     {
                         id: `rt_${requirementType.id}`,
                         name: requirementType.title,
-                        onClick: (): void => handleTreeviewClick(LibraryType.PRES_REQUIREMENT_TYPE, requirementType.id.toString(), `${LibraryType.PRES_REQUIREMENT_TYPE}|${requirementType.code}`),
+                        onClick: (): void => handleTreeviewClick(LibraryType.PRES_REQUIREMENT_TYPE, requirementType.id.toString(), `${LibraryType.PRES_REQUIREMENT_TYPE}s|${requirementType.code.toUpperCase()}`),
                         getChildren: (): Promise<TreeViewNode[]> => {
                             const withInputNodes = requirementType.requirementDefinitions
                                 .filter((itm) => itm.needsUserInput)
@@ -87,7 +89,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                                     return {
                                         id: `field_withinput_${itm.id}`,
                                         name: itm.title,
-                                        onClick: (): void => handleTreeviewClick(LibraryType.PRES_REQUIREMENT_DEFINITION, itm.id.toString(), `${LibraryType.PRES_REQUIREMENT_TYPE}|${requirementType.code}|withInput|${itm.title}`)
+                                        onClick: (): void => handleTreeviewClick(LibraryType.PRES_REQUIREMENT_DEFINITION, itm.id.toString(), `${LibraryType.PRES_REQUIREMENT_TYPE}s|${requirementType.code}|withInput|${itm.title.toUpperCase()}`)
                                     };
                                 });
                             const withoutInput = requirementType.requirementDefinitions
@@ -96,7 +98,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                                     return {
                                         id: `field_withoutinput_${itm.id}`,
                                         name: itm.title,
-                                        onClick: (): void => handleTreeviewClick(LibraryType.PRES_REQUIREMENT_DEFINITION, itm.id.toString(), `${LibraryType.PRES_REQUIREMENT_TYPE}|${requirementType.code}|withoutInput|${itm.title}`)
+                                        onClick: (): void => handleTreeviewClick(LibraryType.PRES_REQUIREMENT_DEFINITION, itm.id.toString(), `${LibraryType.PRES_REQUIREMENT_TYPE}s|${requirementType.code}|withoutInput|${itm.title.toUpperCase()}`)
                                     };
                                 });
                             const nodes: TreeViewNode[] = [];
@@ -138,7 +140,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                 children.push({
                     id: `tf_register_${registerCode}_${tf.code}`,
                     name: `${tf.code}, ${tf.description}`,
-                    onClick: (): void => handleTreeviewClick(LibraryType.TAG_FUNCTION, `${registerCode}|${tf.code}`, `${LibraryType.TAG_FUNCTION}|${registerCode}|${tf.code}`)
+                    onClick: (): void => handleTreeviewClick(LibraryType.TAG_FUNCTION, `${registerCode}|${tf.code}`, `${LibraryType.TAG_FUNCTION}s|${registerCode.toUpperCase()}|${tf.code.toUpperCase()}`)
                 });
             });
         } catch (error) {
@@ -185,7 +187,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
         {
             id: LibraryType.PRES_JOURNEY,
             name: 'Preservation Journeys',
-            onClick: (): void => { handleTreeviewClick(LibraryType.PRES_JOURNEY, '', LibraryType.PRES_JOURNEY); },
+            onClick: (): void => { handleTreeviewClick(LibraryType.PRES_JOURNEY, '', LibraryType.PRES_JOURNEY.toUpperCase() + 'S'); },
             getChildren: getPresJourneyTreeNodes
         },
         {

--- a/src/modules/PlantConfig/views/Library/LibraryTreeview/LibraryTreeview.tsx
+++ b/src/modules/PlantConfig/views/Library/LibraryTreeview/LibraryTreeview.tsx
@@ -175,13 +175,11 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
         {
             id: LibraryType.TAG_FUNCTION,
             name: 'Tag Functions',
-            onClick: (): void => { handleTreeviewClick(LibraryType.TAG_FUNCTION, '', LibraryType.TAG_FUNCTION); },
             getChildren: getRegisterNodes
         },
         {
             id: LibraryType.MODE,
             name: 'Modes',
-            onClick: (): void => { handleTreeviewClick(LibraryType.MODE, '', LibraryType.MODE); },
             getChildren: getModes
         },
         {
@@ -193,7 +191,6 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
         {
             id: LibraryType.PRES_REQUIREMENT_TYPE,
             name: 'Preservation requirements',
-            onClick: (): void => { handleTreeviewClick(LibraryType.PRES_REQUIREMENT_TYPE, '', LibraryType.PRES_REQUIREMENT_TYPE); },
             getChildren: getRequirementTreeNodes,
         }
     ];


### PR DESCRIPTION
Update URL based on library item clicked.

Note:
-if you have a url with parameters filled out and reload or copy/pase it on a new page, the parameters are cleared because the tree view will not open to that.
-url only updated when clicking on an item in the treeview, not just by expanding a part.