### PR TITLE
Support aquire token in safari

### DIFF
--- a/src/core/UserContext.tsx
+++ b/src/core/UserContext.tsx
@@ -42,6 +42,7 @@ export const UserContextProvider: React.FC = (props): JSX.Element => {
             const plantResponse = await procosysApiClient.getAllPlantsForUserAsync((c) => {plantRequestCanceler = c;});
             setPlants(plantResponse);
         } catch (error) {
+            console.error(error);
             setErrorEncountered(true);
         }
 

--- a/src/http/ApiClient.ts
+++ b/src/http/ApiClient.ts
@@ -24,16 +24,10 @@ export default class ApiClient extends HttpClient {
             if (!this.authService) throw 'Missing authService initialization in API client';
             try {
                 const accessToken = await this.authService.getAccessTokenAsync(resource);
+                if (!accessToken) throw 'Failed to get AccessToken';
                 config.headers.common['Authorization'] = 'Bearer ' + accessToken.token;
             } catch (authError) {
-                if (['login_required'].indexOf(authError.errorCode) !== -1) {
-                    this.authService.login();
-                    return config;
-                }
-                if (['consent_required', 'interaction_required', 'login_required'].indexOf(authError.errorCode) !== -1) {
-                    this.authService.aquireConcent(resource);
-                    return config;
-                }
+                console.error('Failed to aquire token', authError);
                 throw authError;
             }
 


### PR DESCRIPTION
Safari blocks all 3rd party cookies when doing ajax requests. This causes microsoft to always return "login_required" when trying to aquire a token silently. 

Closes DevOps#78321