### PR TITLE
Introduce loading state for permissions

### DIFF
--- a/src/core/PlantContext.tsx
+++ b/src/core/PlantContext.tsx
@@ -1,14 +1,16 @@
-import React, {useEffect, useState} from 'react';
+import React, { useEffect, useState } from 'react';
 
+import Axios from 'axios';
 import CacheService from './CacheService';
+import { Canceler } from '../http/HttpClient';
 import ErrorComponent from '../components/Error';
 import Loading from '../components/Loading';
 import propTypes from 'prop-types';
+import { useAnalytics } from './services/Analytics/AnalyticsContext';
 import { useCurrentUser } from './UserContext';
 import { useParams } from 'react-router-dom';
 import { useProcosysContext } from './ProcosysContext';
 import useRouter from '../hooks/useRouter';
-import { Canceler } from '../http/HttpClient';
 
 type PlantContextDetails = {
     id: string;
@@ -23,16 +25,22 @@ type PlantContextProps = {
     permissions: string[];
 }
 
-class InvalidParameterException extends Error {}
+type LoadingState = {
+    permissions: boolean;
+}
+
+class InvalidParameterException extends Error { }
 
 const cache = new CacheService('Default', localStorage);
 
-export const PlantContextProvider: React.FC = ({children}): JSX.Element => {
+export const PlantContextProvider: React.FC = ({ children }): JSX.Element => {
     const user = useCurrentUser();
-    const {procosysApiClient} = useProcosysContext();
-    const {history, location} = useRouter();
-    const {plant: plantInPath} = useParams() as any;
+    const { procosysApiClient } = useProcosysContext();
+    const { history, location } = useRouter();
+    const { plant: plantInPath } = useParams() as any;
     const [permissions, setPermissions] = useState<string[]>([]);
+    const [isLoading, setIsLoading] = useState<LoadingState>({ permissions: true });
+    const analytics = useAnalytics();
 
     if (!plantInPath || plantInPath === '') {
         return <ErrorComponent title='Missing plant in path' />;
@@ -40,11 +48,11 @@ export const PlantContextProvider: React.FC = ({children}): JSX.Element => {
 
     const [currentPlant, setCurrentPlantInContext] = useState<PlantContextDetails>(() => {
         const plant = user.plants.filter(plant => plant.id === `PCS$${plantInPath}`)[0];
-        return {id: plant.id, title: plant.title, pathId: plantInPath};
+        return { id: plant.id, title: plant.title, pathId: plantInPath };
     });
 
     const setCurrentPlant = (plantId: string): void => {
-        const normalizedPlantId = (plantId.indexOf('PCS$') != -1 && plantId.replace('PCS$','')) || plantId;
+        const normalizedPlantId = (plantId.indexOf('PCS$') != -1 && plantId.replace('PCS$', '')) || plantId;
         const plantsFiltered = user.plants.filter(plant => plant.id === `PCS$${normalizedPlantId}`);
         if (plantsFiltered.length <= 0) {
             throw new InvalidParameterException(`PlantID: ${plantId} does not exist`);
@@ -58,7 +66,7 @@ export const PlantContextProvider: React.FC = ({children}): JSX.Element => {
     useEffect(() => {
         if (!currentPlant || currentPlant.pathId === plantInPath) return;
         let newPath = `/${currentPlant.pathId}`;
-        newPath = location.pathname.replace(plantInPath,currentPlant.pathId);
+        newPath = location.pathname.replace(plantInPath, currentPlant.pathId);
         history.push(newPath);
     }, [currentPlant]);
 
@@ -66,11 +74,18 @@ export const PlantContextProvider: React.FC = ({children}): JSX.Element => {
         procosysApiClient.setCurrentPlant(currentPlant.id);
         let requestCanceler: Canceler;
         (async (): Promise<void> => {
-            const permissions = await procosysApiClient.getPermissionsForCurrentUser((e) => requestCanceler = e);
-            setPermissions(permissions);
+            try {
+                const permissions = await procosysApiClient.getPermissionsForCurrentUser((e) => requestCanceler = e);
+                setPermissions(permissions);
+            } catch (error) {
+                if (Axios.isCancel(error)) return;
+                console.error('Failed to load permissions', error);
+                analytics.trackException(error);
+            }
+            setIsLoading((currentLoadingState) => ({ ...currentLoadingState, permissions: false }));
         })();
         return (): void => requestCanceler && requestCanceler();
-    },[currentPlant]);
+    }, [currentPlant]);
 
     useEffect(() => {
         setCurrentPlant(plantInPath);
@@ -78,6 +93,9 @@ export const PlantContextProvider: React.FC = ({children}): JSX.Element => {
 
     if (!currentPlant) {
         return (<Loading title="Loading plant information" />);
+    }
+    if (isLoading.permissions) {
+        return (<Loading title="Loading plant permissions" />);
     }
 
     return (


### PR DESCRIPTION
Adds a loading indicator to permissions, which also prevents modules to load before data is ready and showing "Access restricted" while waiting for permissions to finish downloading. 