### PR TITLE
80551: Handle project name instead of id when coming from main

### DIFF
--- a/src/modules/InvitationForPunchOut/index.tsx
+++ b/src/modules/InvitationForPunchOut/index.tsx
@@ -17,7 +17,7 @@ const InvitationForPunchOut = (): JSX.Element => {
                 <Router basename={url}>
                     <Switch>
                         <Route
-                            path={'/CreateIPO/:projectId?/:commPkgNo?'}
+                            path={'/CreateIPO/:projectName?/:commPkgNo?'}
                             exact
                             component={CreateIPO}
                         />

--- a/src/modules/InvitationForPunchOut/types.d.ts
+++ b/src/modules/InvitationForPunchOut/types.d.ts
@@ -12,7 +12,6 @@ export type Step = {
 }
 
 export type GeneralInfoDetails = {
-    projectId: number | null;
     projectName: string | null;
     poType: SelectItem | null;
     title: string | null;

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateAndEditIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateAndEditIPO.tsx
@@ -10,7 +10,6 @@ import Participants from './Participants/Participants';
 import SelectScope from './SelectScope/SelectScope';
 import Summary from './Summary/Summary';
 import { useDirtyContext } from '@procosys/core/DirtyContext';
-import { useParams } from 'react-router-dom';
 
 export enum StepsEnum {
     GeneralInfo = 1,
@@ -38,6 +37,9 @@ interface CreateAndEditProps {
     fromMain: boolean;
     confirmationChecked: boolean;
     setConfirmationChecked: React.Dispatch<React.SetStateAction<boolean>>
+    ipoId?: number | null;
+    isEditMode?: boolean;
+    commPkgNoFromMain?: string | null;
 };
 
 const CreateAndEditIPO = ({
@@ -57,12 +59,12 @@ const CreateAndEditIPO = ({
     availableRoles,
     fromMain,
     confirmationChecked,
-    setConfirmationChecked
+    setConfirmationChecked,
+    ipoId = null,
+    isEditMode = false,
+    commPkgNoFromMain = null
 }: CreateAndEditProps): JSX.Element => {
 
-    const params = useParams<{ ipoId: any; projectId: any; commPkgNo: any }>();
-
-    const [commPkgNoFromMain, setCommPkgNoFromMain] = useState<string | null>(params.commPkgNo ? decodeURIComponent(params.commPkgNo) : null);
     const [currentStep, setCurrentStep] = useState<number>(StepsEnum.GeneralInfo);
     const [canCreateOrUpdate, setCanCreateOrUpdate] = useState<boolean>(false);
 
@@ -165,7 +167,7 @@ const CreateAndEditIPO = ({
 
     return (<Container>
         <CreateAndEditIPOHeader
-            ipoId={params.ipoId}
+            ipoId={ipoId}
             title={generalInfo.title}
             steps={steps}
             currentStep={currentStep}
@@ -180,7 +182,7 @@ const CreateAndEditIPO = ({
                 generalInfo={generalInfo}
                 setGeneralInfo={setGeneralInfo}
                 fromMain={fromMain}
-                isEditMode={params.ipoId != null}
+                isEditMode={isEditMode}
                 clearScope={clearScope}
                 confirmationChecked={confirmationChecked}
                 setConfirmationChecked={setConfirmationChecked}

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateIPO.tsx
@@ -18,7 +18,6 @@ import useRouter from '@procosys/hooks/useRouter';
 const initialDate = getNextHalfHourTimeString(new Date());
 
 const emptyGeneralInfo: GeneralInfoDetails = {
-    projectId: null,
     projectName: '',
     poType: null,
     title: '',
@@ -73,7 +72,7 @@ const initialParticipants: Participant[] = [
 
 const CreateIPO = (): JSX.Element => {
 
-    const params = useParams<{ ipoId: any; projectId: any; commPkgNo: any }>();
+    const params = useParams<{ ipoId: any; projectName: any; commPkgNo: any }>();
 
     const initialSteps: Step[] = [
         { title: 'General info', isCompleted: false },
@@ -83,7 +82,7 @@ const CreateIPO = (): JSX.Element => {
         { title: 'Summary & create', isCompleted: false }
     ];
 
-    const initialGeneralInfo = { ...emptyGeneralInfo, projectId: params.projectId };
+    const initialGeneralInfo = { ...emptyGeneralInfo, projectName: params.projectName };
     const [generalInfo, setGeneralInfo] = useState<GeneralInfoDetails>(initialGeneralInfo);
     const [confirmationChecked, setConfirmationChecked] = useState<boolean>(false);
     const [selectedCommPkgScope, setSelectedCommPkgScope] = useState<CommPkgRow[]>([]);
@@ -101,7 +100,8 @@ const CreateIPO = (): JSX.Element => {
     const { history } = useRouter();
     const { unsetDirtyStateFor } = useDirtyContext();
     const [steps, setSteps] = useState<Step[]>(initialSteps);
-
+    const [projectNameFromMain] = useState<string | null>(params.projectName ? decodeURIComponent(params.projectName) : null);
+    const [commPkgNoFromMain] = useState<string | null>(params.commPkgNo ? decodeURIComponent(params.commPkgNo) : null);
 
     /**
      * Fetch available functional roles 
@@ -257,11 +257,11 @@ const CreateIPO = (): JSX.Element => {
     };
 
     useEffect(() => {
-        if (params.projectId && params.commPkgNo) {
+        if (params.projectName && params.commPkgNo) {
             setFromMain(true);
-            setGeneralInfo(gi => { return { ...gi, projectId: params.projectId }; });
+            setGeneralInfo(gi => { return { ...gi, projectName: projectNameFromMain }; });
         }
-    }, [fromMain]);
+    }, [projectNameFromMain]);
 
     if (isCreating) {
         return (
@@ -289,6 +289,7 @@ const CreateIPO = (): JSX.Element => {
         fromMain={fromMain}
         confirmationChecked={confirmationChecked}
         setConfirmationChecked={setConfirmationChecked}
+        commPkgNoFromMain={commPkgNoFromMain}
     />);
 };
 

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
@@ -19,7 +19,6 @@ import { OrganizationMap } from '../utils';
 import { Organization } from '../../types';
 
 const emptyGeneralInfo: GeneralInfoDetails = {
-    projectId: null,
     projectName: null,
     poType: null,
     title: null,
@@ -407,6 +406,8 @@ const EditIPO = (): JSX.Element => {
         fromMain={false}
         confirmationChecked={confirmationChecked}
         setConfirmationChecked={setConfirmationChecked}
+        isEditMode={true}
+        ipoId={params.ipoId}
     />);
 };
 

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/GeneralInfo/GeneralInfo.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/GeneralInfo/GeneralInfo.tsx
@@ -79,17 +79,9 @@ const GeneralInfo = ({
 
     const setProjectForm = (event: React.MouseEvent, index: number): void => {
         event.preventDefault();
-        if (generalInfo.projectId !== filteredProjects[index].id) clearScope();
-        setGeneralInfo(gi => { return { ...gi, projectId: filteredProjects[index].id, projectName: filteredProjects[index].name }; });
+        if (generalInfo.projectName !== filteredProjects[index].name) clearScope();
+        setGeneralInfo(gi => { return { ...gi, projectName: filteredProjects[index].name }; });
     };
-
-    const selectedProject = availableProjects.find(p => p.id == generalInfo.projectId);
-
-    useEffect(() => {
-        if (selectedProject) {
-            setGeneralInfo(gi => { return { ...gi, projectName: selectedProject.name }; });
-        }
-    }, [selectedProject]);
 
     const handleSetDate = (dateString: string): void => {
         const date = new Date(dateString);
@@ -120,7 +112,7 @@ const GeneralInfo = ({
                 label={'Project'}
                 maxHeight='300px'
                 variant='form'
-                text={selectedProject && selectedProject.description || generalInfo.projectName || 'Select'}
+                text={generalInfo.projectName || 'Select'}
                 onFilter={setFilterForProjects}
                 disabled={fromMain || isEditMode}
             >


### PR DESCRIPTION
# Description

Handle getting project name in url from main instad of id. 

Completes: [AB#80551](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/80551)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
