### PR TITLE
Feature 78524: Link to old preservation wrong url

### DIFF
--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
@@ -31,6 +31,7 @@ import { showModalDialog } from '../../../../core/services/ModalDialogService';
 import { showSnackbarNotification } from '../../../../core/services/NotificationService';
 import { tokens } from '@equinor/eds-tokens';
 import { useAnalytics } from '@procosys/core/services/Analytics/AnalyticsContext';
+import { useCurrentPlant } from '@procosys/core/PlantContext';
 import { usePreservationContext } from '../../context/PreservationContext';
 
 export const getFirstUpcomingRequirement = (tag: PreservedTag): Requirement | null => {
@@ -148,6 +149,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
     const history = useHistory();
     const location = useLocation();
     const analytics = useAnalytics();
+    const { plant } = useCurrentPlant();
 
     const numberOfFilters: number = Object.values(tagListFilter).filter(v => v && JSON.stringify(v) != '[]').length;
 
@@ -742,7 +744,10 @@ const ScopeOverview: React.FC = (): JSX.Element => {
 
     const navigateToOldPreservation = (): void => {
         analytics.trackUserAction('Btn_SwitchToOldPreservation', { module: 'preservation' });
-        window.location.href = './OldPreservation';
+        const oldPreservationUrl = 
+            window.location.origin + '/' +
+            plant.pathId + '/OldPreservation';
+        window.location.href = oldPreservationUrl;
     };
 
     const closeReschededuleDialog = (): void => {

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
@@ -744,10 +744,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
 
     const navigateToOldPreservation = (): void => {
         analytics.trackUserAction('Btn_SwitchToOldPreservation', { module: 'preservation' });
-        const oldPreservationUrl = 
-            window.location.origin + '/' +
-            plant.pathId + '/OldPreservation';
-        window.location.href = oldPreservationUrl;
+        window.location.href = '/' + plant.pathId + '/OldPreservation';
     };
 
     const closeReschededuleDialog = (): void => {


### PR DESCRIPTION
# Description

Previously added extra path to url. Now uses window.location.origin and plant.pathId from useCurrentPlant context.

Completes: [AB#78524](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/78524)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [x] My code is covered by tests.
