### PR TITLE
Feature/74836   standardize buttons scope overview buttons

### DIFF
--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
@@ -136,10 +136,10 @@ const ScopeOverview: React.FC = (): JSX.Element => {
     useEffect(() => {
         setVoidedTagsSelected(selectedTags.find(t => t.isVoided) ? true : false);
         setUnvoidedTagsSelected(selectedTags.find(t => !t.isVoided) ? true : false);
-        setCompletableTagsSelected(selectedTags.find(t => t.readyToBeCompleted) ? true : false);
-        setPreservableTagsSelected(selectedTags.find(t => t.readyToBePreserved) ? true : false);
-        setStartableTagsSelected(selectedTags.find(t => t.readyToBeStarted) ? true : false);
-        setTransferableTagsSelected(selectedTags.find(t => t.readyToBeTransferred) ? true : false);
+        setCompletableTagsSelected(selectedTags.find(t => t.readyToBeCompleted && !t.isVoided) ? true : false);
+        setPreservableTagsSelected(selectedTags.find(t => t.readyToBePreserved && !t.isVoided) ? true : false);
+        setStartableTagsSelected(selectedTags.find(t => t.readyToBeStarted && !t.isVoided) ? true : false);
+        setTransferableTagsSelected(selectedTags.find(t => t.readyToBeTransferred && !t.isVoided) ? true : false);
         if (selectedTags.length == 1) {
             setSelectedTagId(selectedTags[0].id);
         } else {
@@ -349,7 +349,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
     };
 
     let voidableTags: PreservedTag[] = [];
-    let unVoidableTags: PreservedTag[] = [];
+    let unvoidableTags: PreservedTag[] = [];
 
     const voidTags = async (): Promise<void> => {
         try {
@@ -368,7 +368,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
 
     const unVoidTags = async (): Promise<void> => {
         try {
-            for (const tag of unVoidableTags) {
+            for (const tag of unvoidableTags) {
                 await apiClient.unvoidTag(tag.id, tag.rowVersion);
             }
             refreshScopeList();
@@ -383,22 +383,33 @@ const ScopeOverview: React.FC = (): JSX.Element => {
 
     const showVoidDialog = (voiding: boolean): void => {
         voidableTags = [];
-        unVoidableTags = [];
+        unvoidableTags = [];
+        // selectedTags.map((tag) => {
+        //     const newTag: PreservedTag = { ...tag };
+        //     if (!tag.isVoided && voiding) {
+        //         voidableTags.push(newTag);
+        //     } else if (tag.isVoided && !voiding) {
+        //         unvoidableTags.push(newTag);
+        //     }
+        // });
+        // const voidButton = voidableTags.length > 0 ? 'Void' : 'Unvoid';
+        // const voidFunc = voidableTags.length > 0 ? voidTags : unVoidTags;
+        // const voidTitle = voidableTags.length > 0 ? 'Voiding following tags' : 'Unvoiding following tags';
         selectedTags.map((tag) => {
             const newTag: PreservedTag = { ...tag };
-            if (!tag.isVoided && voiding) {
+            if (!tag.isVoided) {
                 voidableTags.push(newTag);
-            } else if (tag.isVoided && !voiding) {
-                unVoidableTags.push(newTag);
+            } else {
+                unvoidableTags.push(newTag);
             }
         });
-        const voidButton = voidableTags.length > 0 ? 'Void' : 'Unvoid';
-        const voidFunc = voidableTags.length > 0 ? voidTags : unVoidTags;
-        const voidTitle = voidableTags.length > 0 ? 'Voiding following tags' : 'Unvoiding following tags';
+        const voidButton = voiding ? 'Void' : 'Unvoid';
+        const voidFunc = voiding ? voidTags : unVoidTags;
+        const voidTitle = voiding ? 'Voiding following tags' : 'Unvoiding following tags';
 
         showModalDialog(
             voidTitle,
-            <VoidDialog tags={voidableTags.length > 0 ? voidableTags : unVoidableTags} voiding={voiding} />,
+            <VoidDialog voidableTags={voidableTags} unvoidableTags={unvoidableTags} voiding={voiding} />,
             '80vw',
             backToListButton,
             null,

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
@@ -89,6 +89,10 @@ const ScopeOverview: React.FC = (): JSX.Element => {
     const [numberOfTags, setNumberOfTags] = useState<number>();
     const [voidedTagsSelected, setVoidedTagsSelected] = useState<boolean>();
     const [unvoidedTagsSelected, setUnvoidedTagsSelected] = useState<boolean>();
+    const [completableTagsSelected, setCompletableTagsSelected] = useState<boolean>();
+    const [preservableTagsSelected, setPreservableTagsSelected] = useState<boolean>();
+    const [startableTagsSelected, setStartableTagsSelected] = useState<boolean>();
+    const [transferableTagsSelected, setTransferableTagsSelected] = useState<boolean>();
     const [selectedTagId, setSelectedTagId] = useState<string | number>();
     const [resetTablePaging, setResetTablePaging] = useState<boolean>(false);
     const [numberOfFilters, setNumberOfFilters] = useState<number>(0);
@@ -131,6 +135,10 @@ const ScopeOverview: React.FC = (): JSX.Element => {
     useEffect(() => {
         setVoidedTagsSelected(selectedTags.find(t => t.isVoided) ? true : false);
         setUnvoidedTagsSelected(selectedTags.find(t => !t.isVoided) ? true : false);
+        setCompletableTagsSelected(selectedTags.find(t => t.readyToBeCompleted) ? true : false);
+        setPreservableTagsSelected(selectedTags.find(t => t.readyToBePreserved) ? true : false);
+        setStartableTagsSelected(selectedTags.find(t => t.readyToBeStarted) ? true : false);
+        setTransferableTagsSelected(selectedTags.find(t => t.readyToBeTransferred) ? true : false);
         if (selectedTags.length == 1) {
             setSelectedTagId(selectedTags[0].id);
         } else {
@@ -531,30 +539,30 @@ const ScopeOverview: React.FC = (): JSX.Element => {
                     <IconBar>
                         <Button
                             onClick={preservedDialog}
-                            disabled={selectedTags.length < 1}>Preserved this week
+                            disabled={!preservableTagsSelected}>Preserved this week
                         </Button>
                         <StyledButton
                             variant='ghost'
                             title='Start preservation for selected tag(s)'
                             onClick={startPreservationDialog}
-                            disabled={selectedTags.length < 1}>
-                            <div className='iconNextToText' ><EdsIcon name='play' color={selectedTags.length < 1 ? tokens.colors.interactive.disabled__border.rgba : ''} /></div>
+                            disabled={!startableTagsSelected}>
+                            <div className='iconNextToText' ><EdsIcon name='play' color={!startableTagsSelected ? tokens.colors.interactive.disabled__border.rgba : ''} /></div>
                         Start
                         </StyledButton>
                         <StyledButton
                             variant='ghost'
                             title="Transfer selected tag(s)"
                             onClick={transferDialog}
-                            disabled={selectedTags.length < 1}>
-                            <div className='iconNextToText' ><EdsIcon name='fast_forward' color={selectedTags.length < 1 ? tokens.colors.interactive.disabled__border.rgba : ''} /></div>
+                            disabled={!transferableTagsSelected}>
+                            <div className='iconNextToText' ><EdsIcon name='fast_forward' color={!transferableTagsSelected ? tokens.colors.interactive.disabled__border.rgba : ''} /></div>
                         Transfer
                         </StyledButton>
                         <StyledButton
                             variant='ghost'
                             title="Complete selected tag(s)"
                             onClick={showCompleteDialog}
-                            disabled={selectedTags.length < 1}>
-                            <div className='iconNextToText' ><EdsIcon name='done_all' color={selectedTags.length < 1 ? tokens.colors.interactive.disabled__border.rgba : ''} /></div>
+                            disabled={!completableTagsSelected}>
+                            <div className='iconNextToText' ><EdsIcon name='done_all' color={!completableTagsSelected ? tokens.colors.interactive.disabled__border.rgba : ''} /></div>
                         Complete
                         </StyledButton>
                         <OptionsDropdown

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
@@ -130,6 +130,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
 
         setResetTablePaging(true);
         refreshScopeList();
+        setSelectedTags([]);
     }, [tagListFilter]);
 
     useEffect(() => {

--- a/src/modules/Preservation/views/ScopeOverview/VoidDialog.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/VoidDialog.tsx
@@ -29,8 +29,6 @@ const getRequirementIcons = (tag: PreservedTag): JSX.Element => {
     );
 };
 
-
-
 const columns: Column<any>[] = [
     { title: 'Tag nr', field: 'tagNo' },
     { title: 'Description', field: 'description' },

--- a/src/modules/Preservation/views/ScopeOverview/VoidDialog.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/VoidDialog.tsx
@@ -9,7 +9,8 @@ import { Column } from 'material-table';
 import EdsIcon from '@procosys/components/EdsIcon';
 
 interface VoidDialogProps {
-    tags: PreservedTag[];
+    voidableTags: PreservedTag[];
+    unvoidableTags: PreservedTag[];
     voiding: boolean;
 }
 
@@ -28,8 +29,7 @@ const getRequirementIcons = (tag: PreservedTag): JSX.Element => {
     );
 };
 
-const voidingText = 'Tags will be removed from preservation scope';
-const unVoidingText = 'Note that tags have been removed from preservation during the period the tags have been voided. Preservation will be started in the same step of the journey as when they were voided.';
+
 
 const columns: Column<any>[] = [
     { title: 'Tag nr', field: 'tagNo' },
@@ -41,18 +41,31 @@ const columns: Column<any>[] = [
 ];
 
 const VoidDialog = ({
-    tags,
+    voidableTags,
+    unvoidableTags,
     voiding
 }: VoidDialogProps): JSX.Element => {
+    const topTable = voiding ? unvoidableTags : voidableTags;
+    const bottomTable = voiding ? voidableTags : unvoidableTags;
+
+    const voidingText = `${voidableTags.length} tag(s) will be removed from preservation scope`;
+    const unvoidingText = 'Note that tag(s) have been removed from preservation during the period the tag(s) have been voided. Preservation will be started in the same step of the journey as when they were voided.';
 
     return (<div>
-        <TopText>
-            <EdsIcon name='warning_filled' color={tokens.colors.interactive.danger__text.rgba}/>
-            <Typography variant="caption" style={{color: tokens.colors.interactive.danger__text.rgba}}>{voiding ? voidingText : unVoidingText} </Typography>
-        </TopText>
-        <DialogTable tags={tags} columns={columns} />
-    </div>
-    );
+        {topTable.length > 0 && (
+            <div>
+                <Typography variant="meta">{`${topTable.length} tag(s) cannot be ${voiding ? 'voided' : 'unvoided'}.`}</Typography>
+                <DialogTable tags={topTable} columns={columns} toolbarText={`tag(s) are already ${voiding ? 'voided' : 'unvoided'}`} toolbarColor={tokens.colors.interactive.danger__text.rgba} />
+            </div>)}
+        {bottomTable.length > 0 && (
+            <div>
+                <TopText>
+                    <EdsIcon name='warning_filled' color={tokens.colors.interactive.danger__text.rgba}/>
+                    <Typography variant='h6' style={{color: tokens.colors.interactive.danger__text.rgba}}>{voiding ? voidingText : unvoidingText}</Typography>
+                </TopText>
+                <DialogTable tags={bottomTable} columns={columns} />
+            </div>)}
+    </div>);
 };
 
 export default VoidDialog;


### PR DESCRIPTION
Buttons on header level on scope overview are only enabled if any tags that meet the requirement of that button's action are selected.
Eg. if we select a tag and it is not ready to be preserved, then the Ready to be preserved button is not enabled.

Added section on void/unvoid dialog for tags that are not able to be voided/unvoided