### PR TITLE
Feature 79576: UI Fix external guest person clocked, email field

### DIFF
--- a/src/modules/InvitationForPunchOut/views/CreateIPO/Participants/Participants.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateIPO/Participants/Participants.tsx
@@ -174,7 +174,7 @@ const Participants = ({
                 participantsCopy[index].organization = organization;
                 return participantsCopy;
             });
-            if(organization.text === OrganizationsEnum.External) {
+            if(organization.value === OrganizationsEnum.External) {
                 setType('Person', index);
             }
         }
@@ -340,12 +340,12 @@ const Participants = ({
                                     onChange={(value): void => setType(value, index)}
                                     data={ParticipantType}
                                     label={'Type'}
-                                    disabled={p.organization.text == OrganizationsEnum.External}
+                                    disabled={p.organization.value == OrganizationsEnum.External}
                                 >
                                     {p.type}
                                 </SelectInput>
                             </div>
-                            { p.organization.text == OrganizationsEnum.External &&
+                            { p.organization.value == OrganizationsEnum.External &&
                                 <div>
                                     <TextField
                                         id={'guestEmail'}
@@ -356,7 +356,7 @@ const Participants = ({
                                     />
                                 </div>
                             }
-                            { p.type == ParticipantType[1].text && p.organization.text != OrganizationsEnum.External &&
+                            { p.type == ParticipantType[1].text && p.organization.value != OrganizationsEnum.External &&
                                 <div>
                                     <Dropdown
                                         label={'Person'}

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/OutlookInfo/__tests__/OutlookInfoTest.test.jsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/OutlookInfo/__tests__/OutlookInfoTest.test.jsx
@@ -40,7 +40,7 @@ export const participants = [
                 email: 'lkjawc@equinor.com',
                 company: 'EQUI',
             },
-            response: OutlookResponseType.TENTATIVE
+            response: OutlookResponseType.TENTATIVELY_ACCEPTED
         },
     },
     {

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/OutlookInfo/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/OutlookInfo/index.tsx
@@ -36,6 +36,7 @@ const OutlookInfo = ({ close, organizer, participants, status }: Props): JSX.Ele
                         setAttending(a => [...a, p]);
                         break;
                     case OutlookResponseType.TENTATIVE:
+                    case OutlookResponseType.TENTATIVELY_ACCEPTED:
                         setTentative(a => [...a, p]);
                         break;
                     case OutlookResponseType.NONE:

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/utils.ts
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/utils.ts
@@ -3,6 +3,7 @@ import { Organization } from '../../types';
 export enum OutlookResponseType {
     ATTENDING = 'Accepted',
     TENTATIVE = 'Tentative',
+    TENTATIVELY_ACCEPTED = 'TentativelyAccepted',
     NONE = 'None',
     UNKNOWN = 'Unknown',
     DECLINED = 'Declined'


### PR DESCRIPTION
# Description

- Add organization.value comparison to OrganizationEnum
- Add TENTATIVELY_ACCEPTED as outlook response type

Note: as per this PR, invitation response includes person data in externalEmail participant, resulting in representative rendered as 'null null' in view IPO participant table

Completes: [AB#79576](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/79576)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [x] My code is covered by tests.
