### PR TITLE
Bug 79944: UI - Entering  0 hours in AM/PM 

### DIFF
--- a/src/modules/InvitationForPunchOut/views/CreateIPO/GeneralInfo/GeneralInfo.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateIPO/GeneralInfo/GeneralInfo.tsx
@@ -95,15 +95,17 @@ const GeneralInfo = ({
 
     const handleSetTime = (from: 'start' | 'end', timeString: string): void => {
         const timeSplit = timeString.split(':');
-        if (from === 'start') {
-            const newTime = set(generalInfo.startTime, { hours: Number(timeSplit[0]), minutes: Number(timeSplit[1]) });
-            const newEndTime = newTime > generalInfo.endTime ? getEndTime(newTime) : generalInfo.endTime;
-            setGeneralInfo(gi => { return { ...gi, startTime: newTime, endTime: newEndTime }; });
-            setErrorFormat(newTime >= newEndTime);
-        } else {
-            const newEndTime = set(generalInfo.endTime, { hours: Number(timeSplit[0]), minutes: Number(timeSplit[1]) });
-            setGeneralInfo(gi => { return { ...gi, endTime: newEndTime }; });
-            setErrorFormat(generalInfo.startTime >= newEndTime);
+        if (timeSplit[0] && timeSplit[1]) {
+            if (from === 'start') {
+                const newTime = set(generalInfo.startTime, { hours: Number(timeSplit[0]), minutes: Number(timeSplit[1]) });
+                const newEndTime = newTime > generalInfo.endTime ? getEndTime(newTime) : generalInfo.endTime;
+                setGeneralInfo(gi => { return { ...gi, startTime: newTime, endTime: newEndTime }; });
+                setErrorFormat(newTime >= newEndTime);
+            } else {
+                const newEndTime = set(generalInfo.endTime, { hours: Number(timeSplit[0]), minutes: Number(timeSplit[1]) });
+                setGeneralInfo(gi => { return { ...gi, endTime: newEndTime }; });
+                setErrorFormat(generalInfo.startTime >= newEndTime);
+            }
         }
     };
 

--- a/src/modules/InvitationForPunchOut/views/CreateIPO/__tests__/CreateIPO.test.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateIPO/__tests__/CreateIPO.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, waitFor, within } from '@testing-library/react';
 import CreateIPO from '../CreateIPO';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
+import { configure } from '@testing-library/dom';
 
 jest.mock('react-router-dom', () => ({
     useParams: (): {projectId: any, commPkgNo: any} => ({
@@ -58,6 +59,32 @@ describe('<CreateIPO />', () => {
     it('Should render Previous button enabled', async () => {
         const { getByText } = render(<CreateIPO />);
         await waitFor(() => expect(getByText('Previous').closest('button')).toHaveProperty('disabled', true));
+    });
+
+    it('Should update end time when entering start time > end time', async () => {
+        configure({ testIdAttribute: 'id' }); // makes id attibute data-testid for subsequent tests
+        const { getByTestId } = render(<CreateIPO />);
+        const startTime = getByTestId('startTime');
+        const endTime = getByTestId('endDate');
+        fireEvent.change(startTime, { target: { value: '22:23'}});
+        await waitFor(() => expect(endTime).toHaveValue('23:23'));
+    });
+
+    it('Should not update end time when entering start time < end time', async () => {
+        const { getByTestId } = render(<CreateIPO />);
+        const startTime = getByTestId('startTime');
+        const endTime = getByTestId('endDate');
+        fireEvent.change(endTime, { target: { value: '23:23'}});
+        fireEvent.change(startTime, { target: { value: '08:23'}});
+        await waitFor(() => expect(endTime).toHaveValue('23:23'));
+    });
+
+    it('Should not update time when invalid (empty)', async () => {
+        const { getByTestId } = render(<CreateIPO />);
+        const startTime = getByTestId('startTime');
+        fireEvent.change(startTime, { target: { value: '13:30'}});
+        fireEvent.change(startTime, { target: { value: ''}});
+        await waitFor(() => expect(startTime).toHaveValue('13:30'));
     });
 });
 

--- a/src/modules/InvitationForPunchOut/views/CreateIPO/__tests__/CreateIPO.test.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateIPO/__tests__/CreateIPO.test.tsx
@@ -66,6 +66,8 @@ describe('<CreateIPO />', () => {
         const { getByTestId } = render(<CreateIPO />);
         const startTime = getByTestId('startTime');
         const endTime = getByTestId('endDate');
+        fireEvent.change(startTime, { target: { value: '08:00'}});
+        fireEvent.change(endTime, { target: { value: '09:00'}});
         fireEvent.change(startTime, { target: { value: '22:23'}});
         await waitFor(() => expect(endTime).toHaveValue('23:23'));
     });
@@ -74,8 +76,9 @@ describe('<CreateIPO />', () => {
         const { getByTestId } = render(<CreateIPO />);
         const startTime = getByTestId('startTime');
         const endTime = getByTestId('endDate');
+        fireEvent.change(startTime, { target: { value: '08:00'}});
         fireEvent.change(endTime, { target: { value: '23:23'}});
-        fireEvent.change(startTime, { target: { value: '08:23'}});
+        fireEvent.change(startTime, { target: { value: '10:23'}});
         await waitFor(() => expect(endTime).toHaveValue('23:23'));
     });
 


### PR DESCRIPTION
# Description

It appears that when entering 0 hours when locale is AM/PM, the date input returns an empty string. 
Added check: the resulting array "HH:mm" is non-empty for hours and minutes.

Completes: [AB#79944](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/79944)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [x] My code is covered by tests.
