### PR TITLE
Add error boundary component

### DIFF
--- a/src/app/ProcosysRouter.tsx
+++ b/src/app/ProcosysRouter.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react-router-dom';
 
 import { DirtyContextProvider } from '../core/DirtyContext';
+import ErrorBoundary from '@procosys/components/ErrorBoundary';
 import Header from '../modules/Header';
 import LazyRoute from '../components/LazyRoute';
 import { PlantContextProvider } from '../core/PlantContext';
@@ -36,7 +37,7 @@ const ProcosysRouter = (): JSX.Element => {
                                 path={path}
                                 exact
                                 component={(routeProps: RouteComponentProps): JSX.Element =>
-                                    LazyRoute(UserGreeting, routeProps)
+                                    <ErrorBoundary>{LazyRoute(UserGreeting, routeProps)}</ErrorBoundary>
                                 }
                             />
                             <Route

--- a/src/components/ErrorBoundary/ErrorBoundary.style.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.style.tsx
@@ -5,4 +5,5 @@ export const ErrorBoundaryContainer = styled.div`
     justify-content: center;
     align-items: center;
     flex: 1;
+    flex-direction: column;
 `;

--- a/src/components/ErrorBoundary/ErrorBoundary.style.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.style.tsx
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const ErrorBoundaryContainer = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex: 1;
+`;

--- a/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.jsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.jsx
@@ -16,7 +16,7 @@ describe('<ErrorBoundary />', () => {
     console.error = jest.fn();
     it('Renders error with default message', () => {
         const { getByText } = render(<ErrorBoundary><FaultyComponent /></ErrorBoundary>);
-        expect(getByText('Sorry, an unexpected error occured')).toBeInTheDocument();
+        expect(getByText('An unexpected error occured')).toBeInTheDocument();
     });
 
     it('Renders error with custom error message', () => {
@@ -24,7 +24,7 @@ describe('<ErrorBoundary />', () => {
         expect(getByText('My custom error')).toBeInTheDocument();
     });
 
-    it('Renders error with custom error message', () => {
+    it('Renders component without error', () => {
         const { getByText } = render(<ErrorBoundary><SuccessfullComponent /></ErrorBoundary>);
         expect(getByText('Hello')).toBeInTheDocument();
     });

--- a/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.jsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.jsx
@@ -1,0 +1,31 @@
+import ErrorBoundary from '..';
+import React from 'react';
+import { render } from '@testing-library/react';
+
+const FaultyComponent = () => {
+    throw 'This is an expected error from ErrorBoundary';
+};
+
+const SuccessfullComponent = () => {
+    return <p>Hello</p>;
+};
+
+
+describe('<ErrorBoundary />', () => {
+    // just prevent it from cluttering the log statements from test
+    console.error = jest.fn();
+    it('Renders error with default message', () => {
+        const { getByText } = render(<ErrorBoundary><FaultyComponent /></ErrorBoundary>);
+        expect(getByText('Sorry, an unexpected error occured')).toBeInTheDocument();
+    });
+
+    it('Renders error with custom error message', () => {
+        const { getByText } = render(<ErrorBoundary message="My custom error"><FaultyComponent /></ErrorBoundary>);
+        expect(getByText('My custom error')).toBeInTheDocument();
+    });
+
+    it('Renders error with custom error message', () => {
+        const { getByText } = render(<ErrorBoundary><SuccessfullComponent /></ErrorBoundary>);
+        expect(getByText('Hello')).toBeInTheDocument();
+    });
+});

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -32,7 +32,13 @@ class ErrorBoundary extends React.Component<ErrorProps, ErrorState> {
         if (this.state.hasError) {
             return (
                 <ErrorBoundaryContainer>
-                    <Typography variant="h1">{!this.props.message ? 'Sorry, an unexpected error occured' : this.props.message}</Typography>
+                    <Typography variant="h1">{!this.props.message ? 'An unexpected error occured' : this.props.message}</Typography>
+                    {!this.props.message && (
+                        <>
+                            <Typography variant="h4">Please try to <a href="#" onClick={(): void => window.location.reload()}>refresh</a> the page, and see if the error persists.</Typography>
+                            <Typography variant="h6">The incident has been logged, contact support if the error is not resolved.</Typography>
+                        </>
+                    )}
                 </ErrorBoundaryContainer>);
         }
 

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -1,0 +1,43 @@
+import React, { ErrorInfo } from 'react';
+
+import { ErrorBoundaryContainer } from './ErrorBoundary.style';
+import { Typography } from '@equinor/eds-core-react';
+
+type ErrorProps = {
+    message?: string;
+    children: React.ReactChild;
+}
+
+type ErrorState = {
+    hasError: boolean;
+}
+
+class ErrorBoundary extends React.Component<ErrorProps, ErrorState> {
+    constructor(props: ErrorProps) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError(): ErrorState {
+        return { hasError: true };
+    }
+
+    componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+        console.error('CRITICAL ERROR OCCURED');
+        console.error('Error: ', error);
+        console.error('ErrorInfo: ', errorInfo);
+    }
+
+    render(): React.ReactChild {
+        if (this.state.hasError) {
+            return (
+                <ErrorBoundaryContainer>
+                    <Typography variant="h1">{!this.props.message ? 'Sorry, an unexpected error occured' : this.props.message}</Typography>
+                </ErrorBoundaryContainer>);
+        }
+
+        return this.props.children;
+    }
+}
+
+export default ErrorBoundary;

--- a/src/modules/Preservation/index.tsx
+++ b/src/modules/Preservation/index.tsx
@@ -1,12 +1,13 @@
+import React, { ReactElement } from 'react';
 import { Route, BrowserRouter as Router, Switch, useRouteMatch } from 'react-router-dom';
 
 import AddScope from './views/AddScope/AddScope';
+import ClosedProjectWarning from './ClosedProjectWarning';
 import EditTagProperties from './views/EditTagProperties/EditTagProperties';
+import ErrorBoundary from '@procosys/components/ErrorBoundary';
 import { PreservationContextProvider } from './context/PreservationContext';
-import React from 'react';
 import ScopeOverview from './views/ScopeOverview/ScopeOverview';
 import withAccessControl from '../../core/security/withAccessControl';
-import ClosedProjectWarning from './ClosedProjectWarning';
 
 const Preservation = (): JSX.Element => {
 
@@ -20,17 +21,17 @@ const Preservation = (): JSX.Element => {
                     <Route
                         path={'/AddScope/:method'}
                         exact
-                        component={AddScope}
+                        component={(): ReactElement => (<ErrorBoundary><AddScope /></ErrorBoundary>)}
                     />
                     <Route
                         path={'/'}
                         exact
-                        component={ScopeOverview}
+                        component={(): ReactElement => (<ErrorBoundary><ScopeOverview /></ErrorBoundary>)}
                     />
                     <Route
                         path={'/EditTagProperties/:tagId'}
                         exact
-                        component={EditTagProperties}
+                        component={(): ReactElement => (<ErrorBoundary><EditTagProperties /></ErrorBoundary>)}
                     />
                     <Route
                         component={(): JSX.Element =>


### PR DESCRIPTION
This adds a component that will prevent your other components or modules from crashing the entire application if an error occures. 

Usage: 
```js
<ErrorBoundary message="Optional custom error message" >
    <SuccessfullComponent />
</ErrorBoundary>
```

Important: 
Its always the mounting component that has to add the ErrorBoundary to the application. Not the component that the error is emerging from. 

So this does not work as a wrapper for every component, but rather as a wrapper that is added at the usage point. 

In the example above, that means that <SuccessFullComponent> can not have "its own protection" by just wrapping its return statement with <ErrorBoundary>

Example - will not work: 
```js
const myFaultFunction = () => throw 'error'

const SuccessfullComponent = () => {
    return (<ErrorBoundary><p>{myFaultyFunction()}</p></ErrorBoundary>
}
```

Example - will work: 
```js
const myFaultFunction = () => throw 'error'

const SuccessfullComponent = () => {
    return (<p>{myFaultyFunction()}</p>)
}

const ParentComponent = () => {
    return (<ErrorBoundary><SuccessfullComponent /></ErrorBoundary>)
}
```