### PR TITLE
Fix/icon size in buttons

### DIFF
--- a/src/assets/sass/global.scss
+++ b/src/assets/sass/global.scss
@@ -7,11 +7,6 @@ body {
     color: var(--text--default);
 }
 
-button span svg {
-    height: 16px !important;
-    width: 16px !important;
-}
-
 #procosys-root {
     height: 100vh;
     display: flex;

--- a/src/components/OptionsDropdown/index.tsx
+++ b/src/components/OptionsDropdown/index.tsx
@@ -22,7 +22,7 @@ const OptionsDropdown: React.FC<DropdownProps> = ({
     icon,
     children,
     variant,
-    iconSize = 16
+    iconSize = 24
 }: DropdownProps): JSX.Element => {
     const [isOpen, setIsOpen] = useState(false);
     const containerRef = useRef<HTMLDivElement>(null);

--- a/src/modules/Header/style.ts
+++ b/src/modules/Header/style.ts
@@ -92,9 +92,4 @@ export const MenuItem = styled.div`
     a {
         text-decoration: none;
     }
-    
-    button svg {
-        height: 24px !important;
-        width: 24px !important;
-    }
 `;

--- a/src/modules/PlantConfig/views/Library/Mode/Mode.style.ts
+++ b/src/modules/PlantConfig/views/Library/Mode/Mode.style.ts
@@ -30,9 +30,6 @@ export const ButtonContainer = styled.div`
     display: flex;
     width: 100%;
     justify-content: flex-end;
-    .buttonIcon svg {
-        padding-right: var(--grid-unit);
-    }
 `;
 
 export const IconContainer = styled.div`

--- a/src/modules/PlantConfig/views/Library/Mode/Mode.tsx
+++ b/src/modules/PlantConfig/views/Library/Mode/Mode.tsx
@@ -245,18 +245,18 @@ const Mode = (props: ModeProps): JSX.Element => {
             }
             <ButtonContainer>
                 {newMode.isVoided &&
-                    <Button className='buttonIcon' variant="outlined" onClick={deleteMode} disabled={newMode.inUse} title={newMode.inUse ? 'Mode that is in use cannot be deleted' : ''}>
+                    <Button variant="outlined" onClick={deleteMode} disabled={newMode.inUse} title={newMode.inUse ? 'Mode that is in use cannot be deleted' : ''}>
                         {deleteIcon} Delete
                     </Button>
                 }
                 <ButtonSpacer />
                 {newMode.isVoided &&
-                    <Button className='buttonIcon' variant="outlined" onClick={unvoidMode}>
+                    <Button variant="outlined" onClick={unvoidMode}>
                         {unvoidIcon} Unvoid
                     </Button>
                 }
                 {!newMode.isVoided && newMode.id != -1 &&
-                    <Button className='buttonIcon' variant="outlined" onClick={voidMode}>
+                    <Button variant="outlined" onClick={voidMode}>
                         {voidIcon} Void
                     </Button>
                 }

--- a/src/modules/PlantConfig/views/Library/Mode/Mode.tsx
+++ b/src/modules/PlantConfig/views/Library/Mode/Mode.tsx
@@ -9,10 +9,10 @@ import { showSnackbarNotification } from '@procosys/core/services/NotificationSe
 import { useDirtyContext } from '@procosys/core/DirtyContext';
 import { usePlantConfigContext } from '@procosys/modules/PlantConfig/context/PlantConfigContext';
 
-const deleteIcon = <EdsIcon name='delete_to_trash' size={16} />;
-const addIcon = <EdsIcon name='add' size={16} />;
-const voidIcon = <EdsIcon name='delete_forever' size={16} />;
-const unvoidIcon = <EdsIcon name='restore_from_trash' size={16} />;
+const deleteIcon = <EdsIcon name='delete_to_trash'/>;
+const addIcon = <EdsIcon name='add'/>;
+const voidIcon = <EdsIcon name='delete_forever'/>;
+const unvoidIcon = <EdsIcon name='restore_from_trash'/>;
 const baseBreadcrumb = 'Library / Modes';
 
 interface ModeItem {

--- a/src/modules/PlantConfig/views/Library/PreservationJourney/PreservationJourney.style.ts
+++ b/src/modules/PlantConfig/views/Library/PreservationJourney/PreservationJourney.style.ts
@@ -40,9 +40,6 @@ export const ButtonContainer = styled.div`
     display: flex;
     width: 100%;
     justify-content: flex-end;
-    .buttonIcon svg {
-        padding-right: var(--grid-unit);
-    }
 `;
 
 export const IconContainer = styled.div`

--- a/src/modules/PlantConfig/views/Library/PreservationJourney/PreservationJourney.style.ts
+++ b/src/modules/PlantConfig/views/Library/PreservationJourney/PreservationJourney.style.ts
@@ -9,9 +9,6 @@ export const FormFieldSpacer = styled.div`
     display: flex;
     margin-right: calc(var(--grid-unit) * 2);
     padding-bottom: var(--grid-unit);
-    .voidUnvoid svg {
-        padding-right: var(--grid-unit);
-    }
 `;
 
 export const InputContainer = styled.div`

--- a/src/modules/PlantConfig/views/Library/PreservationJourney/PreservationJourney.tsx
+++ b/src/modules/PlantConfig/views/Library/PreservationJourney/PreservationJourney.tsx
@@ -13,13 +13,13 @@ import { showSnackbarNotification } from '@procosys/core/services/NotificationSe
 import { useDirtyContext } from '@procosys/core/DirtyContext';
 import { usePlantConfigContext } from '@procosys/modules/PlantConfig/context/PlantConfigContext';
 
-const addIcon = <EdsIcon name='add' size={16} />;
-const upIcon = <EdsIcon name='arrow_up' size={16} />;
-const downIcon = <EdsIcon name='arrow_down' size={16} />;
-const deleteIcon = <EdsIcon name='delete_to_trash' size={16} />;
-const duplicateIcon = <EdsIcon name='copy' size={16} />;
-const voidIcon = <EdsIcon name='delete_forever' size={16} />;
-const unvoidIcon = <EdsIcon name='restore_from_trash' size={16} />;
+const addIcon = <EdsIcon name='add'/>;
+const upIcon = <EdsIcon name='arrow_up'/>;
+const downIcon = <EdsIcon name='arrow_down'/>;
+const deleteIcon = <EdsIcon name='delete_to_trash'/>;
+const duplicateIcon = <EdsIcon name='copy'/>;
+const voidIcon = <EdsIcon name='delete_forever'/>;
+const unvoidIcon = <EdsIcon name='restore_from_trash'/>;
 
 const saveTitle = 'If you have changes to save, check that all fields are filled in, no titles are identical, and if you have a supplier step it must be the first step.';
 const baseBreadcrumb = 'Library / Preservation journeys';
@@ -778,13 +778,13 @@ const PreservationJourney = (props: PreservationJourneyProps): JSX.Element => {
                                             </Button>)
                                         }
                                         {(step.id != -1 && !step.isVoided) &&
-                                            (<Button disabled={canSave} className='voidUnvoid' variant='ghost' onClick={(): Promise<void> => voidStep(step)}>
+                                            (<Button disabled={canSave} variant='ghost' onClick={(): Promise<void> => voidStep(step)}>
                                                 {voidIcon} Void
                                             </Button>)
                                         }
 
                                         {(step.id != -1 && step.isVoided) &&
-                                            (<Button disabled={canSave} className='voidUnvoid' variant='ghost' onClick={(): Promise<void> => unvoidStep(step)}>
+                                            (<Button disabled={canSave} variant='ghost' onClick={(): Promise<void> => unvoidStep(step)}>
                                                 {unvoidIcon} Unvoid
                                             </Button>)
                                         }

--- a/src/modules/PlantConfig/views/Library/PreservationJourney/PreservationJourney.tsx
+++ b/src/modules/PlantConfig/views/Library/PreservationJourney/PreservationJourney.tsx
@@ -619,24 +619,24 @@ const PreservationJourney = (props: PreservationJourneyProps): JSX.Element => {
             }
             <ButtonContainer>
                 {newJourney.isVoided && newJourney.id != -1 &&
-                    <Button className='buttonIcon' variant="outlined" onClick={deleteJourney} disabled={newJourney.isInUse} title={newJourney.isInUse ? 'Journey that is in use cannot be deleted' : ''}>
+                    <Button variant="outlined" onClick={deleteJourney} disabled={newJourney.isInUse} title={newJourney.isInUse ? 'Journey that is in use cannot be deleted' : ''}>
                         {deleteIcon} Delete
                     </Button>
                 }
                 <ButtonSpacer />
                 {!newJourney.isVoided && newJourney.id != -1 &&
-                    < Button className='buttonIcon' variant="outlined" onClick={duplicateJourney}>
+                    < Button  variant="outlined" onClick={duplicateJourney}>
                         {duplicateIcon} Duplicate
                     </Button>
                 }
                 <ButtonSpacer />
                 {newJourney.isVoided &&
-                    <Button className='buttonIcon' variant="outlined" onClick={unvoidJourney}>
+                    <Button variant="outlined" onClick={unvoidJourney}>
                         {unvoidIcon} Unvoid
                     </Button>
                 }
                 {!newJourney.isVoided && newJourney.id != -1 &&
-                    <Button className='buttonIcon' variant="outlined" onClick={voidJourney}>
+                    <Button variant="outlined" onClick={voidJourney}>
                         {voidIcon} Void
                     </Button>
                 }

--- a/src/modules/PlantConfig/views/Library/PreservationRequirements/PreservationRequirementDefinition.tsx
+++ b/src/modules/PlantConfig/views/Library/PreservationRequirements/PreservationRequirementDefinition.tsx
@@ -14,12 +14,12 @@ import { tokens } from '@equinor/eds-tokens';
 import { useDirtyContext } from '@procosys/core/DirtyContext';
 import { usePlantConfigContext } from '@procosys/modules/PlantConfig/context/PlantConfigContext';
 
-const addIcon = <EdsIcon name='add' size={16} />;
-const upIcon = <EdsIcon name='arrow_up' size={16} />;
-const downIcon = <EdsIcon name='arrow_down' size={16} />;
-const deleteIcon = <EdsIcon name='delete_to_trash' size={16} />;
-const voidIcon = <EdsIcon name='delete_forever' size={16} />;
-const unvoidIcon = <EdsIcon name='restore_from_trash' size={16} />;
+const addIcon = <EdsIcon name='add'/>;
+const upIcon = <EdsIcon name='arrow_up'/>;
+const downIcon = <EdsIcon name='arrow_down'/>;
+const deleteIcon = <EdsIcon name='delete_to_trash'/>;
+const voidIcon = <EdsIcon name='delete_forever'/>;
+const unvoidIcon = <EdsIcon name='restore_from_trash'/>;
 
 interface RequirementDefinitionItem {
     id: number;
@@ -450,19 +450,19 @@ const PreservationRequirementDefinition = (props: PreservationRequirementDefinit
             <ButtonContainer>
                 {newRequirementDefinition.isVoided && newRequirementDefinition.id != -1 &&
                     <>
-                        <Button className='buttonIcon' variant="outlined" onClick={deleteRequirementDefinition} disabled={!canDeleteReqDef()} title={newRequirementDefinition.isInUse ? 'Requirement definition that is in use or has fields, cannot be deleted.' : ''}>
+                        <Button variant="outlined" onClick={deleteRequirementDefinition} disabled={!canDeleteReqDef()} title={newRequirementDefinition.isInUse ? 'Requirement definition that is in use or has fields, cannot be deleted.' : ''}>
                             {deleteIcon} Delete
                         </Button>
                         <ButtonSpacer />
                     </>
                 }
                 {newRequirementDefinition.isVoided &&
-                    <Button className='buttonIcon' variant='outlined' onClick={unvoidRequirementDefinition}>
+                    <Button variant='outlined' onClick={unvoidRequirementDefinition}>
                         {unvoidIcon} Unvoid
                     </Button>
                 }
                 {!newRequirementDefinition.isVoided && newRequirementDefinition.id != -1 &&
-                    < Button className='buttonIcon' variant='outlined' onClick={voidRequirementDefinition}>
+                    < Button variant='outlined' onClick={voidRequirementDefinition}>
                         {voidIcon} Void
                     </Button>
                 }
@@ -640,7 +640,7 @@ const PreservationRequirementDefinition = (props: PreservationRequirementDefinit
                                     </Button>)
                                 }
                                 {(!field.isVoided && field.id != null) &&
-                                    (<Button disabled={newRequirementDefinition.isVoided} className='voidUnvoid' variant='ghost'
+                                    (<Button disabled={newRequirementDefinition.isVoided} variant='ghost'
                                         onClick={(): void => {
                                             field.isVoided = true;
                                             setNewRequirementDefinition(cloneRequirementDefinition(newRequirementDefinition));
@@ -649,7 +649,7 @@ const PreservationRequirementDefinition = (props: PreservationRequirementDefinit
                                     </Button>)
                                 }
                                 {(field.isVoided) &&
-                                    (<Button disabled={newRequirementDefinition.isVoided} className='voidUnvoid' variant='ghost'
+                                    (<Button disabled={newRequirementDefinition.isVoided} variant='ghost'
                                         onClick={(): void => {
                                             field.isVoided = false;
                                             setNewRequirementDefinition(cloneRequirementDefinition(newRequirementDefinition));

--- a/src/modules/PlantConfig/views/Library/PreservationRequirements/PreservationRequirements.style.ts
+++ b/src/modules/PlantConfig/views/Library/PreservationRequirements/PreservationRequirements.style.ts
@@ -8,9 +8,6 @@ export const FormFieldSpacer = styled.div`
     display: flex;
     margin-right: calc(var(--grid-unit) * 2);
     padding-bottom: var(--grid-unit);
-    .voidUnvoid svg {
-        padding-right: var(--grid-unit);
-    }
 `;
 
 export const InputContainer = styled.div`
@@ -31,9 +28,6 @@ export const ButtonContainer = styled.div`
     display: flex;
     width: 100%;
     justify-content: flex-end;
-    .buttonIcon svg {
-        padding-right: var(--grid-unit);
-    }
 `;
 
 export const IconContainer = styled.div`

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.style.ts
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.style.ts
@@ -68,10 +68,6 @@ export const StyledButton = styled(Button)`
     display: flex;
     align-items: center;
     justify-content: center;
-
-    .iconNextToText {
-        height: calc(var(--grid-unit) * 2);
-    }
 `;
 
 interface DropdownProps {

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
@@ -689,7 +689,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
                             title='Start preservation for selected tag(s)'
                             onClick={startPreservationDialog}
                             disabled={!startableTagsSelected}>
-                            <div className='iconNextToText' ><EdsIcon name='play' color={!startableTagsSelected ? tokens.colors.interactive.disabled__border.rgba : ''} /></div>
+                            <EdsIcon name='play' color={!startableTagsSelected ? tokens.colors.interactive.disabled__border.rgba : ''} />
                         Start
                         </StyledButton>
                         <StyledButton
@@ -697,7 +697,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
                             title="Transfer selected tag(s)"
                             onClick={transferDialog}
                             disabled={!transferableTagsSelected}>
-                            <div className='iconNextToText' ><EdsIcon name='fast_forward' color={!transferableTagsSelected ? tokens.colors.interactive.disabled__border.rgba : ''} /></div>
+                            <EdsIcon name='fast_forward' color={!transferableTagsSelected ? tokens.colors.interactive.disabled__border.rgba : ''} />
                         Transfer
                         </StyledButton>
                         <StyledButton
@@ -705,7 +705,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
                             title="Complete selected tag(s)"
                             onClick={showCompleteDialog}
                             disabled={!completableTagsSelected}>
-                            <div className='iconNextToText' ><EdsIcon name='done_all' color={!completableTagsSelected ? tokens.colors.interactive.disabled__border.rgba : ''} /></div>
+                            <EdsIcon name='done_all' color={!completableTagsSelected ? tokens.colors.interactive.disabled__border.rgba : ''} />
                         Complete
                         </StyledButton>
                         <OptionsDropdown


### PR DESCRIPTION
Standard icon size on buttons are 24px according to EDS, and so this should be used by us as well (Jon has confirmed this). We started to work around this, and using 16px, but starting IPO I see that doing this fix ASAP is beneficial, as we dont need to specify sizes now, to undo this later.