### PR TITLE
Always reset isLoading state

### DIFF
--- a/src/modules/PlantConfig/views/Library/TagFunction/tabs/PreservationTab.tsx
+++ b/src/modules/PlantConfig/views/Library/TagFunction/tabs/PreservationTab.tsx
@@ -59,7 +59,6 @@ const PreservationTab = (props: PreservationTabProps): JSX.Element => {
         try {
             const response = await apiClient.getTagFunction(props.tagFunctionCode, props.registerCode, requestCanceller);
             setTagFunctionDetails(response);
-            setIsLoading(false);
         } catch (error) {
             if (error && error.data) {
                 const serverError = error.data as AxiosResponse;
@@ -69,6 +68,7 @@ const PreservationTab = (props: PreservationTabProps): JSX.Element => {
                 }
             }
         }
+        setIsLoading(false);
     };
 
     const submitChanges = async (): Promise<void> => {


### PR DESCRIPTION
Endpoint returns a 404 when no entities exist. This caused the catch statement to trigger, and reset of isLoading state was skipped. 

DevOps#76455