### PR TITLE
75131: Use includeAllUsages=true when getting requirements for editing tag

### DIFF
--- a/src/modules/Preservation/http/PreservationApiClient.ts
+++ b/src/modules/Preservation/http/PreservationApiClient.ts
@@ -1399,11 +1399,12 @@ class PreservationApiClient extends ApiClient {
         }
     }
 
-    async getTagRequirements(tagId: number, includeVoided = false, setRequestCanceller?: RequestCanceler): Promise<TagRequirementsResponse[]> {
+    async getTagRequirements(tagId: number, includeVoided = false, includeAllUsages = false, setRequestCanceller?: RequestCanceler): Promise<TagRequirementsResponse[]> {
         const endpoint = `/Tags/${tagId}/Requirements`;
         const settings: AxiosRequestConfig = {
             params: {
                 IncludeVoided: includeVoided,
+                IncludeAllUsages: includeAllUsages
             },
         };
         this.setupRequestCanceler(settings, setRequestCanceller);

--- a/src/modules/Preservation/views/EditTagProperties/EditTagProperties.tsx
+++ b/src/modules/Preservation/views/EditTagProperties/EditTagProperties.tsx
@@ -87,7 +87,7 @@ const EditTagProperties = (): JSX.Element => {
         (async (): Promise<void> => {
             if (tagId) {
                 try {
-                    const response = await apiClient.getTagRequirements(Number.parseInt(tagId), true, (cancel: Canceler) => requestCancellor = cancel);
+                    const response = await apiClient.getTagRequirements(Number.parseInt(tagId), true, true, (cancel: Canceler) => requestCancellor = cancel);
                     const mappedResponse = response.map(itm => {
                         return {
                             requirementDefinitionId: -1,


### PR DESCRIPTION
Always show supplier requirements when on "Edit tag" page. Use includeAllUsages flag in endpoint where default is false.