### PR TITLE
Rename from PlantConfig to libraryv2

### DIFF
--- a/src/app/ProcosysRouter.tsx
+++ b/src/app/ProcosysRouter.tsx
@@ -41,7 +41,7 @@ const ProcosysRouter = (): JSX.Element => {
                     }
                 />
                 <Route
-                    path={`${path}/plantconfig`}
+                    path={`${path}/libraryv2`}
                     component={(routeProps: RouteComponentProps): JSX.Element =>
                         LazyRoute(PlantConfig, routeProps)
                     }

--- a/src/modules/Header/index.tsx
+++ b/src/modules/Header/index.tsx
@@ -321,7 +321,7 @@ const Header: React.FC = (): JSX.Element => {
                 <a href={`/${params.plant}/Hookup`}>Hookup</a>
                 <NavLink
                     activeClassName={'active'}
-                    to={`/${params.plant}/PlantConfig`}
+                    to={`/${params.plant}/libraryv2`}
                 >
                     Plant Configuration
                 </NavLink>


### PR DESCRIPTION
Renaming the temporary URI used for "new library" from `/PlantConfig` to `/libraryv2`

`/PlantConfig` is showing a link overview in the old solution, so we cant use that URL. 
`/Library` is used by the "old" library