### PR TITLE
75218 - UI - Tag content not automatically updated when changing Area Type

### DIFF
--- a/src/modules/Preservation/views/AddScope/CreateDummyTag/CreateDummyTag.tsx
+++ b/src/modules/Preservation/views/AddScope/CreateDummyTag/CreateDummyTag.tsx
@@ -258,18 +258,13 @@ const CreateDummyTag = (props: CreateDummyTagProps): JSX.Element => {
 
     useEffect(() => {
         const checkTagNos = async (): Promise<void> => {
-            if (props.suffix && /\s/.test(props.suffix)) {
-                setTagNoValidationError(spacesInTagNoMessage);
-                setTagNoValid(false);
-            }
-            else if (props.discipline && props.areaType && props.areaType.value != 'PoArea') {
+            if (props.discipline && props.areaType && props.areaType.value != 'PoArea') {
                 const areaCode = (props.area) ? props.area.code : null;
                 const response = await checkTagNo(props.areaType.value, props.discipline.code, areaCode, null, props.suffix || null);
                 props.setSelectedTags([{
                     tagNo: response.tagNo,
                     description: props.description || ''
-                }
-                ]);
+                }]);
                 setTagNoValid(!response.exists);
                 setTagNoValidationError(!response.exists ? null : invalidTagNoMessage);
             } else if (props.areaType && props.discipline && props.purchaseOrder && props.areaType.value == 'PoArea') {
@@ -277,12 +272,20 @@ const CreateDummyTag = (props: CreateDummyTagProps): JSX.Element => {
                 props.setSelectedTags([{
                     tagNo: response.tagNo,
                     description: props.description || ''
-                }
-                ]);
+                }]);
                 setTagNoValid(!response.exists);
                 setTagNoValidationError(!response.exists ? null : invalidTagNoMessage);
             } else {
+                props.setSelectedTags([{
+                    tagNo: 'type-discipline-area/PO-suffix',
+                    description: props.description || ''
+                }]);
                 setTagNoValidationError(null);
+            }
+
+            if (props.suffix && /\s/.test(props.suffix)) {
+                setTagNoValidationError(spacesInTagNoMessage);
+                setTagNoValid(false);
             }
         };
 

--- a/src/modules/Preservation/views/AddScope/CreateDummyTag/__tests__/CreateDummyTag.test.jsx
+++ b/src/modules/Preservation/views/AddScope/CreateDummyTag/__tests__/CreateDummyTag.test.jsx
@@ -99,7 +99,7 @@ describe('<CreateDummyTag />', () => {
     it('Displays error message when suffix contains space', async () => {
         await act(async () => {
             var propFunc = jest.fn();
-            const { queryByText } = render(<CreateDummyTag suffix="1 2"  setArea={propFunc} setPurchaseOrder={propFunc}/>);
+            const { queryByText } = render(<CreateDummyTag suffix="1 2" setSelectedTags={propFunc} setArea={propFunc} setPurchaseOrder={propFunc}/>);
             await waitFor(() => expect(queryByText(spacesInTagNoMessage)).toBeInTheDocument());
         });
     });
@@ -107,7 +107,7 @@ describe('<CreateDummyTag />', () => {
     it('\'Next\' button disabled when not all mandatory fields are passed', async () => {
         await act(async () => {
             var propFunc = jest.fn();
-            const { getByText } = render(<CreateDummyTag areaType={{title: 'Normal', value: 'PreArea'}} discipline='testDiscipline' suffix='12' setArea={propFunc} setPurchaseOrder={propFunc}/>);
+            const { getByText } = render(<CreateDummyTag areaType={{title: 'Normal', value: 'PreArea'}} discipline='testDiscipline' suffix='12' setSelectedTags={propFunc} setArea={propFunc} setPurchaseOrder={propFunc}/>);
             expect(getByText('Next')).toHaveProperty('disabled', true);
         });
     });
@@ -115,7 +115,7 @@ describe('<CreateDummyTag />', () => {
     it('\'Next\' button disabled when not all mandatory fields are passed for PO tag', async () => {
         await act(async () => {
             var propFunc = jest.fn();
-            const { getByText } = render(<CreateDummyTag areaType={{title: 'Supplier', value: 'PoArea'}} discipline='testDiscipline' description='test description' suffix='12' setArea={propFunc} setPurchaseOrder={propFunc}/>);
+            const { getByText } = render(<CreateDummyTag areaType={{title: 'Supplier', value: 'PoArea'}} discipline='testDiscipline' description='test description' suffix='12' setSelectedTags={propFunc} setArea={propFunc} setPurchaseOrder={propFunc}/>);
             expect(getByText('Next')).toHaveProperty('disabled', true);
         });
     });


### PR DESCRIPTION
The problem seems to occur when changing area/dummy type from "#PRE" or "#SITE" to "Supplier (#PO)". 
The third dropdown (PO/Calloff) becomes mandatory, and the previous "selected tag no" was not updated. 
The tag no is now reset to the default placeholder when this happens (type-discipline-area/PO-suffix), and is updated once the po/calloff dropdown has been selected.

Also, any validation error to the suffix will now not prevent the tag no to be updated. It will still invalidate the tag no and disallow going to the next step.