### PR TITLE
73429 - UI - performance issues

### DIFF
--- a/src/http/HttpClient.ts
+++ b/src/http/HttpClient.ts
@@ -23,19 +23,10 @@ export default class HttpClient {
      * @param customSettings Any custom <AxiosRequestConfig> for the client
      */
     constructor(baseUrl = '', customSettings: AxiosRequestConfig = {}) {
-        const instance =  axios.create({
+        const instance = axios.create({
             ...axiosSettings,
             baseURL: baseUrl,
             ...customSettings
-        });
-
-        instance.interceptors.response.use((successResponse) => {
-            return successResponse;
-        }, (error) => {
-            if (axios.isCancel(error)) {
-                return Promise.reject('Cancelled');
-            }
-            return Promise.reject(error);
         });
 
         this.client = instance;

--- a/src/modules/Preservation/views/ScopeOverview/ScopeFilter/ScopeFilter.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeFilter/ScopeFilter.tsx
@@ -141,7 +141,7 @@ const ScopeFilter = ({
                 const journeys = await apiClient.getJourneyFilters(project.name, (cancel: Canceler) => requestCancellor = cancel);
                 setJourneys(journeys);
             } catch (error) {
-                showSnackbarNotification(error.message, 5000);
+                !error.isCancel && showSnackbarNotification(error.message, 5000);
             }})();
         return (): void => requestCancellor && requestCancellor();
     },[]);
@@ -154,7 +154,7 @@ const ScopeFilter = ({
                 const response = await apiClient.getResponsiblesFilterForProject(project.name,(cancel: Canceler) => requestCancellor = cancel);
                 setResponsibles(response.map(resp => {return {id: resp.id, title: resp.code};}));
             } catch (error) {
-                showSnackbarNotification(error.message, 5000);
+                !error.isCancel && showSnackbarNotification(error.message, 5000);
             }})();
         return (): void => requestCancellor && requestCancellor();
     },[]);
@@ -167,7 +167,7 @@ const ScopeFilter = ({
                 const response = await apiClient.getAreaFilterForProject(project.name,(cancel: Canceler) => requestCancellor = cancel);
                 setAreas(response.map(resp => {return {id: resp.code, title: resp.code};}));
             } catch (error) {
-                showSnackbarNotification(error.message, 5000);
+                !error.isCancel && showSnackbarNotification(error.message, 5000);
             }})();
         return (): void => requestCancellor && requestCancellor();
     },[]);
@@ -180,7 +180,7 @@ const ScopeFilter = ({
                 const modes = await apiClient.getModeFilters(project.name, (cancel: Canceler) => requestCancellor = cancel);
                 setModes(modes);
             } catch (error) {
-                showSnackbarNotification(error.message, 5000);
+                !error.isCancel && showSnackbarNotification(error.message, 5000);
             }})();
         return (): void => requestCancellor && requestCancellor();
     },[]);
@@ -193,7 +193,7 @@ const ScopeFilter = ({
                 const requirements = await apiClient.getRequirementTypeFilters(project.name, (cancel: Canceler) => requestCancellor = cancel);
                 setRequirements(requirements);
             } catch (error) {
-                showSnackbarNotification(error.message, 5000);
+                !error.isCancel && showSnackbarNotification(error.message, 5000);
             }})();
         return (): void => requestCancellor && requestCancellor();
     },[]);
@@ -210,7 +210,7 @@ const ScopeFilter = ({
                 });
                 setTagFunctions(tagFunctions);
             } catch (error) {
-                showSnackbarNotification(error.message, 5000);
+                !error.isCancel && showSnackbarNotification(error.message, 5000);
             }})();
         return (): void => requestCancellor && requestCancellor();
     },[]);
@@ -226,7 +226,7 @@ const ScopeFilter = ({
                 });
                 setDisciplines(disciplines);
             } catch (error) {
-                showSnackbarNotification(error.message, 5000);
+                !error.isCancel && showSnackbarNotification(error.message, 5000);
             }
         })();
 

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
@@ -75,6 +75,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
     const [voidedTagsSelected, setVoidedTagsSelected] = useState<boolean>();
     const [unvoidedTagsSelected, setUnvoidedTagsSelected] = useState<boolean>();
     const [selectedTagId, setSelectedTagId] = useState<string | number>();
+    const [filterWasActivated, setFilterWasActivated] = useState<boolean>(false);
 
     const {
         project,
@@ -93,6 +94,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
 
     useEffect(
         () => {
+            setFilterWasActivated(true);
             refreshScopeList();
         }, [tagListFilter]
     );
@@ -519,6 +521,8 @@ const ScopeOverview: React.FC = (): JSX.Element => {
                     setRefreshScopeListCallback={setRefreshScopeListCallback}
                     pageSize={pageSize}
                     setPageSize={setPageSize}
+                    shouldSelectFirstPage={filterWasActivated}
+                    setFirstPageSelected={(): void => setFilterWasActivated(false)}
                 />
                 {
                     displayFlyout && (

--- a/src/modules/Preservation/views/ScopeOverview/ScopeTable.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeTable.tsx
@@ -17,6 +17,8 @@ interface ScopeTableProps {
     setRefreshScopeListCallback: (callback: () => void) => void;
     pageSize: number;
     setPageSize: (pageSize: number) => void;
+    shouldSelectFirstPage: boolean;
+    setFirstPageSelected: () => void;
 }
 
 class ScopeTable extends React.Component<ScopeTableProps, {}> {
@@ -102,6 +104,12 @@ class ScopeTable extends React.Component<ScopeTableProps, {}> {
             'Disc': 'Discipline',
             'Mode': 'Mode'
         };
+
+        if (this.props.shouldSelectFirstPage) {
+            // set query to first page = 0
+            query.page = 0;
+            this.props.setFirstPageSelected();
+        }
 
         const orderByField: string | null = query.orderBy ? sortFieldMap[query.orderBy.title as string] : null;
         const orderDirection: string | null = orderByField ? query.orderDirection ? query.orderDirection : 'Asc' : null;


### PR DESCRIPTION
- Detect cancelled requests in Preservation API exception handling. Added "isCancel" property to the exception object, which can be handled wherever needed. This is currently checked in ScopeFilter to avoid showing snackbar notification for cancelled requests (happens when you close the filter before all filter-type requests are done).

- Filter + paging: Fixed a bug causing the page to crash when the scope list was at page number larger than the filtered tag list could fill up. The first page is now always selected when a filter is activated.