### PR TITLE
Library tree - update of children nodes and show void

### DIFF
--- a/src/components/TreeView/index.tsx
+++ b/src/components/TreeView/index.tsx
@@ -8,12 +8,14 @@ import Spinner from '../Spinner';
 /**
  * @param id Unique identifier across all nodes in the tree (number or string).
  * @param name Node display name.
+ * @param isVoided Optional: indicates that node is voided (will render different than non-voided nodes)
  * @param getChildren Optional: function to load children.
  * @param onClick Optional: function to handle click event on node.
  */
 export interface TreeViewNode {
     id: number | string;
     name: string;
+    isVoided?: boolean;
     getChildren?: () => Promise<TreeViewNode[]>;
     onClick?: () => void;
 }
@@ -47,7 +49,7 @@ const TreeView = ({
             let nodeParentId: number | string | null | undefined = treeNode.parentId;
             
             while (nodeParentId) {
-                // check whether the child exists under the parent node in question
+                // check whether the child exists under the parent node in question (and collapse)
                 if (nodeParentId === parentNodeId) {
                     treeNode.isExpanded = false;
                     childCount++;
@@ -186,11 +188,13 @@ const TreeView = ({
         return (
             <NodeName
                 hasChildren={node.getChildren ? true : false}
-                isExpanded={node.isExpanded === true}>
+                isExpanded={node.isExpanded === true}
+                isVoided={node.isVoided === true}>
                 {
                     node.onClick && (
                         <NodeLink
                             isExpanded={node.isExpanded === true}
+                            isVoided={node.isVoided === true}
                             onClick={node.onClick}
                         >
                             {node.name}

--- a/src/components/TreeView/index.tsx
+++ b/src/components/TreeView/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
@@ -27,14 +27,58 @@ interface NodeData extends TreeViewNode {
 
 interface TreeViewProps {
     rootNodes: TreeViewNode[];
+    dirtyNodeId?: number | string;
+    resetDirtyNode?: () => void;
 }
 
 const TreeView = ({
-    rootNodes
+    rootNodes,
+    dirtyNodeId,
+    resetDirtyNode
 }: TreeViewProps): JSX.Element => {
 
     const [treeData, setTreeData] = useState<NodeData[]>(rootNodes);
     const [loading, setLoading] = useState<number | string | null>();
+
+    const getNodeChildCountAndCollapse = (parentNodeId: string | number): number => {
+        let childCount = 0;
+    
+        treeData.forEach(treeNode => {
+            let nodeParentId: number | string | null | undefined = treeNode.parentId;
+            
+            while (nodeParentId) {
+                // check whether the child exists under the parent node in question
+                if (nodeParentId === parentNodeId) {
+                    treeNode.isExpanded = false;
+                    childCount++;
+                }
+    
+                // move up the tree
+                const parent = treeData.find(data => data.id === nodeParentId);
+                nodeParentId = parent ? parent.parentId : null;
+            }
+        });
+
+        return childCount;
+    };
+
+    const getNodeChildren = async (node: NodeData): Promise<NodeData[]> => {
+        let children: NodeData[] = [];
+
+        if (node.getChildren) {
+            setLoading(node.id);
+            children = await node.getChildren();
+            setLoading(null);
+        }
+
+        // set parent relation for all children
+        children.forEach(child => child.parentId = node.id);
+
+        // set child relations for the parent
+        node.children = children;
+
+        return children;
+    };
 
     const collapseNode = (node: NodeData): void => {
         // set collapsed state
@@ -43,24 +87,8 @@ const TreeView = ({
         const collapsingNodeId = node.id;
         const collapsingNodeIndex = treeData.findIndex(data => data.id === collapsingNodeId);
 
-        let childCount = 0;
-
         // get number of child nodes to remove
-        treeData.forEach(treeNode => {
-            let nodeParentId: number | string | null | undefined = treeNode.parentId;
-
-            while (nodeParentId) {
-                // check whether the child exists under node being collapsed
-                if (nodeParentId === collapsingNodeId) {
-                    treeNode.isExpanded = false;
-                    childCount++;
-                }
-
-                // move up the tree
-                const parent = treeData.find(data => data.id === nodeParentId);
-                nodeParentId = parent ? parent.parentId : null;
-            }
-        });
+        const childCount = getNodeChildCountAndCollapse(collapsingNodeId);
 
         // remove children after parent
         const newTreeData = [...treeData];
@@ -79,25 +107,35 @@ const TreeView = ({
             // use already loaded children
             children = node.children;
         } else {
-            // load children 
-            if (node.getChildren) {
-                setLoading(node.id);
-                children = await node.getChildren();
-                setLoading(null);
-            }
-
-            // set parent relation for all children
-            children.forEach(child => child.parentId = node.id);
-
-            // set child relations for the parent
-            node.children = children;
+            // load children
+            children = await getNodeChildren(node);
         }
 
         // insert children after parent
-        const parentIndex = treeData.findIndex(data => data.id === node.id);
+        const expandingNodeIndex = treeData.findIndex(data => data.id === node.id);
 
         const newTreeData = [...treeData];
-        newTreeData.splice(parentIndex + 1, 0, ...children);
+        newTreeData.splice(expandingNodeIndex + 1, 0, ...children);
+
+        setTreeData(newTreeData);
+    };
+
+    const refreshNode = async (node: NodeData): Promise<void> => {
+        const refreshingNodeId = node.id;
+        const refreshingNodeIndex = treeData.findIndex(data => data.id === refreshingNodeId);
+    
+        // get number of child nodes to remove
+        const childCount = getNodeChildCountAndCollapse(refreshingNodeId);
+  
+        // remove children after parent
+        const newTreeData = [...treeData];
+        newTreeData.splice(refreshingNodeIndex + 1, childCount);
+    
+        // get new children
+        const newChildren = await getNodeChildren(node);
+
+        // insert new children after parent
+        newTreeData.splice(refreshingNodeIndex + 1, 0, ...newChildren);
 
         setTreeData(newTreeData);
     };
@@ -176,6 +214,17 @@ const TreeView = ({
             </NodeContainer>
         );
     };
+
+    useEffect(() => {
+        if (dirtyNodeId && dirtyNodeId !== '') {
+            const dirtyNode = treeData.find(node => node.id === dirtyNodeId);
+
+            if (dirtyNode && dirtyNode.children && dirtyNode.children.length > 0) {
+                refreshNode(dirtyNode);
+                resetDirtyNode && resetDirtyNode();
+            }            
+        }        
+    }, [dirtyNodeId]);
 
     return (
         <TreeContainer>

--- a/src/components/TreeView/style.ts
+++ b/src/components/TreeView/style.ts
@@ -51,6 +51,7 @@ export const ExpandCollapseIcon = styled.div<ExpandCollapseIconProps>`
 interface NodeNameProps {
     hasChildren: boolean;
     isExpanded: boolean;
+    isVoided: boolean;
 }
 
 export const NodeName = styled.div<NodeNameProps>`
@@ -61,12 +62,17 @@ export const NodeName = styled.div<NodeNameProps>`
         color: ${tokens.colors.interactive.primary__resting.rgba};
     `}
 
+    ${(props): any => props.isVoided && css`
+        color: ${tokens.colors.interactive.danger__resting.rgba};
+    `}
+
     /* add margin to nodes without children, to align with those that do (with expand/collapse icon) */
     margin-left: ${(props): string => !props.hasChildren ? 'calc(var(--grid-unit) * 6.5)' : '0'};
 `;
 
 interface NodeLinkProps {
     isExpanded: boolean;
+    isVoided: boolean;
 }
 
 export const NodeLink = styled.span<NodeLinkProps>`
@@ -76,7 +82,11 @@ export const NodeLink = styled.span<NodeLinkProps>`
         color: ${tokens.colors.interactive.primary__resting.rgba};
     `}
 
+    ${(props): any => props.isVoided && css`
+        color: ${tokens.colors.interactive.danger__resting.rgba};
+    `}
+
     :hover {
-        color: ${tokens.colors.interactive.primary__resting.rgba};
+        color: ${(props): string => !props.isVoided ? tokens.colors.interactive.primary__resting.rgba : ''}
     }
 `;

--- a/src/modules/PlantConfig/views/Library/Library.tsx
+++ b/src/modules/PlantConfig/views/Library/Library.tsx
@@ -20,6 +20,7 @@ const Library = (): JSX.Element => {
 
     const [selectedLibraryType, setSelectedLibraryType] = useState('');
     const [selectedLibraryItem, setSelectedLibraryItem] = useState('');
+    const [dirtyLibraryType, setDirtyLibraryType] = useState('');
 
     const match = useRouteMatch();
     const params: any = match.params;
@@ -30,11 +31,20 @@ const Library = (): JSX.Element => {
 
     return (
         <Container>
-            <LibraryTreeview setSelectedLibraryType={setSelectedLibraryType} setSelectedLibraryItem={setSelectedLibraryItem} />
+            <LibraryTreeview 
+                setSelectedLibraryType={setSelectedLibraryType} 
+                setSelectedLibraryItem={setSelectedLibraryItem} 
+                dirtyLibraryType={dirtyLibraryType} 
+                resetDirtyLibraryType={(): void => setDirtyLibraryType('')}
+            />
 
             <Divider />
 
-            <LibraryItemDetails libraryType={selectedLibraryType} libraryItem={selectedLibraryItem} />
+            <LibraryItemDetails 
+                libraryType={selectedLibraryType} 
+                libraryItem={selectedLibraryItem} 
+                setDirtyLibraryType={setDirtyLibraryType}
+            />
 
         </Container>
     );

--- a/src/modules/PlantConfig/views/Library/LibraryItemDetails.tsx
+++ b/src/modules/PlantConfig/views/Library/LibraryItemDetails.tsx
@@ -6,9 +6,12 @@ import PreservationJourney from './PreservationJourney/PreservationJourney';
 type LibraryItemProps = {
     libraryType: string;
     libraryItem: string;
+    setDirtyLibraryType: (libraryType: string) => void;
 };
 
 const LibraryItemDetails = (props: LibraryItemProps): JSX.Element => {
+
+    // TODO: add "setDirtyLibrary type" to all types and events within them.
 
     switch (props.libraryType) {
         case LibraryType.TAG_FUNCTION: {
@@ -18,7 +21,10 @@ const LibraryItemDetails = (props: LibraryItemProps): JSX.Element => {
         case LibraryType.MODE:
             return <div>Mode id={props.libraryItem}</div>;
         case LibraryType.PRES_JOURNEY:
-            return <PreservationJourney journeyId={Number(props.libraryItem)} />;
+            return <PreservationJourney 
+                journeyId={Number(props.libraryItem)} 
+                setDirtyLibraryType={(): void => props.setDirtyLibraryType(LibraryType.PRES_JOURNEY)} 
+            />;
         case LibraryType.PRES_REQUIREMENT_TYPE:
             return <div>req type</div>;
         case LibraryType.PRES_REQUIREMENT_DEFINITION:

--- a/src/modules/PlantConfig/views/Library/LibraryItemDetails.tsx
+++ b/src/modules/PlantConfig/views/Library/LibraryItemDetails.tsx
@@ -11,8 +11,6 @@ type LibraryItemProps = {
 
 const LibraryItemDetails = (props: LibraryItemProps): JSX.Element => {
 
-    // TODO: add "setDirtyLibrary type" to all types and events within them.
-
     switch (props.libraryType) {
         case LibraryType.TAG_FUNCTION: {
             const [registerCode, tagFunctionCode] = props.libraryItem.split('|');

--- a/src/modules/PlantConfig/views/Library/LibraryTreeview/LibraryTreeview.tsx
+++ b/src/modules/PlantConfig/views/Library/LibraryTreeview/LibraryTreeview.tsx
@@ -34,6 +34,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                             {
                                 id: mode.id,
                                 name: mode.title,
+                                // TODO: isVoided (need data from API)
                                 onClick: (): void => handleTreeviewClick(LibraryType.MODE, mode.id.toString())
                             }));
                     }
@@ -57,6 +58,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                             {
                                 id: journey.id,
                                 name: journey.title,
+                                isVoided: journey.isVoided,
                                 onClick: (): void => handleTreeviewClick(LibraryType.PRES_JOURNEY, journey.id.toString()),
                             }));
                     }
@@ -79,6 +81,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                     {
                         id: `rt_${requirementType.id}`,
                         name: requirementType.title,
+                        isVoided: requirementType.isVoided,
                         onClick: (): void => handleTreeviewClick(LibraryType.PRES_REQUIREMENT_TYPE, requirementType.id.toString()),
                         getChildren: (): Promise<TreeViewNode[]> => {
                             const withInputNodes = requirementType.requirementDefinitions
@@ -87,6 +90,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                                     return {
                                         id: `field_withinput_${itm.id}`,
                                         name: itm.title,
+                                        isVoided: itm.isVoided,
                                         onClick: (): void => handleTreeviewClick(LibraryType.PRES_REQUIREMENT_DEFINITION, itm.id.toString())
                                     };
                                 });
@@ -96,6 +100,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                                     return {
                                         id: `field_withoutinput_${itm.id}`,
                                         name: itm.title,
+                                        isVoided: itm.isVoided,
                                         onClick: (): void => handleTreeviewClick(LibraryType.PRES_REQUIREMENT_DEFINITION, itm.id.toString())
                                     };
                                 });
@@ -138,6 +143,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                 children.push({
                     id: `tf_register_${registerCode}_${tf.code}`,
                     name: `${tf.code}, ${tf.description}`,
+                    // TODO: isVoided (need data from API)
                     onClick: (): void => handleTreeviewClick(LibraryType.TAG_FUNCTION, `${registerCode}|${tf.code}`)
                 });
             });
@@ -158,6 +164,7 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
                 children.push({
                     id: `tf_register_${reg.code}`,
                     name: reg.description,
+                    // TODO: isVoided (need data from API)
                     getChildren: () => getTagFunctionNodes(reg.code)
                 });
             });

--- a/src/modules/PlantConfig/views/Library/LibraryTreeview/LibraryTreeview.tsx
+++ b/src/modules/PlantConfig/views/Library/LibraryTreeview/LibraryTreeview.tsx
@@ -8,6 +8,8 @@ import { Container } from './LibraryTreeview.style';
 type LibraryTreeviewProps = {
     setSelectedLibraryType: (libraryType: string) => void;
     setSelectedLibraryItem: (libraryItem: string) => void;
+    dirtyLibraryType: string;
+    resetDirtyLibraryType: () => void;
 };
 
 const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
@@ -16,7 +18,6 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
         libraryApiClient,
         preservationApiClient
     } = usePlantConfigContext();
-
 
     const handleTreeviewClick = (libraryType: LibraryType, libraryItem: string): void => {
         props.setSelectedLibraryType(libraryType);
@@ -169,7 +170,6 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
         return children;
     };
 
-
     const rootNodes: TreeViewNode[] = [
         {
             id: LibraryType.TAG_FUNCTION,
@@ -195,9 +195,12 @@ const LibraryTreeview = (props: LibraryTreeviewProps): JSX.Element => {
     ];
 
     return (
-
         <Container>
-            <TreeView rootNodes={rootNodes}></TreeView>
+            <TreeView 
+                rootNodes={rootNodes} 
+                dirtyNodeId={props.dirtyLibraryType} 
+                resetDirtyNode={props.resetDirtyLibraryType} 
+            />
         </Container>
     );
 };

--- a/src/modules/PlantConfig/views/Library/PreservationJourney/PreservationJourney.tsx
+++ b/src/modules/PlantConfig/views/Library/PreservationJourney/PreservationJourney.tsx
@@ -39,6 +39,7 @@ interface Step {
 
 type PreservationJourneyProps = {
     journeyId: number;
+    setDirtyLibraryType: () => void;
 };
 
 const PreservationJourney = (props: PreservationJourneyProps): JSX.Element => {
@@ -156,7 +157,11 @@ const PreservationJourney = (props: PreservationJourneyProps): JSX.Element => {
             for await (const step of newJourney.steps) {
                 await saveNewStep(journeyId, step);
             }
+
             getJourney(journeyId);
+            
+            props.setDirtyLibraryType();
+            
             showSnackbarNotification('New journey is saved.', 5000);
         } catch (error) {
             console.error('Add journey failed: ', error.messsage, error.data);
@@ -167,6 +172,7 @@ const PreservationJourney = (props: PreservationJourneyProps): JSX.Element => {
     const updateJourney = async (): Promise<void> => {
         try {
             await preservationApiClient.updateJourney(newJourney.id, newJourney.title, newJourney.rowVersion);
+            props.setDirtyLibraryType();
         } catch (error) {
             console.error('Update journey failed: ', error.messsage, error.data);
             showSnackbarNotification(error.message, 5000);
@@ -219,7 +225,7 @@ const PreservationJourney = (props: PreservationJourneyProps): JSX.Element => {
         }
 
         if (isSaved) {
-            getJourney(newJourney.id);
+            getJourney(newJourney.id);            
             showSnackbarNotification('Changes for journey is saved.', 5000);
         } else {
             showSnackbarNotification('No changes need to be saved.', 5000);

--- a/src/modules/PlantConfig/views/Library/PreservationJourney/PreservationJourney.tsx
+++ b/src/modules/PlantConfig/views/Library/PreservationJourney/PreservationJourney.tsx
@@ -255,6 +255,7 @@ const PreservationJourney = (props: PreservationJourneyProps): JSX.Element => {
             try {
                 await preservationApiClient.voidJourney(journey.id, journey.rowVersion);
                 getJourney(journey.id);
+                props.setDirtyLibraryType();
                 showSnackbarNotification('Journey is voided.', 5000);
             } catch (error) {
                 console.error('Error occured when trying to void journey: ', error.messsage, error.data);
@@ -270,6 +271,7 @@ const PreservationJourney = (props: PreservationJourneyProps): JSX.Element => {
             try {
                 await preservationApiClient.unvoidJourney(journey.id, journey.rowVersion);
                 getJourney(journey.id);
+                props.setDirtyLibraryType();
                 showSnackbarNotification('Journey is unvoided.', 5000);
             } catch (error) {
                 console.error('Error occured when trying to unvoid journey: ', error.messsage, error.data);


### PR DESCRIPTION
Set library type "dirty" when creating/renaming/voiding/unvoiding, which triggers the relevant tree node to be refreshed. Currently only implemented for Preservation Journeys (the only one having edit view). 

Voided nodes are now rendered with red text color (can easily be redesigned later). We are missing voided data from some of the library api endpoints, so these will have to be added later.