### PR TITLE
Feature 78826:  UI show attachment type icon

### DIFF
--- a/src/components/EdsIcon/index.tsx
+++ b/src/components/EdsIcon/index.tsx
@@ -27,7 +27,10 @@ import {
     edit_text,
     error_filled,
     fast_forward,
+    file,
+    file_description,
     filter_list,
+    image,
     info_circle,
     iphone,
     link,
@@ -35,6 +38,8 @@ import {
     menu,
     microsoft_excel,
     microsoft_outlook,
+    microsoft_powerpoint,
+    microsoft_word,
     more_horizontal,
     more_verticle,
     notifications,
@@ -59,9 +64,9 @@ import React from 'react';
 const icons = {
     error_filled, close, cloud_download, checkbox, checkbox_outline, done_all, add_circle_filled, attach_file,
     notifications, chevron_down, chevron_up, edit, delete_to_trash, calendar_today, person, alarm_on, world, link,
-    place, pressure, verticle_split, category, search, bookmark_collection, add, arrow_down, arrow_up, filter_list, more_verticle,
+    place, pressure, verticle_split, category, search, bookmark_collection, add, arrow_down, arrow_up, file, file_description, image, filter_list, more_verticle,
     warning_filled, delete_forever, restore_from_trash, edit_text, account_circle, lock, info_circle, iphone, print, fast_forward, play,
-    copy, star_filled, star_outlined, microsoft_excel, done, chevron_right, arrow_back, warning_outlined, more_horizontal, microsoft_outlook, calendar_date_range, menu
+    copy, star_filled, star_outlined, microsoft_excel, done, chevron_right, arrow_back, warning_outlined, more_horizontal, microsoft_outlook, microsoft_powerpoint, microsoft_word, calendar_date_range, menu
 };
 
 Icon.add(icons);

--- a/src/modules/InvitationForPunchOut/views/CreateIPO/Attachments/Attachments.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateIPO/Attachments/Attachments.tsx
@@ -1,6 +1,7 @@
 import { AddAttachmentContainer, Container, DragAndDropContainer, FormContainer } from './Attachments.style';
 import { Button, Typography } from '@equinor/eds-core-react';
 import React, { useRef } from 'react';
+import { getFileExtension, getFileName, getFileTypeIconName } from '../../utils';
 
 import EdsIcon from '@procosys/components/EdsIcon';
 import Table from '@procosys/components/Table';
@@ -39,7 +40,14 @@ const Attachments = ({
 
     const getAttachmentName = (attachment: File): JSX.Element => {
         return (
-            <div>{attachment.name}</div>
+            <div>{getFileName(attachment.name)}</div>
+        );
+    };
+
+    const getAttachmentIcon = (attachment: File): JSX.Element => {
+        const iconName = getFileTypeIconName(attachment.name);
+        return (
+            <EdsIcon name={iconName} size={24}/>
         );
     };
     
@@ -81,7 +89,7 @@ const Attachments = ({
             </DragAndDropContainer>
             <Typography variant='h5'>Attachments</Typography>
             <Table
-                columns={[{ title: 'Title', render: getAttachmentName }]}
+                columns={[{ title: 'Type', render: getAttachmentIcon, width: '30px' }, { title: 'Title', render: getAttachmentName }]}
                 data={attachments}
                 options={{
                     toolbar: false,

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/Attachments/__tests__/Attachments.test.jsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/Attachments/__tests__/Attachments.test.jsx
@@ -24,7 +24,7 @@ describe('Module: <Attachments ipoId={} />', () => {
     it('Should render attachments in table', async () => {
         const { getByText } = render(<Attachments ipoId={0} />);
 
-        await waitFor(() => expect(getByText('file1.txt')).toBeInTheDocument());
+        await waitFor(() => expect(getByText('file1')).toBeInTheDocument());
     });
 });
 

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/Attachments/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/Attachments/index.tsx
@@ -1,6 +1,7 @@
 import { AddAttachmentContainer, AttachmentTable, Container, DragAndDropContainer, FormContainer, SpinnerContainer } from './index.style';
 import { Button, Typography } from '@equinor/eds-core-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { getFileName, getFileTypeIconName } from '../../utils';
 
 import { Attachment } from '../types';
 import { Canceler } from '@procosys/http/HttpClient';
@@ -149,6 +150,7 @@ const Attachments = ({ ipoId }: AttachmentsProps): JSX.Element => {
             <AttachmentTable>
                 <Head>
                     <Row>
+                        <Cell as="th" scope="col" style={{verticalAlign: 'middle'}}>Type</Cell>
                         <Cell as="th" scope="col" style={{verticalAlign: 'middle'}}>Title</Cell>
                         <Cell as="th" scope="col" style={{verticalAlign: 'middle'}}>{' '}</Cell>
                     </Row>
@@ -156,9 +158,12 @@ const Attachments = ({ ipoId }: AttachmentsProps): JSX.Element => {
                 <Body>
                     {attachments && attachments.length > 0 ? attachments.map((attachment, index) => (
                         <Row key={attachment.id}>
+                            <Cell as="td" style={{verticalAlign: 'middle', lineHeight: '1em', width: '30px'}}>
+                                <EdsIcon name={getFileTypeIconName(attachment.fileName)} size={24} />
+                            </Cell>
                             <Cell as="td" style={{verticalAlign: 'middle', lineHeight: '1em'}}>
                                 <CustomTooltip title="Click to open in new tab" arrow>
-                                    <Typography onClick={(): Promise<void> => openAttachment(attachment.id)} variant="body_short" link>{attachment.fileName}</Typography>
+                                    <Typography onClick={(): Promise<void> => openAttachment(attachment.id)} variant="body_short" link>{getFileName(attachment.fileName)}</Typography>
                                 </CustomTooltip>
                             </Cell>
                             <Cell as="td" style={{verticalAlign: 'middle', lineHeight: '1em', width: '30px'}}>

--- a/src/modules/InvitationForPunchOut/views/__tests__/utils.test.js
+++ b/src/modules/InvitationForPunchOut/views/__tests__/utils.test.js
@@ -1,0 +1,35 @@
+import { getFileExtension, getFileName } from '../utils';
+
+describe('Common IPO utilities', () => {
+    it('Function getFileName should return filename without extension', async () => {
+        const fullFileName1 = 'textfile.txt';
+        const fullFileName2 = 'textfile.txt.doc';
+        const fullFileName3 = 'textfile 1';
+
+        const fileName1 = getFileName(fullFileName1);
+        const fileName2 = getFileName(fullFileName2);
+        const fileName3 = getFileName(fullFileName3);
+
+        expect(fileName1).toBe('textfile');
+        expect(fileName2).toBe('textfile.txt');
+        expect(fileName3).toBe('textfile 1');
+    });
+
+    it('Function getFileExtension should return file extension', async () => {
+        const fullFileName1 = 'textfile.txt';
+        const fullFileName2 = 'textfile.txt.doc';
+        const fullFileName3 = 'textfile 1';
+
+        const fileExt1 = getFileExtension(fullFileName1);
+        const fileExt2 = getFileExtension(fullFileName2);
+        const fileExt3 = getFileExtension(fullFileName3);
+
+        expect(fileExt1).toBe('txt');
+        expect(fileExt2).toBe('doc');
+        expect(fileExt3).toBe('');
+    });
+});
+
+
+
+

--- a/src/modules/InvitationForPunchOut/views/utils.tsx
+++ b/src/modules/InvitationForPunchOut/views/utils.tsx
@@ -8,6 +8,7 @@ export const getFileTypeIconName = (fileName: string): string => {
         case 'JPEG':
         case 'PNG':
         case 'SVG':
+        case 'ICO':
             return 'image';
         case 'PDF':
             return 'file_description';
@@ -16,8 +17,10 @@ export const getFileTypeIconName = (fileName: string): string => {
             return 'microsoft_word';
         case 'XLS':
         case 'XLSX':
+        case 'CSV':
             return 'microsoft_excel';
         case 'PPT':
+        case 'PPTX':
             return 'microsoft_powerpoint';
         default:
             return 'file';

--- a/src/modules/InvitationForPunchOut/views/utils.tsx
+++ b/src/modules/InvitationForPunchOut/views/utils.tsx
@@ -30,5 +30,9 @@ export const getFileExtension = (filename: string): string => {
 };
 
 export const getFileName = (fullName: string): string => {
-    return fullName.split('.').slice(0, -1).join('.');
+    return fullName.includes('.') ? (
+        fullName.split('.').slice(0, -1).join('.')
+    ) : (
+        fullName
+    );
 };

--- a/src/modules/InvitationForPunchOut/views/utils.tsx
+++ b/src/modules/InvitationForPunchOut/views/utils.tsx
@@ -1,0 +1,34 @@
+
+
+export const getFileTypeIconName = (fileName: string): string => {
+    const ext = getFileExtension(fileName).toUpperCase();
+
+    switch (ext) {
+        case 'JPG':
+        case 'JPEG':
+        case 'PNG':
+        case 'SVG':
+            return 'image';
+        case 'PDF':
+            return 'file_description';
+        case 'DOC':
+        case 'DOCX':
+            return 'microsoft_word';
+        case 'XLS':
+        case 'XLSX':
+            return 'microsoft_excel';
+        case 'PPT':
+            return 'microsoft_powerpoint';
+        default:
+            return 'file';
+
+    }
+};
+
+export const getFileExtension = (filename: string): string => {
+    return filename.slice((filename.lastIndexOf('.') - 1 >>> 0) + 2);
+};
+
+export const getFileName = (fullName: string): string => {
+    return fullName.split('.').slice(0, -1).join('.');
+};


### PR DESCRIPTION
# Description

- Add Type field for attachment tables with icon
- Add tests for utility functions

Completes: [AB#78826](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/78826)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [x] My code is covered by tests.
