### PR TITLE
Bug 79015: UI can not remove selected mc pkgs (comm pkgs)

### DIFF
--- a/src/modules/InvitationForPunchOut/views/CreateIPO/SelectScope/McPkgTable.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateIPO/SelectScope/McPkgTable.tsx
@@ -1,14 +1,15 @@
-import React, { useEffect, useState, useImperativeHandle, forwardRef } from 'react';
-import { Container, TopContainer, Search } from './Table.style';
-import Table from '@procosys/components/Table';
-import { tokens } from '@equinor/eds-tokens';
-import { Canceler } from '@procosys/http/HttpClient';
+import { Container, Search, TopContainer } from './Table.style';
 import { McPkgRow, McScope } from '@procosys/modules/InvitationForPunchOut/types';
-import { Tooltip } from '@material-ui/core';
-import { TextField } from '@equinor/eds-core-react';
-import { useInvitationForPunchOutContext } from '@procosys/modules/InvitationForPunchOut/context/InvitationForPunchOutContext';
-import { showSnackbarNotification } from '@procosys/core/services/NotificationService';
+import React, { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
+
+import { Canceler } from '@procosys/http/HttpClient';
 import Loading from '@procosys/components/Loading';
+import Table from '@procosys/components/Table';
+import { TextField } from '@equinor/eds-core-react';
+import { Tooltip } from '@material-ui/core';
+import { showSnackbarNotification } from '@procosys/core/services/NotificationService';
+import { tokens } from '@equinor/eds-tokens';
+import { useInvitationForPunchOutContext } from '@procosys/modules/InvitationForPunchOut/context/InvitationForPunchOutContext';
 
 interface McPkgTableProps {
     selectedMcPkgScope: McScope;
@@ -18,6 +19,16 @@ interface McPkgTableProps {
 }
 
 const KEYCODE_ENTER = 13;
+
+export const multipleDisciplines = (selected: McPkgRow[]): boolean => {
+    if(selected.length > 0) {
+        const initialDiscipline = selected[0].discipline;
+        if(selected.some(mc => mc.discipline !== initialDiscipline)) {
+            return true;
+        }
+    }
+    return false;
+};
 
 const McPkgTable = forwardRef(({
     selectedMcPkgScope,
@@ -73,15 +84,6 @@ const McPkgTable = forwardRef(({
         }));
     }, [filter]);
 
-    const multipleDisciplines = (selected: McPkgRow[]): boolean => {
-        if(selected.length > 0) {
-            const initialDiscipline = selected[0].discipline;
-            if(selected.some(mc => mc.discipline !== initialDiscipline)) {
-                return true;
-            }
-        }
-        return false;
-    };
 
     const unselectMcPkg = (mcPkgNo: string): void => {
         const selectedIndex = selectedMcPkgScope.selected.findIndex(mcPkg => mcPkg.mcPkgNo === mcPkgNo);

--- a/src/modules/InvitationForPunchOut/views/CreateIPO/SelectScope/SelectScope.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateIPO/SelectScope/SelectScope.tsx
@@ -1,11 +1,11 @@
 import { Button, Typography } from '@equinor/eds-core-react';
 import { CommPkgRow, McScope } from '@procosys/modules/InvitationForPunchOut/types';
 import { Container, Divider, Header, SelectComponent } from './SelectScope.style';
+import McPkgTable, { multipleDisciplines } from './McPkgTable';
 import React, { useEffect, useRef, useState } from 'react';
 
 import CommPkgTable from './CommPkgTable';
 import EdsIcon from '@procosys/components/EdsIcon';
-import McPkgTable from './McPkgTable';
 import SelectedScope from './SelectedScope';
 
 interface SelectScopeProps {
@@ -38,6 +38,34 @@ const SelectScope = ({
             setCurrentCommPkg(commPkgNo);
         }
     }, []);
+
+    
+    const handleRemoveMcPkg = (mcPkgNo: string): void => {
+        if (mcPkgRef.current) {
+            mcPkgRef.current.removeSelectedMcPkg(mcPkgNo);
+        } else {
+            const selectedIndex = selectedMcPkgScope.selected.findIndex(mcPkg => mcPkg.mcPkgNo === mcPkgNo);
+            if (selectedIndex > -1) {
+                // remove from selected mcPkgs
+                const newSelected = [...selectedMcPkgScope.selected.slice(0, selectedIndex), ...selectedMcPkgScope.selected.slice(selectedIndex + 1)];
+                const newSelectedMcPkgScope = {commPkgNoParent: newSelected.length > 0 ? selectedMcPkgScope.commPkgNoParent : null, multipleDisciplines: multipleDisciplines(newSelected), selected: newSelected};
+                setSelectedMcPkgScope(newSelectedMcPkgScope);
+            }
+        }
+    };
+
+    const handleRemoveCommPkg = (commPkgNo: string): void => {
+        if (commPkgRef.current) {
+            commPkgRef.current.removeSelectedCommPkg(commPkgNo);
+        } else {
+            const selectedIndex = selectedCommPkgScope.findIndex(commPkg => commPkg.commPkgNo === commPkgNo);
+            if (selectedIndex > -1) {
+            // remove from selected commPkgs
+                const newSelectedCommPkgScope = [...selectedCommPkgScope.slice(0, selectedIndex), ...selectedCommPkgScope.slice(selectedIndex + 1)];
+                setSelectedCommPkgScope(newSelectedCommPkgScope);
+            }
+        }
+    };
 
     return (     
         <Container>
@@ -81,9 +109,9 @@ const SelectScope = ({
             <Divider />
             <SelectedScope 
                 selectedCommPkgs={selectedCommPkgScope} 
-                removeCommPkg={(commPkgNo: string): void => commPkgRef.current.removeSelectedCommPkg(commPkgNo)}
+                removeCommPkg={(commPkgNo: string): void => handleRemoveCommPkg(commPkgNo)}
                 selectedMcPkgs={selectedMcPkgScope.selected} 
-                removeMcPkg={(mcPkgNo: string): void => mcPkgRef.current.removeSelectedMcPkg(mcPkgNo)}
+                removeMcPkg={(mcPkgNo: string): void => handleRemoveMcPkg(mcPkgNo)}
                 multipleDisciplines={selectedMcPkgScope.multipleDisciplines}
             />
         </Container>


### PR DESCRIPTION
# Description

- Add handlers in SelectScope
- Export multidisciplines function from McPkgTable

Completes: [AB#79015](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/79015)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [x] My code is covered by tests.
