### PR TITLE
Feature 79599: UI Preset time is next half or full hour

### DIFF
--- a/src/modules/InvitationForPunchOut/views/CreateIPO/CreateIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateIPO/CreateIPO.tsx
@@ -1,6 +1,6 @@
 import { CommPkgRow, GeneralInfoDetails, McScope, Participant, RoleParticipant, Step } from '../../types';
 import { FunctionalRoleDto, ParticipantDto, PersonDto } from '../../http/InvitationForPunchOutApiClient';
-import { OrganizationMap, OrganizationsEnum, getEndTime } from './utils';
+import { OrganizationMap, OrganizationsEnum, getEndTime, getNextHalfHourTimeString } from './utils';
 import React, { useEffect, useState } from 'react';
 
 import Attachments from './Attachments/Attachments';
@@ -16,14 +16,16 @@ import { useInvitationForPunchOutContext } from '../../context/InvitationForPunc
 import { useParams } from 'react-router-dom';
 import useRouter from '@procosys/hooks/useRouter';
 
+const initialDate = getNextHalfHourTimeString(new Date());
+
 const emptyGeneralInfo: GeneralInfoDetails = {
     projectId: null,
     projectName: null,
     poType: null,
     title: null,
     description: null,
-    startTime: new Date(),
-    endTime: getEndTime(new Date()),
+    startTime: initialDate,
+    endTime: getEndTime(initialDate),
     location: null
 };
 

--- a/src/modules/InvitationForPunchOut/views/CreateIPO/__tests__/utils.test.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateIPO/__tests__/utils.test.tsx
@@ -1,4 +1,4 @@
-import { getEndTime } from '../utils';
+import { getEndTime, getNextHalfHourTimeString } from '../utils';
 
 describe('Create IPO utilities', () => {
     it('Function getEndTime should return date an hour later when given date with time earlier than 23:00', async () => {
@@ -19,6 +19,41 @@ describe('Create IPO utilities', () => {
         const date = new Date(2020, 11, 24, 22, 59);
         const expectedDate = new Date(2020, 11, 24, 23, 59);
         const endDate = getEndTime(date);
+        expect(endDate.toString()).toBe(expectedDate.toString());
+    });
+
+    it('Function getNextHalfHourTimeString should return next half hour when minutes < 30', async () => {
+        const date = new Date(2020, 11, 24, 11, 11);
+        const expectedDate = new Date(2020, 11, 24, 11, 30);
+        const endDate = getNextHalfHourTimeString(date);
+        expect(endDate.toString()).toBe(expectedDate.toString());
+    });
+
+    it('Function getNextHalfHourTimeString should return next half hour when minutes = 0', async () => {
+        const date = new Date(2020, 11, 24, 11, 0);
+        const expectedDate = new Date(2020, 11, 24, 11, 30);
+        const endDate = getNextHalfHourTimeString(date);
+        expect(endDate.toString()).toBe(expectedDate.toString());
+    });
+
+    it('Function getNextHalfHourTimeString should return next half hour when minutes > 30', async () => {
+        const date = new Date(2020, 11, 24, 11, 40);
+        const expectedDate = new Date(2020, 11, 24, 12, 0);
+        const endDate = getNextHalfHourTimeString(date);
+        expect(endDate.toString()).toBe(expectedDate.toString());
+    });
+
+    it('Function getNextHalfHourTimeString should return next half hour when minutes = 30', async () => {
+        const date = new Date(2020, 11, 24, 11, 30);
+        const expectedDate = new Date(2020, 11, 24, 12, 0);
+        const endDate = getNextHalfHourTimeString(date);
+        expect(endDate.toString()).toBe(expectedDate.toString());
+    });
+
+    it('Function getNextHalfHourTimeString should return next day hour 07:00 when hours >= 20', async () => {
+        const date = new Date(2020, 11, 24, 20, 30);
+        const expectedDate = new Date(2020, 11, 25, 7, 0);
+        const endDate = getNextHalfHourTimeString(date);
         expect(endDate.toString()).toBe(expectedDate.toString());
     });
 });

--- a/src/modules/InvitationForPunchOut/views/CreateIPO/utils.ts
+++ b/src/modules/InvitationForPunchOut/views/CreateIPO/utils.ts
@@ -1,4 +1,4 @@
-import { addHours, addMinutes } from 'date-fns';
+import { addDays, addHours, addMinutes, set } from 'date-fns';
 
 import { Organization } from '../../types';
 
@@ -32,5 +32,20 @@ export const getEndTime = (date: Date): Date => {
         return addMinutes(date, 59 - minutes);
     } else {
         return addHours(date, 1);
+    }
+};
+
+export const getNextHalfHourTimeString = (date: Date): Date => {
+    const hours  = date.getHours();
+    const minutes = date.getMinutes();
+    if (hours < 20) {
+        if (minutes < 30) {
+            return addMinutes(date, 30 - minutes);
+        } else {
+            return set(date, { hours: hours + 1, minutes: 0});
+        }
+    } else {
+        const nextDay = addDays(date, 1);
+        return set(nextDay, { hours: 7, minutes: 0});
     }
 };


### PR DESCRIPTION
# Description

- Add function getNextHalfHourTimeString
- Add tests
- Add set inital time in GeneralInfo

Note: In getNextHalfHourTimeString, the returned time is 07:00 the following day if current time is 20:00 or later. Up for discussion?

Completes: [AB#79599](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/79599)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [x] My code is covered by tests.
