### PR TITLE
Bug 80234: UI Participants dropdown hang

### DIFF
--- a/src/hooks/useClickOutsideNotifier.tsx
+++ b/src/hooks/useClickOutsideNotifier.tsx
@@ -21,7 +21,7 @@ const useClickOutsideNotifier = (
         return (): void => {
             document.removeEventListener('mousedown', handleClickOutsideTarget);
         };
-    });
+    }, []);
 };
 
 export default useClickOutsideNotifier;


### PR DESCRIPTION
# Description

useEffect in useClickOutsideNotifier did not have a dependency array

Completes: [AB#80234](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/80234)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [x] My code is covered by tests.
