### PR TITLE
Feature 78647: Link in preservation tag

### DIFF
--- a/src/modules/Preservation/views/EditTagProperties/EditTagProperties.tsx
+++ b/src/modules/Preservation/views/EditTagProperties/EditTagProperties.tsx
@@ -1,5 +1,5 @@
 import { Button, Typography } from '@equinor/eds-core-react';
-import { ButtonContainer, Container, ErrorContainer, Header, InputContainer, SpinnerContainer, ContentContainer } from './EditTagProperties.style';
+import { ButtonContainer, Container, ContentContainer, ErrorContainer, Header, InputContainer, SpinnerContainer } from './EditTagProperties.style';
 import { Journey, RequirementType, Step, TagDetails } from './types';
 import React, { useEffect, useRef, useState } from 'react';
 import SelectInput, { SelectItem } from '../../../../components/Select';

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/PreservationTab.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/PreservationTab.tsx
@@ -1,14 +1,15 @@
-import React, { useState, useEffect } from 'react';
-import { Container, TagDetailsContainer, Details, GridFirstRow, GridSecondRow, TagDetailsInputContainer, TextFieldContainer, StyledButton, IconContainer, TextFieldLabelReadOnly, TextFieldReadOnly } from './PreservationTab.style';
-import { TextField, Typography } from '@equinor/eds-core-react';
+import { Container, Details, GridFirstRow, GridSecondRow, IconContainer, StyledButton, TagDetailsContainer, TagDetailsInputContainer, TextFieldContainer, TextFieldLabelReadOnly, TextFieldReadOnly } from './PreservationTab.style';
+import React, { useEffect, useState } from 'react';
 import { TagDetails, TagRequirement, TagRequirementRecordValues } from './../types';
-import Requirements from './Requirements';
-import { usePreservationContext } from '../../../../context/PreservationContext';
-import { showSnackbarNotification } from './../../../../../../core/services/NotificationService';
-import Spinner from '../../../../../../components/Spinner';
-import EditOutlinedIcon from '@material-ui/icons/EditOutlined';
+import { TextField, Typography } from '@equinor/eds-core-react';
+
 import CheckIcon from '@material-ui/icons/Check';
 import ClearIcon from '@material-ui/icons/Clear';
+import EditOutlinedIcon from '@material-ui/icons/EditOutlined';
+import Requirements from './Requirements';
+import Spinner from '../../../../../../components/Spinner';
+import { showSnackbarNotification } from './../../../../../../core/services/NotificationService';
+import { usePreservationContext } from '../../../../context/PreservationContext';
 
 interface PreservationTabProps {
     tagDetails: TagDetails;
@@ -178,7 +179,7 @@ const PreservationTab = ({
                         <TextField
                             id='remark'
                             label='Remark'
-                            value={remark}
+                            value={remark ? remark : ''}
                             meta="Optional"
                             onChange={(e: React.ChangeEvent<HTMLInputElement>): void => { setRemark(e.target.value); }}
                             onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>): void => {

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/TagFlyout.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/TagFlyout.tsx
@@ -153,13 +153,6 @@ const TagFlyout = ({
         }
     };
 
-    const goToTag = (): void => {
-        if (mainTagId) {
-            window.location.href = `/${plant.pathId}/Completion#Tag|${mainTagId}`;
-        } else {
-            showSnackbarNotification('Something went wrong. Could not direct you to tag.');
-        }
-    };
 
     return (
         <Container>
@@ -175,10 +168,12 @@ const TagFlyout = ({
                 </HeaderNotification>
             }
             <Header>
-                <TagNoContainer isStandardTag={isStandardTag()} onClick={goToTag}>
-                    <Typography variant="h1">
-                        {tagDetails ? tagDetails.tagNo : '-'}
-                    </Typography>
+                <TagNoContainer isStandardTag={isStandardTag()} >
+                    <a href={mainTagId ? `/${plant.pathId}/Completion#Tag|${mainTagId}` : ''}>
+                        <Typography variant="h1">
+                            {tagDetails ? tagDetails.tagNo : '-'}
+                        </Typography>
+                    </a>
                 </TagNoContainer>
                 <HeaderActions>
                     {(!isVoided && preservationIsStarted) &&


### PR DESCRIPTION
# Description

Removed goto function and added link. Link is inactive (empty string) when mainTagId not provided.
Also, added minor fix to Remark text field controlled input giving console errors.

Completes: [AB#78647](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/78647)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [x] My code is covered by tests.
