### PR TITLE
changed getResponsibles from preservationAPI to libraryAPI

### DIFF
--- a/src/modules/PlantConfig/http/LibraryApiClient.ts
+++ b/src/modules/PlantConfig/http/LibraryApiClient.ts
@@ -17,6 +17,11 @@ export interface DisciplineResponse {
     description: string;
 }
 
+export interface ResponsibleResponse {
+    code: string;
+    description: string;
+}
+
 class LibraryApiError extends Error {
 
     data: ErrorResponse | null;
@@ -181,6 +186,31 @@ class LibraryApiClient extends ApiClient {
 
         try {
             const result = await this.client.get<DisciplineResponse[]>(endpoint, settings);
+            return result.data;
+        }
+        catch (error) {
+            throw getLibraryApiError(error);
+        }
+    }
+
+    /**
+    * Get responsibles
+    *
+    * @param setRequestCanceller Returns a function that can be called to cancel the request
+    */
+    async getResponsibles(setRequestCanceller?: RequestCanceler): Promise<ResponsibleResponse[]> {
+        const endpoint = '/Responsibles';
+
+        const settings: AxiosRequestConfig = {
+            params: {}
+        };
+        this.setupRequestCanceler(settings, setRequestCanceller);
+
+        try {
+            const result = await this.client.get<ResponsibleResponse[]>(
+                endpoint,
+                settings
+            );
             return result.data;
         }
         catch (error) {

--- a/src/modules/PlantConfig/views/Library/PreservationJourney/PreservationJourney.tsx
+++ b/src/modules/PlantConfig/views/Library/PreservationJourney/PreservationJourney.tsx
@@ -56,7 +56,8 @@ const PreservationJourney = (props: PreservationJourneyProps): JSX.Element => {
     const [isDirty, setIsDirty] = useState<boolean>(false);
 
     const {
-        preservationApiClient
+        preservationApiClient,
+        libraryApiClient
     } = usePlantConfigContext();
 
     const cloneJourney = (journey: Journey): Journey => {
@@ -95,10 +96,10 @@ const PreservationJourney = (props: PreservationJourneyProps): JSX.Element => {
         (async (): Promise<void> => {
             setIsLoading(true);
             try {
-                const responsibles = await preservationApiClient.getResponsibles((cancel: Canceler) => requestCancellor = cancel);
+                const responsibles = await libraryApiClient.getResponsibles((cancel: Canceler) => requestCancellor = cancel);
                 const mappedResponsibles: SelectItem[] = [];
 
-                responsibles.forEach(resp => mappedResponsibles.push({ text: resp.title, value: resp.code, selected: false }));
+                responsibles.forEach(resp => mappedResponsibles.push({ text: resp.description, value: resp.code, selected: false }));
                 setMappedResponsibles(mappedResponsibles);
             } catch (error) {
                 console.error('Get Responsibles failed: ', error.messsage, error.data);

--- a/src/modules/Preservation/http/PreservationApiClient.ts
+++ b/src/modules/Preservation/http/PreservationApiClient.ts
@@ -74,13 +74,6 @@ interface ModeResponse {
     rowVersion: string;
 }
 
-interface ResponsibleResponse {
-    id: number;
-    title: string;
-    code: string;
-    rowVersion: string;
-}
-
 interface PresJourneyResponse {
     id: number;
     title: string;
@@ -1635,32 +1628,6 @@ class PreservationApiClient extends ApiClient {
             throw getPreservationApiError(error);
         }
     }
-
-    /**
-    * Get responsibles
-    *
-    * @param setRequestCanceller Returns a function that can be called to cancel the request
-    */
-    async getResponsibles(setRequestCanceller?: RequestCanceler): Promise<ResponsibleResponse[]> {
-        const endpoint = '/Responsibles';
-
-        const settings: AxiosRequestConfig = {
-            params: {}
-        };
-        this.setupRequestCanceler(settings, setRequestCanceller);
-
-        try {
-            const result = await this.client.get<ResponsibleResponse[]>(
-                endpoint,
-                settings
-            );
-            return result.data;
-        }
-        catch (error) {
-            throw getPreservationApiError(error);
-        }
-    }
-
 
 }
 


### PR DESCRIPTION
Slik det er nå så hvis du går på Preservation Journey i Plant Config, så vil ikke responsible bli fylt ut hvis det ikke var en responsible der med samme kode som finnes i LibraryApiet (ser ut som det er ca 50/50). Hvis man lager en ny Area Tag, og velger en journey med step der det ikke er en responsible som man ser under Preservation Journey i Plant Config, så ligger enda den gamle responsible koden på den steppen.