### PR TITLE
Feature 79932: UI Set attended state from response in planned state

### DIFF
--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/__tests__/ParticipantsTable.test.jsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/__tests__/ParticipantsTable.test.jsx
@@ -1,3 +1,4 @@
+import { OutlookResponseType } from '../../../utils';
 import ParticipantsTable from '../index';
 import React from 'react';
 import { ThemeProvider } from 'styled-components';
@@ -13,7 +14,7 @@ const participants = [
         externalEmail: {
             id: 0,
             externalEmail: 'asdasd@asdasd.com',
-            response: 'None',
+            response: OutlookResponseType.NONE,
             rowVersion: '00101' 
         },
         attended: false,
@@ -28,7 +29,7 @@ const participants = [
             code: 'asdasdasd',
             email: 'funcitonalRole@asd.com',
             persons: [],
-            response: 'Attending',
+            response: OutlookResponseType.ATTENDING,
             rowVersion: '123o875'
         },        
         externalEmail: null, 
@@ -48,7 +49,7 @@ const participants = [
                 rowVersion: '123123',
             },
             required: true,
-            response: 'I shall not join',
+            response: OutlookResponseType.DECLINED,
 
         },
         externalEmail: null,        
@@ -71,7 +72,7 @@ const participants = [
                 rowVersion: '123123',
             },
             required: true,
-            response: 'Tentative',
+            response: OutlookResponseType.TENTATIVE,
 
         },
         externalEmail: null,
@@ -164,7 +165,7 @@ describe('<ParticipantsTable />', () => {
         expect(queryByText('06/12/2020 12:00')).toBeInTheDocument();
     });
 
-    it('Renders not buttons when canceled', async () => {
+    it('Should not render buttons when canceled', async () => {
         const { queryByText } = renderWithTheme(<ParticipantsTable 
             participants={participants} 
             status="Canceled"
@@ -174,6 +175,28 @@ describe('<ParticipantsTable />', () => {
         expect(queryByText('Approve punch out')).not.toBeInTheDocument();
         expect(queryByText('Complete punch out')).not.toBeInTheDocument();
         expect(queryByText('Sign punch out')).not.toBeInTheDocument();
+    });
+
+    it('Should set attended from outlook response in planned state', async () => {
+        const { queryAllByText } = renderWithTheme(<ParticipantsTable 
+            participants={participants} 
+            status="Planned"
+            accept={approvePunchOut}
+            complete={completePunchOut} />);
+
+        expect(queryAllByText('Attended').length).toBe(2); // +1 for table header
+        expect(queryAllByText('Did not attend').length).toBe(3);
+    });
+
+    it('Should set attended from participant status when not in planned state', async () => {
+        const { queryAllByText } = renderWithTheme(<ParticipantsTable 
+            participants={participants} 
+            status="Completed"
+            accept={approvePunchOut}
+            complete={completePunchOut} />);
+
+        expect(queryAllByText('Attended').length).toBe(3); // +1 for table header
+        expect(queryAllByText('Did not attend').length).toBe(2);
     });
 });
 

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
@@ -1,11 +1,11 @@
 import { Button, Switch, TextField } from '@equinor/eds-core-react';
 import { Container, CustomTable, SpinnerContainer } from './style';
-import { IpoStatusEnum, OrganizationMap, OrganizationsEnum } from '../../utils';
+import { ExternalEmail, FunctionalRole, Participant, Person } from '../../types';
+import { IpoStatusEnum, OrganizationMap, OrganizationsEnum, OutlookResponseType } from '../../utils';
 import React, { useCallback, useRef, useState } from 'react';
 
 import CustomTooltip from './CustomTooltip';
 import { Organization } from '../../../../types';
-import { Participant } from '../../types';
 import Spinner from '@procosys/components/Spinner';
 import { Table } from '@equinor/eds-core-react';
 import { format } from 'date-fns';
@@ -43,9 +43,15 @@ const ParticipantsTable = ({participants, status, complete, accept, sign }: Prop
     const [attNoteData, setAttNoteData] = useState<AttNoteData[]>(
         participants.map(p => {
             const x = p.person ? p.person.person : p.functionalRole ? p.functionalRole : p.externalEmail;
+            const attendedStatus = status === IpoStatusEnum.PLANNED ? 
+                p.person ? 
+                    p.person.response ? p.person.response === OutlookResponseType.ATTENDING : false 
+                    : (x as FunctionalRole | ExternalEmail).response ? (x as FunctionalRole | ExternalEmail).response === OutlookResponseType.ATTENDING : false 
+                : p.attended;
+
             return {
                 id: x.id,
-                attended: p.attended,
+                attended: attendedStatus,
                 note: p.note,
                 rowVersion: x.rowVersion
             };

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/OutlookInfo/__tests__/OutlookInfoTest.test.jsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/OutlookInfo/__tests__/OutlookInfoTest.test.jsx
@@ -1,7 +1,7 @@
 import OutlookInfo, { OutlookStatusType } from '../index';
 
+import { OutlookResponseType } from '../../utils';
 import React from 'react';
-import { ResponseType } from '../index';
 import { ThemeProvider } from 'styled-components';
 import { render } from '@testing-library/react';
 import theme from '../../../../../../assets/theme';
@@ -16,7 +16,7 @@ export const participants = [
                 email: 'kjhasd@lkjasd.com',
                 company: 'EQUI',
             },
-            response: ResponseType.ATTENDING
+            response: OutlookResponseType.ATTENDING
         },
     },
     {
@@ -28,7 +28,7 @@ export const participants = [
                 email: 'lkajsdkjas@equinor.com',
                 company: 'EQUI',
             },
-            response: ResponseType.TENTATIVE
+            response: OutlookResponseType.TENTATIVE
         },
     },
     {
@@ -40,7 +40,7 @@ export const participants = [
                 email: 'lkjawc@equinor.com',
                 company: 'EQUI',
             },
-            response: ResponseType.TENTATIVE
+            response: OutlookResponseType.TENTATIVE
         },
     },
     {
@@ -52,7 +52,7 @@ export const participants = [
                 email: 'jcklwaclakjj@equinor.com',
                 company: 'EQUI',
             },
-            response: ResponseType.NONE
+            response: OutlookResponseType.NONE
         },
     },
     {
@@ -64,7 +64,7 @@ export const participants = [
                 email: 'wwwwwwww@equinor.com',
                 company: 'EQUI',
             },
-            response: ResponseType.DECLINED
+            response: OutlookResponseType.DECLINED
         },
     },
     {
@@ -76,7 +76,7 @@ export const participants = [
                 email: 'clclclcwajjk@equinor.com',
                 company: 'EQUI',
             },
-            response: ResponseType.DECLINED
+            response: OutlookResponseType.DECLINED
         },
     },
     {
@@ -84,7 +84,7 @@ export const participants = [
         functionalRole: {
             code: 'asdasd',
             email: 'sadoiens@weweew.com',
-            response: ResponseType.ATTENDING
+            response: OutlookResponseType.ATTENDING
         }
     }
 ];

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/OutlookInfo/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/OutlookInfo/index.tsx
@@ -4,16 +4,9 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { Button } from '@equinor/eds-core-react';
 import EdsIcon from '@procosys/components/EdsIcon';
 import Flyout from '@procosys/components/Flyout';
