### PR TITLE
Remove dynamic ScopeTable height

### DIFF
--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
@@ -28,8 +28,6 @@ import { showSnackbarNotification } from '../../../../core/services/Notification
 import { tokens } from '@equinor/eds-tokens';
 import { usePreservationContext } from '../../context/PreservationContext';
 
-
-
 export const getFirstUpcomingRequirement = (tag: PreservedTag): Requirement | null => {
     if (!tag.requirements || tag.requirements.length === 0) {
         return null;
@@ -801,7 +799,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
                     setFirstPageSelected={(): void => setResetTablePaging(false)}
                     setOrderByField={setOrderByField}
                     setOrderDirection={setOrderDirection}
-                    maxHeight={moduleAreaHeight && moduleAreaHeight - 300}
+                    maxHeight={moduleAreaHeight}
                 />
                 {
                     displayFlyout && (

--- a/src/modules/Preservation/views/ScopeOverview/ScopeTable.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeTable.tsx
@@ -42,7 +42,6 @@ class ScopeTable extends React.Component<ScopeTableProps> {
     }
 
     shouldComponentUpdate(nextProps: ScopeTableProps): boolean {
-        if (this.props.maxHeight != nextProps.maxHeight) return true;
         return false;
     }
 


### PR DESCRIPTION
Temporary fix as not to halt the testing. But eliminates the added responsivenes to ScopeTable. 

DevOps#78285

Follow-up case: DevOps#78287