### PR TITLE
Bug/74731   failed respons gives no error message to user

### DIFF
--- a/src/modules/PlantConfig/views/Library/PreservationJourney/PreservationJourney.tsx
+++ b/src/modules/PlantConfig/views/Library/PreservationJourney/PreservationJourney.tsx
@@ -235,6 +235,7 @@ const PreservationJourney = (props: PreservationJourneyProps): JSX.Element => {
         if(isSaved) {
             getJourney(newJourney.id);
             showSnackbarNotification('Changes for journey is saved.', 5000);
+            setIsSaved(false);
         }
     }, [isSaved]);
 

--- a/src/modules/PlantConfig/views/Library/PreservationJourney/PreservationJourney.tsx
+++ b/src/modules/PlantConfig/views/Library/PreservationJourney/PreservationJourney.tsx
@@ -148,7 +148,6 @@ const PreservationJourney = (props: PreservationJourneyProps): JSX.Element => {
             console.error('Add journey failed: ', error.messsage, error.data);
             showSnackbarNotification(error.message, 5000);
             getJourney(newJourney.id);
-            setIsSaved(false);
         }
     };
 
@@ -175,7 +174,6 @@ const PreservationJourney = (props: PreservationJourneyProps): JSX.Element => {
             console.error('Update journey failed: ', error.messsage, error.data);
             showSnackbarNotification(error.message, 5000);
             getJourney(newJourney.id);
-            setIsSaved(false);
         }
     };
 
@@ -191,7 +189,6 @@ const PreservationJourney = (props: PreservationJourneyProps): JSX.Element => {
                     console.error('Update journey failed: ', error.messsage, error.data);
                     showSnackbarNotification(error.message, 5000);
                     getJourney(newJourney.id);
-                    setIsSaved(false);
                 }
             }
         }

--- a/src/modules/Preservation/views/ScopeOverview/ScopeFilter/ScopeFilter.style.ts
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeFilter/ScopeFilter.style.ts
@@ -41,6 +41,11 @@ export const Collapse = styled.div<FilterProps>`
             fill: ${tokens.colors.interactive.primary__resting.rgba};
         }
     `}
+    ${({filterActive}): any => !filterActive && css`
+        path {
+            fill: ${tokens.colors.text.static_icons__tertiary.rgba};
+        }
+    `}
 `;
 
 export const CollapseInfo = styled.div`


### PR DESCRIPTION
User gets a notification that changes to journey has been saved even when they have not. Fix so that user gets message with error if the request is not successful