### PR TITLE
Feature/75427 add global dirty context and navigation prevention

### DIFF
--- a/src/app/ProcosysRouter.tsx
+++ b/src/app/ProcosysRouter.tsx
@@ -6,6 +6,7 @@ import {
     useRouteMatch
 } from 'react-router-dom';
 
+import { DirtyContextProvider } from '../core/DirtyContext';
 import Header from '../modules/Header';
 import LazyRoute from '../components/LazyRoute';
 import { PlantContextProvider } from '../core/PlantContext';
@@ -22,32 +23,34 @@ const Page404 = (): JSX.Element => {
 const ProcosysRouter = (): JSX.Element => {
     const { path } = useRouteMatch();
     const { plant } = useParams();
+
     return (
         <PlantContextProvider>
-            <Header />
-
-            <Switch key={plant}>
-                <Route
-                    path={path}
-                    exact
-                    component={(routeProps: RouteComponentProps): JSX.Element =>
-                        LazyRoute(UserGreeting, routeProps)
-                    }
-                />
-                <Route
-                    path={`${path}/preservation`}
-                    component={(routeProps: RouteComponentProps): JSX.Element =>
-                        LazyRoute(Preservation, routeProps)
-                    }
-                />
-                <Route
-                    path={`${path}/libraryv2`}
-                    component={(routeProps: RouteComponentProps): JSX.Element =>
-                        LazyRoute(PlantConfig, routeProps)
-                    }
-                />
-                <Route component={Page404} />
-            </Switch>
+            <DirtyContextProvider>
+                <Header />
+                <Switch key={plant}>
+                    <Route
+                        path={path}
+                        exact
+                        component={(routeProps: RouteComponentProps): JSX.Element =>
+                            LazyRoute(UserGreeting, routeProps)
+                        }
+                    />
+                    <Route
+                        path={`${path}/preservation`}
+                        component={(routeProps: RouteComponentProps): JSX.Element =>
+                            LazyRoute(Preservation, routeProps)
+                        }
+                    />
+                    <Route
+                        path={`${path}/libraryv2`}
+                        component={(routeProps: RouteComponentProps): JSX.Element =>
+                            LazyRoute(PlantConfig, routeProps)
+                        }
+                    />
+                    <Route component={Page404} />
+                </Switch>
+            </DirtyContextProvider>
         </PlantContextProvider>
     );
 };

--- a/src/core/DirtyContext.tsx
+++ b/src/core/DirtyContext.tsx
@@ -1,0 +1,61 @@
+import { Prompt, useLocation } from 'react-router-dom';
+import React, { useEffect, useMemo, useState } from 'react';
+
+import propTypes from 'prop-types';
+
+export interface IDirtyContext {
+    isDirty: boolean;
+    setDirtyStateFor: (componentName: string) => void;
+    unsetDirtyStateFor: (componentName: string) => void;
+    clearDirtyState: () => void;
+}
+
+const DirtyContext = React.createContext<IDirtyContext>({} as IDirtyContext);
+
+export const DirtyContextProvider: React.FC = ({ children }): JSX.Element => {
+    const [dirtyList, setDirtyList] = useState<Set<string>>(new Set<string>());
+    const location = useLocation();
+    const isDirty = useMemo<boolean>(() => {
+        return dirtyList.size > 0;
+    }, [dirtyList]);
+
+    function setDirtyStateFor(componentName: string): void {
+        const newDirtyList = new Set(dirtyList);
+        newDirtyList.add(componentName);
+        setDirtyList(newDirtyList);
+    }
+
+    function unsetDirtyStateFor(componentName: string): void {
+        const newDirtyList = new Set(dirtyList);
+        // Only changes the state if there actually was a item removed
+        newDirtyList.delete(componentName) && setDirtyList(newDirtyList);
+    }
+
+    function clearDirtyState(): void {
+        setDirtyList(new Set());
+    }
+
+    useEffect(() => {
+        clearDirtyState();
+        return (): void => {
+            clearDirtyState();
+        };
+    }, [location]);
+
+
+    return (<DirtyContext.Provider value={{
+        setDirtyStateFor: setDirtyStateFor,
+        unsetDirtyStateFor,
+        clearDirtyState,
+        isDirty,
+    }}>
+        <Prompt message="You have unsaved changes, are you sure you want to continue?" when={isDirty} />
+        {children}
+    </DirtyContext.Provider>);
+};
+
+DirtyContextProvider.propTypes = {
+    children: propTypes.node
+};
+
+export const useDirtyContext = (): IDirtyContext => React.useContext<IDirtyContext>(DirtyContext);

--- a/src/modules/PlantConfig/views/Library/Mode/Mode.tsx
+++ b/src/modules/PlantConfig/views/Library/Mode/Mode.tsx
@@ -1,11 +1,13 @@
-import React, { useState, useEffect } from 'react';
-import { usePlantConfigContext } from '@procosys/modules/PlantConfig/context/PlantConfigContext';
-import { showSnackbarNotification } from '@procosys/core/services/NotificationService';
-import { Container, InputContainer, ButtonContainer, ButtonSpacer, IconContainer, Breadcrumbs } from './Mode.style';
-import EdsIcon from '../../../../../components/EdsIcon';
-import { TextField, Typography, Button } from '@equinor/eds-core-react';
-import Spinner from '@procosys/components/Spinner';
+import { Breadcrumbs, ButtonContainer, ButtonSpacer, Container, IconContainer, InputContainer } from './Mode.style';
+import { Button, TextField, Typography } from '@equinor/eds-core-react';
+import React, { useEffect, useState } from 'react';
+
 import Checkbox from './../../../../../components/Checkbox';
+import EdsIcon from '../../../../../components/EdsIcon';
+import Spinner from '@procosys/components/Spinner';
+import { showSnackbarNotification } from '@procosys/core/services/NotificationService';
+import { useDirtyContext } from '@procosys/core/DirtyContext';
+import { usePlantConfigContext } from '@procosys/modules/PlantConfig/context/PlantConfigContext';
 
 const deleteIcon = <EdsIcon name='delete_to_trash' size={16} />;
 const addIcon = <EdsIcon name='add' size={16} />;
@@ -39,6 +41,7 @@ const Mode = (props: ModeProps): JSX.Element => {
     const [newMode, setNewMode] = useState<ModeItem>(createNewMode);
     const [isDirty, setIsDirty] = useState<boolean>(false);
     const [isSaved, setIsSaved] = useState<boolean>(false);
+    const { setDirtyStateFor, unsetDirtyStateFor } = useDirtyContext();
 
     const {
         preservationApiClient,
@@ -64,6 +67,17 @@ const Mode = (props: ModeProps): JSX.Element => {
         }
         setIsLoading(false);
     };
+
+    useEffect(() => {
+        if (isDirty) {
+            setDirtyStateFor('ModeForm');
+        } else {
+            unsetDirtyStateFor('ModeForm');
+        }
+        return (): void => {
+            unsetDirtyStateFor('ModeForm');
+        };
+    }, [isDirty]);
 
     useEffect((): void => {
         if (props.modeId) {

--- a/src/modules/PlantConfig/views/Library/PreservationJourney/PreservationJourney.tsx
+++ b/src/modules/PlantConfig/views/Library/PreservationJourney/PreservationJourney.tsx
@@ -1,14 +1,16 @@
-import React, { useState, useEffect } from 'react';
-import { usePlantConfigContext } from '@procosys/modules/PlantConfig/context/PlantConfigContext';
-import { showSnackbarNotification } from '@procosys/core/services/NotificationService';
-import { Container, InputContainer, StepsContainer, FormFieldSpacer, ButtonContainer, ButtonSpacer, DropdownItem, IconContainer, ResponsibleDropdownContainer, Breadcrumbs } from './PreservationJourney.style';
-import EdsIcon from '../../../../../components/EdsIcon';
-import { TextField, Typography, Button } from '@equinor/eds-core-react';
+import { Breadcrumbs, ButtonContainer, ButtonSpacer, Container, DropdownItem, FormFieldSpacer, IconContainer, InputContainer, ResponsibleDropdownContainer, StepsContainer } from './PreservationJourney.style';
+import { Button, TextField, Typography } from '@equinor/eds-core-react';
+import React, { useEffect, useState } from 'react';
 import SelectInput, { SelectItem } from '../../../../../components/Select';
+
 import { Canceler } from 'axios';
-import Spinner from '@procosys/components/Spinner';
-import Dropdown from '../../../../../components/Dropdown';
 import Checkbox from './../../../../../components/Checkbox';
+import Dropdown from '../../../../../components/Dropdown';
+import EdsIcon from '../../../../../components/EdsIcon';
+import Spinner from '@procosys/components/Spinner';
+import { showSnackbarNotification } from '@procosys/core/services/NotificationService';
+import { useDirtyContext } from '@procosys/core/DirtyContext';
+import { usePlantConfigContext } from '@procosys/modules/PlantConfig/context/PlantConfigContext';
 
 const addIcon = <EdsIcon name='add' size={16} />;
 const upIcon = <EdsIcon name='arrow_up' size={16} />;
@@ -75,6 +77,7 @@ const PreservationJourney = (props: PreservationJourneyProps): JSX.Element => {
     const [filteredResponsibles, setFilteredResponsibles] = useState<SelectItem[]>([]);
     const [canSave, setCanSave] = useState<boolean>(false);
     const [filterForResponsibles, setFilterForResponsibles] = useState<string>('');
+    const { setDirtyStateFor, unsetDirtyStateFor } = useDirtyContext();
 
     const {
         preservationApiClient,
@@ -532,7 +535,10 @@ const PreservationJourney = (props: PreservationJourneyProps): JSX.Element => {
     useEffect(() => {
         if (JSON.stringify(journey) == JSON.stringify(newJourney)) {
             setCanSave(false);
+            unsetDirtyStateFor('PreservationJourneyForm');
             return;
+        } else {
+            setDirtyStateFor('PreservationJourneyForm');
         }
         if (newJourney.title.length < 3) {
             setCanSave(false);

--- a/src/modules/PlantConfig/views/Library/PreservationRequirements/PreservationRequirementDefinition.tsx
+++ b/src/modules/PlantConfig/views/Library/PreservationRequirements/PreservationRequirementDefinition.tsx
@@ -1,16 +1,18 @@
-import React, { useState, useEffect } from 'react';
-import { usePlantConfigContext } from '@procosys/modules/PlantConfig/context/PlantConfigContext';
-import { showSnackbarNotification } from '@procosys/core/services/NotificationService';
-import { Container, InputContainer, FormFieldSpacer, ButtonContainer, ButtonSpacer, SelectText, IconContainer, FieldsContainer, FormHeader, Breadcrumbs } from './PreservationRequirements.style';
-import { TextField, Typography, Button } from '@equinor/eds-core-react';
+import { Breadcrumbs, ButtonContainer, ButtonSpacer, Container, FieldsContainer, FormFieldSpacer, FormHeader, IconContainer, InputContainer, SelectText } from './PreservationRequirements.style';
+import { Button, TextField, Typography } from '@equinor/eds-core-react';
+import React, { useEffect, useState } from 'react';
 import SelectInput, { SelectItem } from '../../../../../components/Select';
-import Spinner from '@procosys/components/Spinner';
-import PreservationIcon from '@procosys/components/PreservationIcon';
-import EdsIcon from '@procosys/components/EdsIcon';
-import Checkbox from './../../../../../components/Checkbox';
+
 import { Canceler } from 'axios';
+import Checkbox from './../../../../../components/Checkbox';
+import EdsIcon from '@procosys/components/EdsIcon';
+import PreservationIcon from '@procosys/components/PreservationIcon';
 import { RequirementType } from './types';
+import Spinner from '@procosys/components/Spinner';
+import { showSnackbarNotification } from '@procosys/core/services/NotificationService';
 import { tokens } from '@equinor/eds-tokens';
+import { useDirtyContext } from '@procosys/core/DirtyContext';
+import { usePlantConfigContext } from '@procosys/modules/PlantConfig/context/PlantConfigContext';
 
 const addIcon = <EdsIcon name='add' size={16} />;
 const upIcon = <EdsIcon name='arrow_up' size={16} />;
@@ -74,6 +76,8 @@ type PreservationRequirementDefinitionProps = {
 };
 
 const PreservationRequirementDefinition = (props: PreservationRequirementDefinitionProps): JSX.Element => {
+
+    const { setDirtyStateFor, unsetDirtyStateFor } = useDirtyContext();
 
     const [requirementDefinitionId, setRequirementDefinitionId] = useState<number>();
     const [requirementTypes, setRequirementTypes] = useState<RequirementType[]>([]);
@@ -160,7 +164,9 @@ const PreservationRequirementDefinition = (props: PreservationRequirementDefinit
             return;
         }
 
-        if (!isDirty()) {
+        const hasUnsavedChanges = isDirty();
+
+        if (!hasUnsavedChanges) {
             setIsDirtyAndValid(false);
         } else if (newRequirementDefinition.sortKey != -1 && newRequirementDefinition.usage && newRequirementDefinition.requirementTypeId != -1
             && newRequirementDefinition.title && newRequirementDefinition.defaultIntervalWeeks != -1) {
@@ -168,6 +174,13 @@ const PreservationRequirementDefinition = (props: PreservationRequirementDefinit
         } else {
             setIsDirtyAndValid(false);
         }
+
+        if (hasUnsavedChanges) {
+            setDirtyStateFor('PreservationRequirementDefinition');
+        } else {
+            unsetDirtyStateFor('PreservationRequirementDefinition');
+        }
+
     }, [newRequirementDefinition]);
 
     const cloneRequirementDefinition = (reqDef: RequirementDefinitionItem): RequirementDefinitionItem => {

--- a/src/modules/PlantConfig/views/Library/PreservationRequirements/PreservationRequirementType.tsx
+++ b/src/modules/PlantConfig/views/Library/PreservationRequirements/PreservationRequirementType.tsx
@@ -1,13 +1,15 @@
-import React, { useState, useEffect } from 'react';
-import { usePlantConfigContext } from '@procosys/modules/PlantConfig/context/PlantConfigContext';
-import { showSnackbarNotification } from '@procosys/core/services/NotificationService';
-import { Container, InputContainer, FormFieldSpacer, ButtonContainer, ButtonSpacer, SelectText, Breadcrumbs } from './PreservationRequirements.style';
-import { TextField, Typography, Button } from '@equinor/eds-core-react';
+import { Breadcrumbs, ButtonContainer, ButtonSpacer, Container, FormFieldSpacer, InputContainer, SelectText } from './PreservationRequirements.style';
+import { Button, TextField, Typography } from '@equinor/eds-core-react';
+import PreservationIcon, { PreservationTypeIcon, preservationIconList } from '@procosys/components/PreservationIcon';
+import React, { useEffect, useState } from 'react';
 import SelectInput, { SelectItem } from '../../../../../components/Select';
-import Spinner from '@procosys/components/Spinner';
-import PreservationIcon, { preservationIconList, PreservationTypeIcon } from '@procosys/components/PreservationIcon';
+
 import EdsIcon from '../../../../../components/EdsIcon';
 import { RequirementType } from './types';
+import Spinner from '@procosys/components/Spinner';
+import { showSnackbarNotification } from '@procosys/core/services/NotificationService';
+import { useDirtyContext } from '@procosys/core/DirtyContext';
+import { usePlantConfigContext } from '@procosys/modules/PlantConfig/context/PlantConfigContext';
 
 const voidIcon = <EdsIcon name='delete_forever' size={16} />;
 const unvoidIcon = <EdsIcon name='restore_from_trash' size={16} />;
@@ -32,6 +34,7 @@ const PreservationRequirementType = (props: PreservationRequirementTypeProps): J
     const [newRequirementType, setNewRequirementType] = useState<RequirementType>(createNewRequirementType());
     const [isDirty, setIsDirty] = useState<boolean>(false);
     const [iconList, setIconList] = useState<SelectItem[]>([]);
+    const { setDirtyStateFor, unsetDirtyStateFor } = useDirtyContext();
 
     const {
         preservationApiClient,
@@ -54,7 +57,9 @@ const PreservationRequirementType = (props: PreservationRequirementTypeProps): J
     useEffect(() => {
         if (JSON.stringify(requirementType) == JSON.stringify(newRequirementType)) {
             setIsDirty(false);
+            unsetDirtyStateFor('PreservationRequirementType');
         } else {
+            setDirtyStateFor('PreservationRequirementType');
             if (newRequirementType.code && newRequirementType.icon && newRequirementType.sortKey && newRequirementType.title) {
                 setIsDirty(true);
             } else {

--- a/src/modules/PlantConfig/views/Library/TagFunction/tabs/PreservationTab.tsx
+++ b/src/modules/PlantConfig/views/Library/TagFunction/tabs/PreservationTab.tsx
@@ -1,15 +1,17 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import { RequirementType } from './types';
-import PreservationApiClient from '@procosys/modules/Preservation/http/PreservationApiClient';
-import { useProcosysContext } from '@procosys/core/ProcosysContext';
-import { useCurrentPlant } from '@procosys/core/PlantContext';
-import { Canceler, AxiosResponse } from 'axios';
-import { showSnackbarNotification } from '@procosys/core/services/NotificationService';
-import RequirementsWidget from '../../../../../Preservation/components/RequirementsSelector/RequirementsSelector';
+import { ActionContainer, Container, LeftSection, RightSection } from './PreservationTab.style';
+import { AxiosResponse, Canceler } from 'axios';
+import React, { useEffect, useMemo, useState } from 'react';
+
 import { Button } from '@equinor/eds-core-react';
-import { hot } from 'react-hot-loader';
-import { LeftSection, Container, RightSection, ActionContainer } from './PreservationTab.style';
+import PreservationApiClient from '@procosys/modules/Preservation/http/PreservationApiClient';
+import { RequirementType } from './types';
+import RequirementsWidget from '../../../../../Preservation/components/RequirementsSelector/RequirementsSelector';
 import Spinner from '@procosys/components/Spinner';
+import { hot } from 'react-hot-loader';
+import { showSnackbarNotification } from '@procosys/core/services/NotificationService';
+import { useCurrentPlant } from '@procosys/core/PlantContext';
+import { useDirtyContext } from '@procosys/core/DirtyContext';
+import { useProcosysContext } from '@procosys/core/ProcosysContext';
 
 interface TagFunction {
     id: number;
@@ -42,6 +44,7 @@ const PreservationTab = (props: PreservationTabProps): JSX.Element => {
     const [tagFunctionDetails, setTagFunctionDetails] = useState<TagFunction>();
     const [unsavedRequirements, setUnsavedRequirements] = useState<RequirementFormInput[] | null>(null);
     const [isLoading, setIsLoading] = useState<boolean>(true);
+    const { setDirtyStateFor, unsetDirtyStateFor } = useDirtyContext();
 
     const { auth } = useProcosysContext();
     const { plant } = useCurrentPlant();
@@ -108,6 +111,20 @@ const PreservationTab = (props: PreservationTabProps): JSX.Element => {
     const onRequirementsChanged = (req: RequirementFormInput[]): void => {
         setUnsavedRequirements(req);
     };
+
+    /**
+     * Update global dirty state
+     */
+    useEffect(() => {
+        if (unsavedRequirements) {
+            setDirtyStateFor('TagFunctionForm');
+        } else {
+            unsetDirtyStateFor('TagFunctionForm');
+        }
+        return (): void => {
+            unsetDirtyStateFor('TagFunctionForm');
+        };
+    }, [unsavedRequirements]);
 
     /**
      * Get all requirement types


### PR DESCRIPTION
Introduces a dirty context that can be used in all components. 

API: 
```js
// Add a unique key reference that indicates that something is dirty
setDirtyStateFor(key: string)

// Remove your key reference that indicates that something is dirty
unsetDirtyStateFor(key: string)

// Clears all entries from the dirty context, this affects all components. 
clearDirtyState()

// Mainly used by the internal component, but exposed for flexibility. 
isDirty: bool
```

Usage: 
```js
....
const [hasUnsavedChanges, setHasUnsavedChanges] = useState<boolean>(false);
const { setDirtyStateFor, unsetDirtyStateFor } = useDirtyContext();

useEffect(() => {
  if (hasUnsavedChanges) {
    setDirtyStateFor('JourneyForm');
  } else {
    unsetDirtyStateFor('JourneyForm');
  }
},[hasUnsavedChanges])
```

How it works: 

1) User makes some changes that isnt saved
2) component registers itself as dirty, with a string based identifier. 
3) user tries to navigate (change URI)
4) You get a confirmation prompt telling you that you have unsaved changes, and asking if you want to continue. 
![image](https://user-images.githubusercontent.com/385693/91194172-35604180-e6f8-11ea-8f40-205ae9f8db31.png)

Dirtystate is automatically reset on navigation

Caveats: 
Developers need to ensure that dirty state is unset when component is unloaded, in cases where navigation does not occure (just mounting/unmounting) 
An example here is within **Library**, where we dont change the URI or navigate when switching between different entries. 

Check commit 4bb31a0cf4d3e6d350407d62ab8a749b0f8d6b02 for the dirty state component
and 53113e4f840dae29728059ece1feaf2d18b6d77f for implementation details