### PR TITLE
spinner when loading children

### DIFF
--- a/src/components/TreeView/index.tsx
+++ b/src/components/TreeView/index.tsx
@@ -23,7 +23,6 @@ interface NodeData extends TreeViewNode {
     parentId?: number | string;
     isExpanded?: boolean;
     children?: NodeData[];
-    isLoading?: boolean;
 }
 
 interface TreeViewProps {
@@ -35,8 +34,7 @@ const TreeView = ({
 }: TreeViewProps): JSX.Element => {
 
     const [treeData, setTreeData] = useState<NodeData[]>(rootNodes);
-    const [ , setLoading] = useState<boolean>(false);
-
+    const [loading, setLoading] = useState<number | string | null>();
 
     const collapseNode = (node: NodeData): void => {
         // set collapsed state
@@ -83,9 +81,9 @@ const TreeView = ({
         } else {
             // load children 
             if (node.getChildren) {
-                node.isLoading = true;
+                setLoading(node.id);
                 children = await node.getChildren();
-                node.isLoading = false;
+                setLoading(null);
             }
 
             // set parent relation for all children
@@ -131,21 +129,17 @@ const TreeView = ({
 
         const isExpanded = node.isExpanded === true;
 
-        const iconClicked = async (): Promise<void> => {
-            setLoading(true);
-            isExpanded ? collapseNode(node) : await expandNode(node);
-            setLoading(false);
-        };
-
         return (
             <ExpandCollapseIcon
                 isExpanded={isExpanded}
-                onClick={iconClicked}
-                spinner={node.isLoading}
+                onClick={async (): Promise<void> => {
+                    loading ? null : (isExpanded ? collapseNode(node) : await expandNode(node));
+                }}
+                spinner={loading == node.id}
             >
-                {(isExpanded && !node.isLoading) && <KeyboardArrowDownIcon />}
-                {(!isExpanded && !node.isLoading) && <KeyboardArrowRightIcon />}
-                {(node.isLoading) && <Spinner />}
+                {(isExpanded && loading != node.id) && <KeyboardArrowDownIcon />}
+                {(!isExpanded && loading != node.id) && <KeyboardArrowRightIcon />}
+                {(loading == node.id) && <Spinner />}
             </ExpandCollapseIcon>
         );
     };

--- a/src/components/TreeView/index.tsx
+++ b/src/components/TreeView/index.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
 import { TreeContainer, NodeContainer, ExpandCollapseIcon, NodeName, NodeLink } from './style';
+import Spinner from '../Spinner';
 
 /**
  * @param id Unique identifier across all nodes in the tree (number or string).
@@ -22,6 +23,7 @@ interface NodeData extends TreeViewNode {
     parentId?: number | string;
     isExpanded?: boolean;
     children?: NodeData[];
+    isLoading?: boolean;
 }
 
 interface TreeViewProps {
@@ -33,6 +35,8 @@ const TreeView = ({
 }: TreeViewProps): JSX.Element => {
 
     const [treeData, setTreeData] = useState<NodeData[]>(rootNodes);
+    const [ , setLoading] = useState<boolean>(false);
+
 
     const collapseNode = (node: NodeData): void => {
         // set collapsed state
@@ -79,7 +83,9 @@ const TreeView = ({
         } else {
             // load children 
             if (node.getChildren) {
+                node.isLoading = true;
                 children = await node.getChildren();
+                node.isLoading = false;
             }
 
             // set parent relation for all children
@@ -125,15 +131,21 @@ const TreeView = ({
 
         const isExpanded = node.isExpanded === true;
 
+        const iconClicked = async (): Promise<void> => {
+            setLoading(true);
+            isExpanded ? collapseNode(node) : await expandNode(node);
+            setLoading(false);
+        };
+
         return (
             <ExpandCollapseIcon
                 isExpanded={isExpanded}
-                onClick={async (): Promise<void> => {
-                    isExpanded ? collapseNode(node) : await expandNode(node);
-                }}
+                onClick={iconClicked}
+                spinner={node.isLoading}
             >
-                {isExpanded && <KeyboardArrowDownIcon />}
-                {!isExpanded && <KeyboardArrowRightIcon />}
+                {(isExpanded && !node.isLoading) && <KeyboardArrowDownIcon />}
+                {(!isExpanded && !node.isLoading) && <KeyboardArrowRightIcon />}
+                {(node.isLoading) && <Spinner />}
             </ExpandCollapseIcon>
         );
     };

--- a/src/components/TreeView/style.ts
+++ b/src/components/TreeView/style.ts
@@ -20,12 +20,15 @@ export const NodeContainer = styled.div<NodeContainerProps>`
 
 interface ExpandCollapseIconProps {
     isExpanded: boolean;
+    spinner?: boolean;
 }
 
 export const ExpandCollapseIcon = styled.div<ExpandCollapseIconProps>`
     cursor: pointer;
     margin-right: var(--grid-unit);
     padding: var(--grid-unit) calc(var(--grid-unit) + 2px);
+    height: 24px;
+    width: 24px;
 
     :hover {
         background: ${tokens.colors.interactive.primary__selected_highlight.rgba};
@@ -35,6 +38,12 @@ export const ExpandCollapseIcon = styled.div<ExpandCollapseIconProps>`
     ${(props): any => props.isExpanded && css`
         svg path {
             fill: ${tokens.colors.interactive.primary__resting.rgba};
+        }
+    `}
+
+    ${(props): any => props.spinner && css`
+        svg {
+            padding: 2px;
         }
     `}
 `;


### PR DESCRIPTION
Replace icon with spinner when loading children after opening a node.