+import { OutlookResponseType } from '../utils';
 import { Participant } from '../types';
 import { Typography } from '@equinor/eds-core-react';
-
-export enum ResponseType {
-    ATTENDING = 'Accepted',
-    TENTATIVE = 'Tentative',
-    NONE = 'None',
-    UNKNOWN = 'Unknown',
-    DECLINED = 'Declined'
-}
 
 export enum OutlookStatusType {
     OK = 'Ok',
@@ -39,16 +32,16 @@ const OutlookInfo = ({ close, organizer, participants, status }: Props): JSX.Ele
             const role = p.person ? p.person : p.functionalRole ? p.functionalRole : null;
             if (role) {
                 switch (role.response) {
-                    case ResponseType.ATTENDING:
+                    case OutlookResponseType.ATTENDING:
                         setAttending(a => [...a, p]);
                         break;
-                    case ResponseType.TENTATIVE:
+                    case OutlookResponseType.TENTATIVE:
                         setTentative(a => [...a, p]);
                         break;
-                    case ResponseType.NONE:
+                    case OutlookResponseType.NONE:
                         setNotResponded(a => [...a, p]);
                         break;
-                    case ResponseType.DECLINED:
+                    case OutlookResponseType.DECLINED:
                         setDeclined(a => [...a, p]);
                         break;
                     default:

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/utils.ts
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/utils.ts
@@ -1,5 +1,13 @@
 import { Organization } from '../../types';
 
+export enum OutlookResponseType {
+    ATTENDING = 'Accepted',
+    TENTATIVE = 'Tentative',
+    NONE = 'None',
+    UNKNOWN = 'Unknown',
+    DECLINED = 'Declined'
+}
+
 export enum IpoStatusEnum {
     PLANNED = 'Planned',
     COMPLETED = 'Completed',


### PR DESCRIPTION
# Description

- Add set attended status in participant table based on outlook response when in PLANNED state
- Rename and move OutlookResponseType to utils
- Add tests for attended status in participant table

Completes: [AB#79932](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/79932)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [x] My code is covered by tests.
