### PR TITLE
74929: moved icons from top bar to dropdown

### DIFF
--- a/src/components/EdsIcon/index.tsx
+++ b/src/components/EdsIcon/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Icon } from '@equinor/eds-core-react';
 // eslint-disable-next-line @typescript-eslint/camelcase
-import { error_filled, close, checkbox, checkbox_outline, done_all, add_circle_filled, attach_file, notifications, chevron_down, chevron_up, edit, delete_to_trash, calendar_today, person, alarm_on, world, place, pressure, verticle_split, category, search, bookmark_collection, add, arrow_down, arrow_up, filter_list, more_verticle, warning_filled, delete_forever, restore_from_trash, edit_text, account_circle, lock, info_circle } from '@equinor/eds-icons';
+import { error_filled, close, checkbox, checkbox_outline, done_all, add_circle_filled, attach_file, notifications, chevron_down, chevron_up, edit, delete_to_trash, calendar_today, person, alarm_on, world, place, pressure, verticle_split, category, search, bookmark_collection, add, arrow_down, arrow_up, filter_list, more_verticle, warning_filled, delete_forever, restore_from_trash, edit_text, account_circle, lock, info_circle, print, fast_forward, play } from '@equinor/eds-icons';
 
 // eslint-disable-next-line @typescript-eslint/camelcase
-const icons = { error_filled, close, checkbox, checkbox_outline, done_all, add_circle_filled, attach_file, notifications, chevron_down, chevron_up, edit, delete_to_trash, calendar_today, person, alarm_on, world, place, pressure, verticle_split, category, search, bookmark_collection, add, arrow_down, arrow_up, filter_list, more_verticle, warning_filled, delete_forever, restore_from_trash, edit_text, account_circle, lock, info_circle };
+const icons = { error_filled, close, checkbox, checkbox_outline, done_all, add_circle_filled, attach_file, notifications, chevron_down, chevron_up, edit, delete_to_trash, calendar_today, person, alarm_on, world, place, pressure, verticle_split, category, search, bookmark_collection, add, arrow_down, arrow_up, filter_list, more_verticle, warning_filled, delete_forever, restore_from_trash, edit_text, account_circle, lock, info_circle, print, fast_forward, play };
 
 Icon.add(icons);
 

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
@@ -1,11 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Link, useHistory, useLocation } from 'react-router-dom';
 import { Button } from '@equinor/eds-core-react';
-import FastForwardOutlinedIcon from '@material-ui/icons/FastForwardOutlined';
-import CreateOutlinedIcon from '@material-ui/icons/CreateOutlined';
-import DeleteOutlinedIcon from '@material-ui/icons/DeleteOutlined';
-import PlayArrowOutlinedIcon from '@material-ui/icons/PlayArrowOutlined';
-import PrintOutlinedIcon from '@material-ui/icons/PrintOutlined';
 import { showSnackbarNotification } from '../../../../core/services/NotificationService';
 import { usePreservationContext } from '../../context/PreservationContext';
 import { Container, DropdownItem, Header, HeaderContainer, IconBar, StyledButton, FilterDivider, ContentContainer, FilterContainer, TooltipText } from './ScopeOverview.style';
@@ -498,7 +493,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
                             title='Start preservation for selected tag(s)'
                             onClick={startPreservationDialog}
                             disabled={selectedTags.length < 1}>
-                            <PlayArrowOutlinedIcon className='iconNextToText' fontSize='small' />
+                            <div className='iconNextToText' ><EdsIcon name='play' color={selectedTags.length < 1 ? tokens.colors.interactive.disabled__border.rgba : ''} /></div>
                         Start
                         </StyledButton>
                         <StyledButton
@@ -506,7 +501,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
                             title="Transfer selected tag(s)"
                             onClick={transferDialog}
                             disabled={selectedTags.length < 1}>
-                            <FastForwardOutlinedIcon className='iconNextToText' fontSize='small' />
+                            <div className='iconNextToText' ><EdsIcon name='fast_forward' color={selectedTags.length < 1 ? tokens.colors.interactive.disabled__border.rgba : ''} /></div>
                         Transfer
                         </StyledButton>
                         <StyledButton
@@ -529,6 +524,13 @@ const ScopeOverview: React.FC = (): JSX.Element => {
                                 Edit
                             </DropdownItem>
                             <DropdownItem
+                                disabled={true}
+                                //onClick={}
+                            >
+                                <EdsIcon name='delete_forever' color={tokens.colors.interactive.disabled__border.rgba} />
+                                Remove
+                            </DropdownItem>
+                            <DropdownItem
                                 disabled={!unvoidedTagsSelected}
                                 onClick={(): void => showVoidDialog(true)}>
                                 <EdsIcon name='delete_forever' color={!unvoidedTagsSelected ? tokens.colors.interactive.disabled__border.rgba : tokens.colors.text.static_icons__tertiary.rgba} />
@@ -540,22 +542,14 @@ const ScopeOverview: React.FC = (): JSX.Element => {
                                 <EdsIcon name='restore_from_trash' color={!voidedTagsSelected ? tokens.colors.interactive.disabled__border.rgba : tokens.colors.text.static_icons__tertiary.rgba} />
                                 Unvoid
                             </DropdownItem>
+                            <DropdownItem
+                                disabled={true}
+                                //onClick={}
+                            >
+                                <EdsIcon name='print' color={tokens.colors.interactive.disabled__border.rgba} />
+                                Print
+                            </DropdownItem>
                         </OptionsDropdown>
-                        <StyledButton
-                            variant='ghost'
-                            disabled={true}>
-                            <CreateOutlinedIcon fontSize='small' />
-                        </StyledButton>
-                        <StyledButton
-                            variant='ghost'
-                            disabled={true}>
-                            <DeleteOutlinedIcon fontSize='small' />
-                        </StyledButton>
-                        <StyledButton
-                            variant='ghost'
-                            disabled={true}>
-                            <PrintOutlinedIcon fontSize='small' />
-                        </StyledButton>
                         <Tooltip title={<TooltipText><p>{numberOfFilters} active filter(s)</p><p>Filter result {numberOfTags} items</p></TooltipText>} disableHoverListener={numberOfFilters < 1} arrow={true} style={{ textAlign: 'center' }}>
                             <div>
                                 <StyledButton

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
@@ -525,9 +525,8 @@ const ScopeOverview: React.FC = (): JSX.Element => {
                             </DropdownItem>
                             <DropdownItem
                                 disabled={true}
-                                //onClick={}
                             >
-                                <EdsIcon name='delete_forever' color={tokens.colors.interactive.disabled__border.rgba} />
+                                <EdsIcon name='delete_to_trash' color={tokens.colors.interactive.disabled__border.rgba} />
                                 Remove
                             </DropdownItem>
                             <DropdownItem
@@ -544,7 +543,6 @@ const ScopeOverview: React.FC = (): JSX.Element => {
                             </DropdownItem>
                             <DropdownItem
                                 disabled={true}
-                                //onClick={}
                             >
                                 <EdsIcon name='print' color={tokens.colors.interactive.disabled__border.rgba} />
                                 Print


### PR DESCRIPTION
Moved icons in top bar to 'More options' dropdown.
Use EDS icons for start and transfer.