### PR TITLE
Wider scrollbar.

### DIFF
--- a/src/assets/sass/global.scss
+++ b/src/assets/sass/global.scss
@@ -24,7 +24,7 @@ body {
 
 /* width */
 ::-webkit-scrollbar {
-    width: 3px;
+    width: var(--grid-unit);
 }
 
 /* Track */

--- a/src/components/Dropdown/style.ts
+++ b/src/components/Dropdown/style.ts
@@ -12,7 +12,7 @@ export const Container = styled.div`
         background-color: ${tokens.colors.ui.background__default.rgba};
         border-radius: 4px;
         box-shadow: ${tokens.elevation.raised};
-        overflow-y: scroll;
+        overflow-y: auto;
         z-index: 100;
         white-space: nowrap;
     }

--- a/src/components/OptionsDropdown/style.ts
+++ b/src/components/OptionsDropdown/style.ts
@@ -8,13 +8,12 @@ export const Container = styled.div`
     ul {
         position: absolute;
         margin-top: 0.5rem;
-        margin-left: var(--grid-unit);
         max-height: 300px;
         background-color: ${tokens.colors.ui.background__default.rgba};
         border-radius: 4px;
         box-shadow: ${tokens.elevation.raised};
-        overflow-y: scroll;
         z-index: 100;
+        white-space: nowrap;
     }
     :hover {
         cursor: pointer;

--- a/src/components/Select/style.ts
+++ b/src/components/Select/style.ts
@@ -11,7 +11,7 @@ export const Container = styled.div`
         border-radius: 4px;
         z-index: 100;
         white-space: nowrap;
-        overflow-y :hidden;
+        
         li div {
             box-shadow: 0px 3px 4px rgba(0,0,0,0.12), 0px 2px 4px rgba(0,0,0,0.14);
         }

--- a/src/components/Select/style.ts
+++ b/src/components/Select/style.ts
@@ -11,7 +11,7 @@ export const Container = styled.div`
         border-radius: 4px;
         z-index: 100;
         white-space: nowrap;
-
+        overflow-y :hidden;
         li div {
             box-shadow: 0px 3px 4px rgba(0,0,0,0.12), 0px 2px 4px rgba(0,0,0,0.14);
         }

--- a/src/modules/Preservation/views/AddScope/SelectTags/SelectTags.tsx
+++ b/src/modules/Preservation/views/AddScope/SelectTags/SelectTags.tsx
@@ -138,6 +138,7 @@ const SelectTags = (props: SelectTagsProps): JSX.Element => {
                     search: false,
                     draggable: false,
                     pageSize: 10,
+                    emptyRowsWhenPaging: false,
                     pageSizeOptions: [10, 50, 100],
                     padding: 'dense',
                     headerStyle: {

--- a/src/modules/Preservation/views/ScopeOverview/DialogTable.style.ts
+++ b/src/modules/Preservation/views/ScopeOverview/DialogTable.style.ts
@@ -4,3 +4,9 @@ export const Toolbar = styled.div`
     margin-top: calc(var(--grid-unit) * 2);
     margin-bottom: var(--grid-unit);
 `;
+
+export const Container = styled.div`
+    div > div > div > div[style] {
+        overflow-y: hidden !important; /* This is to remove the scrollbar in table that makes it seem like the page is lagging when user is scrolling  */
+    }
+`;

--- a/src/modules/Preservation/views/ScopeOverview/DialogTable.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/DialogTable.tsx
@@ -3,7 +3,7 @@ import { PreservedTag } from './types';
 import { Typography } from '@equinor/eds-core-react';
 import { tokens } from '@equinor/eds-tokens';
 import Table from '../../../../components/Table';
-import { Toolbar } from './DialogTable.style';
+import { Toolbar, Container } from './DialogTable.style';
 import { isTagOverdue } from './ScopeOverview';
 import { Column } from 'material-table';
 
@@ -23,35 +23,38 @@ const DialogTable = ({
 
     const numTags = tags.length;
 
-    return (<Table
-        columns={columns}
-        data={tags}
-        options={{
-            search: false,
-            pageSize: 5,
-            pageSizeOptions: [5, 10, 50, 100],
-            padding: 'dense',
-            showTitle: false,
-            draggable: false,
-            selection: false,
-            emptyRowsWhenPaging: false,
-            headerStyle: {
-                backgroundColor: tokens.colors.interactive.table__header__fill_resting.rgba
-            },
-            rowStyle: (rowData): any => ({
-                color: isTagOverdue(rowData) && tokens.colors.interactive.danger__text.rgba,
-            }),
-        }}
-        components={{
-            Toolbar: (): any => (
-                <Toolbar>
-                    {toolbarText && <Typography style={{ color: toolbarColor }} variant='h6' >{numTags} {toolbarText}</Typography>}
-                </Toolbar>
-            )
-        }}
+    return (
+        <Container>
+            <Table
+                columns={columns}
+                data={tags}
+                options={{
+                    search: false,
+                    pageSize: 5,
+                    pageSizeOptions: [5, 10, 50, 100],
+                    padding: 'dense',
+                    showTitle: false,
+                    draggable: false,
+                    selection: false,
+                    emptyRowsWhenPaging: false,
+                    headerStyle: {
+                        backgroundColor: tokens.colors.interactive.table__header__fill_resting.rgba
+                    },
+                    rowStyle: (rowData): any => ({
+                        color: isTagOverdue(rowData) && tokens.colors.interactive.danger__text.rgba,
+                    }),
+                }}
+                components={{
+                    Toolbar: (): any => (
+                        <Toolbar>
+                            {toolbarText && <Typography style={{ color: toolbarColor }} variant='h6' >{numTags} {toolbarText}</Typography>}
+                        </Toolbar>
+                    )
+                }}
 
-        style={{ boxShadow: 'none' }}
-    />);
+                style={{ boxShadow: 'none' }}
+            />
+        </Container>);
 };
 
 export default DialogTable;

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.style.ts
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.style.ts
@@ -55,8 +55,12 @@ export const IconBar = styled.div`
     display: flex;
     align-items: center;
 
+    #filterButton {
+        margin-right: 0px;
+    }
+
     button {
-        margin-left: var(--grid-unit);
+        margin-right: var(--grid-unit);
     }
 `;
 

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.style.ts
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.style.ts
@@ -4,8 +4,6 @@ import { Button } from '@equinor/eds-core-react';
 
 export const Container = styled.div`
     display: flex;
-    height: 100%;
-    overflow-y: hidden;
 `;
 
 export const ContentContainer = styled.div`
@@ -13,6 +11,7 @@ export const ContentContainer = styled.div`
     flex-direction: column;
     overflow-x: hidden;
     width: 100%;
+    overflow: visible;
     margin-top: -16px;
 `;
 

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
@@ -596,6 +596,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
                         <Tooltip title={<TooltipText><p>{numberOfFilters} active filter(s)</p><p>Filter result {numberOfTags} items</p></TooltipText>} disableHoverListener={numberOfFilters < 1} arrow={true} style={{ textAlign: 'center' }}>
                             <div>
                                 <StyledButton
+                                    id='filterButton'
                                     variant={numberOfFilters > 0 ? 'contained' : 'ghost'}
                                     onClick={(): void => {
                                         toggleFilter();

--- a/src/modules/Preservation/views/ScopeOverview/ScopeTable.style.ts
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeTable.style.ts
@@ -41,4 +41,8 @@ export const Container = styled.div`
         height: 24px;
         
     }
+
+    div > div > div > div[style] {
+        overflow-y: hidden !important; /* This is to remove the scrollbar in table that makes it seem like the page is lagging when user is scrolling  */
+    }
 `;

--- a/src/modules/Preservation/views/ScopeOverview/ScopeTable.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeTable.tsx
@@ -131,7 +131,7 @@ class ScopeTable extends React.Component<ScopeTableProps, {}> {
 
     render(): ReactNode {
         return (
-            <Container>
+            <Container id='scopeTable'>
                 <Table id='table'
                     tableRef={this.refObject} //reference will be used by parent, to trigger rendering
                     columns={[

--- a/src/modules/Preservation/views/ScopeOverview/ScopeTable.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeTable.tsx
@@ -131,7 +131,7 @@ class ScopeTable extends React.Component<ScopeTableProps, {}> {
 
     render(): ReactNode {
         return (
-            <Container id='scopeTable'>
+            <Container>
                 <Table id='table'
                     tableRef={this.refObject} //reference will be used by parent, to trigger rendering
                     columns={[


### PR DESCRIPTION
Force styled table from material-table to remove scrollbar from where it somehow appears.
Fixed overflow problem that I created in my last PR that was supposed to be a fix for when dropdown is cut off when no tags in scope table. Fixed with overflow: visible instead.