### PR TITLE
Feature 79415: UI link to reports

### DIFF
--- a/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/ReportsTable/__tests__/ReportsTable.test.jsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/ReportsTable/__tests__/ReportsTable.test.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import ReportsTable from '../index';
+import { ThemeProvider } from 'styled-components';
+import { render } from '@testing-library/react';
+import theme from '../../../../../../../assets/theme';
+
+const mcPkgScope = [
+    {
+        mcPkgNo: '7101-F001',
+        description: 'M30 LIFEBOAT',
+        commPkgNo: '7101-C01'
+    },
+    { 
+        mcPkgNo: '7101-E001',
+        description: 'LIFEBOAT FOR M30',
+        commPkgNo: '7101-C01'
+    }
+];
+
+const commPkgScope = [
+    {
+        commPkgNo: '7101-C01',
+        description: 'M30 LIFEBOAT',
+        status: 'OS'
+    },
+    {
+        commPkgNo: '7101-C02',
+        description: 'M30 LIFERAFT & DAVIT',
+        status: 'OS'
+    },
+    {
+        commPkgNo: '7101-C08',
+        description: 'M50 MISC LIFESAVING EQUIPMENT',
+        status: 'OS'
+    }
+];
+
+const renderWithTheme = (Component) => {
+    return render(<ThemeProvider theme={theme}>{Component}</ThemeProvider>);
+};
+
+
+describe('<ReportsTable />', () => {
+    it('Renders Report types with MC Scope', async () => {
+        const { queryByText } = renderWithTheme(<ReportsTable mcPkgScope={mcPkgScope} commPkgScope={[]} />);
+
+        expect(queryByText('MC32')).toBeInTheDocument();
+        expect(queryByText('MC84')).toBeInTheDocument();
+        expect(queryByText('CDP06')).toBeInTheDocument();
+    });
+
+    it('Renders Report types with Comm Scope', async () => {
+        const { queryByText } = renderWithTheme(<ReportsTable mcPkgScope={[]} commPkgScope={commPkgScope} />);
+
+        expect(queryByText('MC32')).toBeInTheDocument();
+        expect(queryByText('MC84')).toBeInTheDocument();
+        expect(queryByText('CDP06')).toBeInTheDocument();
+    });
+});
+
+
+

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/ReportsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/ReportsTable/index.tsx
@@ -1,0 +1,94 @@
+import { CommPkgScope, McPkgScope } from '../../types';
+import { Container, CustomTable } from './style';
+import { Table, Typography } from '@equinor/eds-core-react';
+
+import React from 'react';
+import { ReportIdEnum } from '../../utils';
+import { useCurrentPlant } from '@procosys/core/PlantContext';
+
+const getReportParams = (mcScope: McPkgScope[], commScope: CommPkgScope[]): string => {
+    let reportParams = '';
+
+    if (mcScope.length > 0) {
+        reportParams += '&mcPkgs=';
+        mcScope.forEach(mcPkg => {
+            reportParams += `${mcPkg.mcPkgNo},`;
+        });
+        reportParams = reportParams.slice(0, -1);
+    }
+    if (commScope.length > 0) {
+        reportParams += '&commPkgs=';
+        commScope.forEach(commPkg => {
+            reportParams += `${commPkg.commPkgNo},`;
+        });
+        reportParams = reportParams.slice(0, -1);
+    }
+    return reportParams;
+};
+
+
+const { Head, Body, Cell, Row } = Table;
+
+interface Props {
+    mcPkgs: McPkgScope[];
+    commPkgs: CommPkgScope[];
+}
+
+const ReportsTable = ({ mcPkgs, commPkgs }: Props ): JSX.Element => {
+    const { plant } = useCurrentPlant();
+    const reportParams = getReportParams(mcPkgs, commPkgs);
+
+    const goToReport = (reportId: number): void => {
+        if (reportId === ReportIdEnum.MC32) {
+            window.location.href = `/${plant.pathId}/Report/AutoGenerate?reportId=${reportId}${reportParams}`;
+        } else {
+            window.location.href = `/${plant.pathId}/Search/AutoGenerate?searchId=${reportId}${reportParams}`;
+        }
+    };
+ 
+    return (
+        <Container>
+            <CustomTable>
+                <Head>
+                    <Row>
+                        <Cell as="th" scope="col" style={{verticalAlign: 'middle'}}>Report</Cell>
+                        <Cell as="th" scope="col" style={{verticalAlign: 'middle'}}>{' '}</Cell>
+                        <Cell as="th" scope="col" style={{verticalAlign: 'middle'}}>{' '}</Cell>
+                    </Row>
+                </Head>
+                <Body>
+                    <Row as="tr">
+                        <Cell as="td" style={{verticalAlign: 'middle', lineHeight: '1em'}}>
+                            <Typography onClick={(): void => goToReport(ReportIdEnum.MC32)} variant="body_short" link>MC32</Typography>
+                        </Cell>
+                        <Cell as="td" style={{verticalAlign: 'middle'}}>MC Scope</Cell>
+                        <Cell as="td" style={{verticalAlign: 'middle', lineHeight: '1em'}}>
+                            {' '}
+                        </Cell>
+                    </Row>
+                    <Row as="tr">
+                        <Cell as="td" style={{verticalAlign: 'middle', lineHeight: '1em'}}>
+                            <Typography onClick={(): void => goToReport(ReportIdEnum.MC84)} variant="body_short" link>MC84</Typography>
+                        </Cell>
+                        <Cell as="td" style={{verticalAlign: 'middle'}}>Punch List</Cell>
+                        <Cell as="td" style={{verticalAlign: 'middle', lineHeight: '1em'}}>
+                            {' '}
+                        </Cell>
+                    </Row>
+                    <Row as="tr">
+                        <Cell as="td" style={{verticalAlign: 'middle', lineHeight: '1em'}}>
+                            <Typography onClick={(): void => goToReport(ReportIdEnum.CDP06)} variant="body_short" link>CDP06</Typography>
+                        </Cell>
+                        <Cell as="td" style={{verticalAlign: 'middle'}}>Concession Deviation Permit</Cell>
+                        <Cell as="td" style={{verticalAlign: 'middle', lineHeight: '1em'}}>
+                            {' '}
+                        </Cell>
+                    </Row>
+                </Body>
+            </CustomTable> 
+        </Container>
+    );
+};
+
+export default ReportsTable;
+

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/ReportsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/ReportsTable/index.tsx
@@ -9,14 +9,14 @@ import { useCurrentPlant } from '@procosys/core/PlantContext';
 const getReportParams = (mcScope: McPkgScope[], commScope: CommPkgScope[]): string => {
     let reportParams = '';
 
-    if (mcScope.length > 0) {
+    if (mcScope && mcScope.length > 0) {
         reportParams += '&mcPkgs=';
         mcScope.forEach(mcPkg => {
             reportParams += `${mcPkg.mcPkgNo},`;
         });
         reportParams = reportParams.slice(0, -1);
     }
-    if (commScope.length > 0) {
+    if (commScope && commScope.length > 0) {
         reportParams += '&commPkgs=';
         commScope.forEach(commPkg => {
             reportParams += `${commPkg.commPkgNo},`;
@@ -30,13 +30,13 @@ const getReportParams = (mcScope: McPkgScope[], commScope: CommPkgScope[]): stri
 const { Head, Body, Cell, Row } = Table;
 
 interface Props {
-    mcPkgs: McPkgScope[];
-    commPkgs: CommPkgScope[];
+    mcPkgScope: McPkgScope[];
+    commPkgScope: CommPkgScope[];
 }
 
-const ReportsTable = ({ mcPkgs, commPkgs }: Props ): JSX.Element => {
+const ReportsTable = ({ mcPkgScope, commPkgScope }: Props ): JSX.Element => {
     const { plant } = useCurrentPlant();
-    const reportParams = getReportParams(mcPkgs, commPkgs);
+    const reportParams = getReportParams(mcPkgScope, commPkgScope);
 
     const goToReport = (reportId: number): void => {
         if (reportId === ReportIdEnum.MC32) {

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/ReportsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/ReportsTable/index.tsx
@@ -29,12 +29,12 @@ const getReportParams = (mcScope: McPkgScope[], commScope: CommPkgScope[]): stri
 
 const { Head, Body, Cell, Row } = Table;
 
-interface Props {
+interface ReportsTableProps {
     mcPkgScope: McPkgScope[];
     commPkgScope: CommPkgScope[];
 }
 
-const ReportsTable = ({ mcPkgScope, commPkgScope }: Props ): JSX.Element => {
+const ReportsTable = ({ mcPkgScope, commPkgScope }: ReportsTableProps ): JSX.Element => {
     const { plant } = useCurrentPlant();
     const reportParams = getReportParams(mcPkgScope, commPkgScope);
 

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/ReportsTable/style.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/ReportsTable/style.tsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+    position: relative;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+`;
+
+export const CustomTable = styled.table`
+    position: relative;
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+    width: 100%;
+`;
+

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/__tests__/Scope.test.jsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/__tests__/Scope.test.jsx
@@ -41,6 +41,15 @@ const renderWithTheme = (Component) => {
 
 
 describe('<Scope />', () => {
+    it('Renders reports', async () => {
+        const { queryByText } = renderWithTheme(<Scope commPkgScope={commPkgScope} mcPkgScope={[]} />);
+
+        expect(queryByText('Reports')).toBeInTheDocument();
+        expect(queryByText('MC32')).toBeInTheDocument();
+        expect(queryByText('MC84')).toBeInTheDocument();
+        expect(queryByText('CDP06')).toBeInTheDocument();
+    });
+    
     it('Renders comm pkg scope', async () => {
         const { queryByText } = renderWithTheme(<Scope commPkgScope={commPkgScope} mcPkgScope={[]} />);
 

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/index.tsx
@@ -4,6 +4,7 @@ import { Container, HeaderContainer, TableContainer } from './style';
 import CommPkgsTable from './CommPkgsTable';
 import McPkgsTable from './McPkgsTable';
 import React from 'react';
+import ReportsTable from './ReportsTable';
 import { Typography } from '@equinor/eds-core-react';
 
 interface Props {
@@ -15,12 +16,12 @@ interface Props {
 const Scope = ({ mcPkgScope, commPkgScope, projectName }: Props): JSX.Element => {
     return (
         <Container>
-            {/* <HeaderContainer>
+            <HeaderContainer>
                 <Typography variant="h5">Reports</Typography>
             </HeaderContainer>
             <TableContainer>
-                // reports table here
-            </TableContainer> */}
+                <ReportsTable commPkgs={commPkgScope} mcPkgs={mcPkgScope} />
+            </TableContainer>
             {commPkgScope && commPkgScope.length > 0 && (
                 <>
                     <HeaderContainer>

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/index.tsx
@@ -20,7 +20,7 @@ const Scope = ({ mcPkgScope, commPkgScope, projectName }: Props): JSX.Element =>
                 <Typography variant="h5">Reports</Typography>
             </HeaderContainer>
             <TableContainer>
-                <ReportsTable commPkgs={commPkgScope} mcPkgs={mcPkgScope} />
+                <ReportsTable commPkgScope={commPkgScope} mcPkgScope={mcPkgScope} />
             </TableContainer>
             {commPkgScope && commPkgScope.length > 0 && (
                 <>

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/utils.ts
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/utils.ts
@@ -38,3 +38,9 @@ const createOrganizationMap = (): Map<Organization, string> => {
 };
 
 export const OrganizationMap = createOrganizationMap();
+
+export enum ReportIdEnum {
+    MC32 = 132,
+    MC84 = 144,
+    CDP06 = 114
+}


### PR DESCRIPTION
# Description

- Add Reports table
- Add links to autogenerate reports
- Add tests

Search and report ids are set to QP and Prod environment.

Completes: [AB#79415](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/79415)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [x] My code is covered by tests.
