### PR TITLE
75112 - Add project to url

### DIFF
--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
@@ -48,6 +48,7 @@ const defaultTagListFilter: TagListFilter = {
     storageAreaStartsWith: null,
     preservationStatus: null,
     actionStatus: null,
+    voidedFilter: null,
     journeyIds: [],
     modeIds: [],
     dueFilters: [],


### PR DESCRIPTION
Ended up adding project to querystring, instead of route. Project in route was not being preserved (pun intended) when navigating to other views and could be confusing. 

Querystring is cleared after inital render, also to limit confusion, e.g. after changing project or choosing other filters.

Fixed issue with duplicate table queries being fired at initial render.

Fixed crash when changing project after table paging.