### PR TITLE
75226 - Label in field of type attachment do not show

### DIFF
--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/PreservationTab.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/PreservationTab.tsx
@@ -101,6 +101,7 @@ const PreservationTab = ({
                 readonly={isReadOnly()}
                 recordTagRequirementValues={recordTagRequirementValues}
                 preserveRequirement={preserveRequirement}
+                refreshRequirements={refreshTagDetails}
             />
         );
     };

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/RequirementAttachmentField.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/RequirementAttachmentField.tsx
@@ -15,12 +15,14 @@ interface RequirementAttachmentFieldProps {
     requirementId: number;
     field: TagRequirementField;
     tagId: number;
+    attachmentWasUpdated: () => void;
 }
 
 const RequirementAttachmentField = ({
     requirementId,
     field,
-    tagId
+    tagId,
+    attachmentWasUpdated
 }: RequirementAttachmentFieldProps): JSX.Element => {
 
     const { apiClient } = usePreservationContext();
@@ -32,7 +34,8 @@ const RequirementAttachmentField = ({
             const url = await apiClient.getDownloadUrlForAttachmentOnTagRequirement(tagId, requirementId, field.id);
             window.open(url, '_blank');
             showSnackbarNotification('Attachment is downloaded.', 5000, true);
-        } catch (error) {
+        } 
+        catch (error) {
             console.error('Not able to get download url for tag requirement attachment: ', error.message, error.data);
             showSnackbarNotification(error.message, 5000, true);
         }
@@ -46,9 +49,13 @@ const RequirementAttachmentField = ({
                 setFilename(file.name);
             }
             showSnackbarNotification(`Attachment with filename '${file.name}' is added to tag requirement.`, 5000, true);
-        } catch (error) {
+        } 
+        catch (error) {
             console.error('Upload file attachment failed: ', error.message, error.data);
             showSnackbarNotification(error.message, 5000, true);
+        }
+        finally {
+            attachmentWasUpdated();
         }
         setIsLoading(false);
     };
@@ -59,9 +66,13 @@ const RequirementAttachmentField = ({
             await apiClient.removeAttachmentOnTagRequirement(tagId, requirementId, field.id);
             setFilename(null);
             showSnackbarNotification('Attachment is deleted.', 5000, true);
-        } catch (error) {
+        } 
+        catch (error) {
             console.error('Not able to delete attachment on tag requirement: ', error.message, error.data);
             showSnackbarNotification(error.message, 5000, true);
+        }
+        finally {
+            attachmentWasUpdated();
         }
         setIsLoading(false);
     };

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/RequirementAttachmentField.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/RequirementAttachmentField.tsx
@@ -7,7 +7,7 @@ import Spinner from '@procosys/components/Spinner';
 import { Button } from '@equinor/eds-core-react';
 import EdsIcon from '@procosys/components/EdsIcon';
 import { tokens } from '@equinor/eds-tokens';
-import { SelectFileLabel, AttachmentLink } from './Requirements.style';
+import { SelectFileButton, SelectFileLabel, AttachmentLink } from './Requirements.style';
 
 const deleteIcon = <EdsIcon color={tokens.colors.interactive.primary__resting.rgba} name='delete_to_trash' size={16} />;
 
@@ -93,7 +93,7 @@ const RequirementAttachmentField = ({
         <div style={{ display: 'flex', flexDirection: 'column' }}>
             {
                 filename &&
-                < div style={{ display: 'flex', alignItems: 'center' }}>
+                <div style={{ display: 'flex', alignItems: 'center' }}>
                     <AttachmentLink onClick={downloadAttachment}>
                         {filename}
                     </AttachmentLink>
@@ -102,18 +102,16 @@ const RequirementAttachmentField = ({
                     </Button>
                 </div>
             }
-            <div style={{display: 'flex', flexDirection: 'row'}}>
-                <div style={{marginTop: 'calc(var(--grid-unit) * 2 + 3px)', marginRight: 'var(--grid-unit)'}}>
-                    {field.label}
-                </div>
-                <div style={{ display: 'flex', marginTop: 'var(--grid-unit)' }}>
+            <div style={{ display: 'flex', flexDirection: 'row' }}>
+                <div style={{ marginTop: 'var(--grid-unit)' }}>
                     <form>
                         <label htmlFor="uploadFile">
-                            <SelectFileLabel>Select file</SelectFileLabel>
+                            <SelectFileButton>Select file</SelectFileButton>
                         </label>
                         <input id="uploadFile" style={{ display: 'none' }} type='file' onChange={handleSubmitFile} />
                     </form>
                 </div>
+                <SelectFileLabel>{field.label}</SelectFileLabel>
             </div>
         </div>
     );

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/RequirementAttachmentField.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/RequirementAttachmentField.tsx
@@ -15,14 +15,14 @@ interface RequirementAttachmentFieldProps {
     requirementId: number;
     field: TagRequirementField;
     tagId: number;
-    attachmentWasUpdated: () => void;
+    onAttachmentUpdated: () => void;
 }
 
 const RequirementAttachmentField = ({
     requirementId,
     field,
     tagId,
-    attachmentWasUpdated
+    onAttachmentUpdated
 }: RequirementAttachmentFieldProps): JSX.Element => {
 
     const { apiClient } = usePreservationContext();
@@ -55,7 +55,7 @@ const RequirementAttachmentField = ({
             showSnackbarNotification(error.message, 5000, true);
         }
         finally {
-            attachmentWasUpdated();
+            onAttachmentUpdated();
         }
         setIsLoading(false);
     };
@@ -72,7 +72,7 @@ const RequirementAttachmentField = ({
             showSnackbarNotification(error.message, 5000, true);
         }
         finally {
-            attachmentWasUpdated();
+            onAttachmentUpdated();
         }
         setIsLoading(false);
     };

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/RequirementAttachmentField.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/RequirementAttachmentField.tsx
@@ -91,15 +91,18 @@ const RequirementAttachmentField = ({
                     </Button>
                 </div>
             }
-            <div style={{ display: 'flex', marginTop: 'calc(var(--grid-unit)' }}>
-                <form>
-                    <label htmlFor="uploadFile">
-                        <SelectFileLabel>
-                            Select file
-                        </SelectFileLabel>
-                    </label>
-                    <input id="uploadFile" style={{ display: 'none' }} type='file' onChange={handleSubmitFile} />
-                </form>
+            <div style={{display: 'flex', flexDirection: 'row'}}>
+                <div style={{marginTop: 'calc(var(--grid-unit) * 2 + 3px)', marginRight: 'var(--grid-unit)'}}>
+                    {field.label}
+                </div>
+                <div style={{ display: 'flex', marginTop: 'var(--grid-unit)' }}>
+                    <form>
+                        <label htmlFor="uploadFile">
+                            <SelectFileLabel>Select file</SelectFileLabel>
+                        </label>
+                        <input id="uploadFile" style={{ display: 'none' }} type='file' onChange={handleSubmitFile} />
+                    </form>
+                </div>
             </div>
         </div>
     );

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.style.ts
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.style.ts
@@ -26,7 +26,7 @@ export const NextInfo = styled.span<{ isOverdue: boolean }>`
     `}
 `;
 
-export const SelectFileLabel = styled.div`
+export const SelectFileButton = styled.div`
     padding: 10px;
     border: 1px solid ${tokens.colors.interactive.primary__resting.rgba};
     box-sizing: border-box;
@@ -35,6 +35,11 @@ export const SelectFileLabel = styled.div`
     :hover {
         background-color: ${tokens.colors.interactive.primary__hover_alt.rgba};
     }
+`;
+
+export const SelectFileLabel = styled.div`
+    margin-top: calc(var(--grid-unit) * 2 + 3px);
+    margin-left: var(--grid-unit);
 `;
 
 export const AttachmentLink = styled.div`

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
@@ -211,7 +211,7 @@ const Requirements = ({
                         requirementId={requirementId}
                         field={field}
                         tagId={tagId}
-                        attachmentWasUpdated={refreshRequirements}
+                        onAttachmentUpdated={refreshRequirements}
                     />
                 );
 

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
@@ -15,6 +15,7 @@ interface RequirementProps {
     readonly: boolean;
     recordTagRequirementValues: (values: TagRequirementRecordValues) => void;
     preserveRequirement: (requirementId: number) => void;
+    refreshRequirements: () => void;
 }
 
 const Requirements = ({
@@ -22,7 +23,8 @@ const Requirements = ({
     requirements,
     readonly,
     recordTagRequirementValues,
-    preserveRequirement
+    preserveRequirement,
+    refreshRequirements
 }: RequirementProps): JSX.Element => {
 
     const [requirementValues, setRequirementValues] = useState<TagRequirementRecordValues[]>([]);
@@ -209,6 +211,7 @@ const Requirements = ({
                         requirementId={requirementId}
                         field={field}
                         tagId={tagId}
+                        attachmentWasUpdated={refreshRequirements}
                     />
                 );
 


### PR DESCRIPTION
- Display field label for file upload
- Trigger refresh when file is uploaded or deleted. This is needed to get the new "ready to be preserved" status and buttons activated accordingly.