### PR TITLE
Feature 80318: UI - Text before IPO created

### DIFF
--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateAndEditIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateAndEditIPO.tsx
@@ -1,7 +1,8 @@
 import { Attachment, CommPkgRow, GeneralInfoDetails, McScope, Participant, RoleParticipant, Step } from '../../types';
 import React, { useEffect, useState } from 'react';
-import { ComponentName } from '../enums';
+
 import Attachments from './Attachments/Attachments';
+import { ComponentName } from '../enums';
 import { Container } from './CreateAndEditIPO.style';
 import CreateAndEditIPOHeader from './CreateAndEditIPOHeader';
 import GeneralInfo from './GeneralInfo/GeneralInfo';
@@ -33,6 +34,8 @@ interface CreateAndEditProps {
     setAttachments: React.Dispatch<React.SetStateAction<Attachment[]>>;
     availableRoles: RoleParticipant[];
     fromMain: boolean;
+    confirmationChecked: boolean;
+    setConfirmationChecked: React.Dispatch<React.SetStateAction<boolean>>
 };
 
 const CreateAndEditIPO = ({
@@ -48,7 +51,9 @@ const CreateAndEditIPO = ({
     attachments,
     setAttachments,
     availableRoles,
-    fromMain
+    fromMain,
+    confirmationChecked,
+    setConfirmationChecked
 }: CreateAndEditProps): JSX.Element => {
 
     const [currentStep, setCurrentStep] = useState<number>(StepsEnum.GeneralInfo);
@@ -119,12 +124,12 @@ const CreateAndEditIPO = ({
     };
 
     useEffect(() => {
-        if (generalInfo.poType && generalInfo.projectName && generalInfo.title && generalInfo.startTime && generalInfo.endTime && (generalInfo.startTime <= generalInfo.endTime)) {
+        if (confirmationChecked && generalInfo.poType && generalInfo.projectName && generalInfo.title && generalInfo.startTime && generalInfo.endTime && (generalInfo.startTime <= generalInfo.endTime)) {
             changeCompletedStatus(true, StepsEnum.GeneralInfo);
         } else {
             changeCompletedStatus(false, StepsEnum.GeneralInfo);
         }
-    }, [generalInfo]);
+    }, [generalInfo, confirmationChecked]);
 
     useEffect(() => {
         if (selectedCommPkgScope.length > 0 || selectedMcPkgScope.selected.length > 0) {
@@ -181,6 +186,8 @@ const CreateAndEditIPO = ({
                 fromMain={fromMain}
                 isEditMode={params.ipoId != null}
                 clearScope={clearScope}
+                confirmationChecked={confirmationChecked}
+                setConfirmationChecked={setConfirmationChecked}
             />
         }
         { (currentStep == StepsEnum.Scope && generalInfo.poType != null && generalInfo.projectName != null) &&

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateIPO.tsx
@@ -1,18 +1,19 @@
 import { Attachment, CommPkgRow, GeneralInfoDetails, McScope, Participant, RoleParticipant } from '../../types';
-import React, { useEffect, useState } from 'react';
-import { Canceler } from 'axios';
 import { ComponentName, OrganizationsEnum } from '../enums';
 import { FunctionalRoleDto, ParticipantDto, PersonDto } from '../../http/InvitationForPunchOutApiClient';
+import React, { useEffect, useState } from 'react';
 import { getEndTime, getNextHalfHourTimeString } from './utils';
+
+import { Canceler } from 'axios';
 import { Container } from './CreateAndEditIPO.style';
+import CreateAndEditIPO from './CreateAndEditIPO';
 import Loading from '@procosys/components/Loading';
+import { OrganizationMap } from '../utils';
 import { showSnackbarNotification } from '@procosys/core/services/NotificationService';
 import { useDirtyContext } from '@procosys/core/DirtyContext';
 import { useInvitationForPunchOutContext } from '../../context/InvitationForPunchOutContext';
 import { useParams } from 'react-router-dom';
 import useRouter from '@procosys/hooks/useRouter';
-import { OrganizationMap } from '../utils';
-import CreateAndEditIPO from './CreateAndEditIPO';
 
 const initialDate = getNextHalfHourTimeString(new Date());
 
@@ -76,6 +77,7 @@ const CreateIPO = (): JSX.Element => {
 
     const initialGeneralInfo = { ...emptyGeneralInfo, projectId: params.projectId };
     const [generalInfo, setGeneralInfo] = useState<GeneralInfoDetails>(initialGeneralInfo);
+    const [confirmationChecked, setConfirmationChecked] = useState<boolean>(false);
     const [selectedCommPkgScope, setSelectedCommPkgScope] = useState<CommPkgRow[]>([]);
     const [selectedMcPkgScope, setSelectedMcPkgScope] = useState<McScope>({
         commPkgNoParent: null,
@@ -273,6 +275,8 @@ const CreateIPO = (): JSX.Element => {
         setAttachments={setAttachments}
         availableRoles={availableRoles}
         fromMain={fromMain}
+        confirmationChecked={confirmationChecked}
+        setConfirmationChecked={setConfirmationChecked}
     />);
 };
 

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
@@ -1,19 +1,20 @@
 import { Attachment, CommPkgRow, GeneralInfoDetails, McScope, Participant, Person, RoleParticipant } from '../../types';
-import React, { useCallback, useEffect, useState } from 'react';
-import { Canceler } from 'axios';
-import { FunctionalRoleDto, ParticipantDto, PersonDto } from '../../http/InvitationForPunchOutApiClient';
 import { CenterContainer, Container } from './CreateAndEditIPO.style';
-import { poTypes } from './GeneralInfo/GeneralInfo';
+import { FunctionalRoleDto, ParticipantDto, PersonDto } from '../../http/InvitationForPunchOutApiClient';
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { Canceler } from 'axios';
+import { ComponentName } from '../enums';
+import CreateAndEditIPO from './CreateAndEditIPO';
+import { Invitation } from '../ViewIPO/types';
 import Loading from '@procosys/components/Loading';
+import { SelectItem } from '@procosys/components/Select';
+import { poTypes } from './GeneralInfo/GeneralInfo';
 import { showSnackbarNotification } from '@procosys/core/services/NotificationService';
 import { useDirtyContext } from '@procosys/core/DirtyContext';
 import { useInvitationForPunchOutContext } from '../../context/InvitationForPunchOutContext';
 import { useParams } from 'react-router-dom';
 import useRouter from '@procosys/hooks/useRouter';
-import { Invitation } from '../ViewIPO/types';
-import { SelectItem } from '@procosys/components/Select';
-import CreateAndEditIPO from './CreateAndEditIPO';
-import { ComponentName } from '../enums';
 
 const emptyGeneralInfo: GeneralInfoDetails = {
     projectId: null,
@@ -30,6 +31,7 @@ const EditIPO = (): JSX.Element => {
     const params = useParams<{ ipoId: any }>();
     const [attachments, setAttachments] = useState<Attachment[]>([]);
     const [generalInfo, setGeneralInfo] = useState<GeneralInfoDetails>(emptyGeneralInfo);
+    const [confirmationChecked, setConfirmationChecked] = useState<boolean>(true);
     const [selectedCommPkgScope, setSelectedCommPkgScope] = useState<CommPkgRow[]>([]);
     const [selectedMcPkgScope, setSelectedMcPkgScope] = useState<McScope>({
         commPkgNoParent: null,
@@ -381,6 +383,8 @@ const EditIPO = (): JSX.Element => {
         setAttachments={setAttachments}
         availableRoles={availableRoles}
         fromMain={false}
+        confirmationChecked={confirmationChecked}
+        setConfirmationChecked={setConfirmationChecked}
     />);
 };
 

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/GeneralInfo/GeneralInfo.style.ts
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/GeneralInfo/GeneralInfo.style.ts
@@ -1,5 +1,6 @@
 import styled, { css } from 'styled-components';
 
+import { Checkbox } from '@equinor/eds-core-react';
 import { tokens } from '@equinor/eds-tokens';
 
 interface DropdownProps {
@@ -64,4 +65,19 @@ export const FormContainer = styled.div`
     .MuiInput-root:hover::before {
         border-bottom: 1px solid rgba(0, 0, 0, 0.42) !important;
     }
+`;
+
+export const ConfirmationTextContainer = styled.div`
+    display: flex;
+    /* width: 600px; */
+    align-items: flex-start;
+`;
+
+export const TextContainer = styled.div`
+    padding: 12px;
+`;
+
+export const ConfirmCheckbox = styled(Checkbox)`
+    margin: 0 !important;
+    padding: 0 !important;
 `;

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/GeneralInfo/GeneralInfo.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/GeneralInfo/GeneralInfo.tsx
@@ -1,4 +1,4 @@
-import { Container, DateTimeContainer, DropdownItem, FormContainer, LocationContainer, PoTypeContainer } from './GeneralInfo.style';
+import { ConfirmCheckbox, ConfirmationTextContainer, Container, DateTimeContainer, DropdownItem, FormContainer, LocationContainer, PoTypeContainer, TextContainer } from './GeneralInfo.style';
 import { GeneralInfoDetails, ProjectDetails } from '@procosys/modules/InvitationForPunchOut/types';
 import React, { ChangeEvent, useEffect, useState } from 'react';
 import SelectInput, { SelectItem } from '../../../../../components/Select';
@@ -21,6 +21,8 @@ interface GeneralInfoProps {
     fromMain: boolean;
     isEditMode: boolean;
     clearScope: () => void;
+    confirmationChecked: boolean;
+    setConfirmationChecked: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 const GeneralInfo = ({
@@ -28,7 +30,9 @@ const GeneralInfo = ({
     setGeneralInfo,
     fromMain,
     isEditMode,
-    clearScope
+    clearScope,
+    confirmationChecked,
+    setConfirmationChecked
 }: GeneralInfoProps): JSX.Element => {
     const { apiClient } = useInvitationForPunchOutContext();
     const [availableProjects, setAvailableProjects] = useState<ProjectDetails[]>([]);
@@ -215,6 +219,19 @@ const GeneralInfo = ({
                     }}
                 />
             </LocationContainer>
+            <ConfirmationTextContainer>
+                <ConfirmCheckbox checked={confirmationChecked} onChange={(): void => setConfirmationChecked(confirmed => !confirmed)} />
+                <TextContainer>
+                    <Typography variant="body_short" fontWeight={400}>
+                        I hereby confirm that prior to common punch out all relevant MCCR shall be signed and all punch items registered.
+                    </Typography>
+                    <br />
+                    <Typography variant="body_short" fontWeight={400}>
+                        Mechanical Completion means that the installation is built in accordance with relevant drawings and specifications. 
+                            All specified tests and inspections are carried out and documented in a uniform way.
+                    </Typography>
+                </TextContainer>
+            </ConfirmationTextContainer>
         </FormContainer>
     </Container>);
 };

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/GeneralInfo/GeneralInfo.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/GeneralInfo/GeneralInfo.tsx
@@ -220,7 +220,7 @@ const GeneralInfo = ({
                 />
             </LocationContainer>
             <ConfirmationTextContainer>
-                <ConfirmCheckbox checked={confirmationChecked} onChange={(): void => setConfirmationChecked(confirmed => !confirmed)} />
+                {isEditMode ? <ConfirmCheckbox disabled checked /> : <ConfirmCheckbox checked={confirmationChecked} onChange={(): void => setConfirmationChecked(confirmed => !confirmed)} />}
                 <TextContainer>
                     <Typography variant="body_short" fontWeight={400}>
                         I hereby confirm that prior to common punch out all relevant MCCR shall be signed and all punch items registered.


### PR DESCRIPTION
# Description

- Add checkbox and confirmation text to general info 
- Add check for checkbox checked to proceed

Completes: [AB#80318](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/80318)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
