### PR TITLE
Feature/80393 link to main should be clickable before ipo is created

### DIFF
--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateAndEditIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateAndEditIPO.tsx
@@ -213,7 +213,7 @@ const CreateAndEditIPO = ({
         {currentStep == StepsEnum.SummaryAndCreate &&
             <Summary
                 generalInfo={generalInfo}
-                mcPkgScope={selectedMcPkgScope.selected}
+                mcPkgScope={selectedMcPkgScope.selected.map((mcPkg) => { return { mcPkgNo: mcPkg.mcPkgNo, description: mcPkg.description, commPkgNo: selectedMcPkgScope.commPkgNoParent ? selectedMcPkgScope.commPkgNoParent : '' }; })}
                 commPkgScope={selectedCommPkgScope}
                 participants={participants}
                 attachments={attachments}

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Summary/Summary.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Summary/Summary.tsx
@@ -6,6 +6,7 @@ import { getFileName, getFileTypeIconName } from '../../utils';
 import EdsIcon from '@procosys/components/EdsIcon';
 import React from 'react';
 import { format } from 'date-fns';
+import ReportsTable from '../../ViewIPO/Scope/ReportsTable';
 
 const { Body, Row, Cell, Head } = Table;
 
@@ -158,6 +159,11 @@ const Summary = ({
                     <Typography variant="body_long">{generalInfo.location ? generalInfo.location : '-'}</Typography>
                 </Subsection>
             </Section>
+
+            <Section>
+                <ReportsTable commPkgNumbers={commPkgScope.map((commPkg) => { return commPkg.commPkgNo; })} mcPkgNumbers={mcPkgScope.map((mcPkg) => { return mcPkg.mcPkgNo; })} />
+            </Section>
+
             <TableSection>
                 <Typography variant="h5">Reports added</Typography>
                 <Table>

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Summary/Summary.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Summary/Summary.tsx
@@ -1,18 +1,20 @@
-import { Attachment, CommPkgRow, GeneralInfoDetails, McPkgRow, Participant, Person } from '@procosys/modules/InvitationForPunchOut/types';
+import { Attachment, CommPkgRow, GeneralInfoDetails, Participant, Person } from '@procosys/modules/InvitationForPunchOut/types';
 import { Container, FormContainer, Section, Subsection, TableSection } from './Summary.style';
 import { Table, Typography } from '@equinor/eds-core-react';
 import { getFileName, getFileTypeIconName } from '../../utils';
-
 import EdsIcon from '@procosys/components/EdsIcon';
 import React from 'react';
 import { format } from 'date-fns';
 import ReportsTable from '../../ViewIPO/Scope/ReportsTable';
+import McPkgsTable from '../../ViewIPO/Scope/McPkgsTable';
+import CommPkgsTable from '../../ViewIPO/Scope/CommPkgsTable';
+import { McPkgScope } from '../../ViewIPO/types';
 
 const { Body, Row, Cell, Head } = Table;
 
 interface SummaryProps {
     generalInfo: GeneralInfoDetails;
-    mcPkgScope: McPkgRow[];
+    mcPkgScope: McPkgScope[];
     commPkgScope: CommPkgRow[];
     participants: Participant[];
     attachments: Attachment[];
@@ -26,46 +28,6 @@ const Summary = ({
     attachments
 }: SummaryProps): JSX.Element => {
 
-    const getHeaders = (): JSX.Element => {
-        if (mcPkgScope.length > 0) {
-            return (<Row>
-                <Cell as="th" scope="col">
-                    Mc pkg no
-                </Cell>
-                <Cell as="th" scope="col">
-                    Description
-                </Cell>
-            </Row>);
-        }
-        return (<Row>
-            <Cell as="th" scope="col">
-                Comm pkg no
-            </Cell>
-            <Cell as="th" scope="col">
-                Description
-            </Cell>
-            <Cell as="th" scope="col">
-                Comm status
-            </Cell>
-        </Row>);
-    };
-
-    const getMcPkgScope = (mcPkg: McPkgRow): JSX.Element => {
-        return (
-            <Row key={mcPkg.mcPkgNo}>
-                <Cell>{mcPkg.mcPkgNo}</Cell>
-                <Cell>{mcPkg.description}</Cell>
-            </Row>);
-    };
-
-    const getCommPkgScope = (commPkg: CommPkgRow): JSX.Element => {
-        return (
-            <Row key={commPkg.commPkgNo}>
-                <Cell>{commPkg.commPkgNo}</Cell>
-                <Cell>{commPkg.description}</Cell>
-                <Cell>{commPkg.status}</Cell>
-            </Row>);
-    };
 
     const getNotifiedPersons = (persons: Person[], value: string): string => {
         const filtered = persons.filter(p => p.radioOption == value.toLocaleLowerCase());
@@ -161,50 +123,28 @@ const Summary = ({
             </Section>
 
             <Section>
+                <Typography variant="h5">Reports added</Typography>
                 <ReportsTable commPkgNumbers={commPkgScope.map((commPkg) => { return commPkg.commPkgNo; })} mcPkgNumbers={mcPkgScope.map((mcPkg) => { return mcPkg.mcPkgNo; })} />
             </Section>
 
-            <TableSection>
-                <Typography variant="h5">Reports added</Typography>
-                <Table>
-                    <Head>
-                        <Row>
-                            <Cell as="th" scope="col">
-                                Reports
-                            </Cell>
-                            <Cell as="th" scope="col">
-                                {''}
-                            </Cell>
-                        </Row>
-                    </Head>
-                    <Body>
-                        <Row key={'MC32D'}>
-                            <Cell>{'MC32D'}</Cell>
-                            <Cell>{'MC scope'}</Cell>
-                        </Row>
-                        <Row key={'MC84'}>
-                            <Cell>{'MC84'}</Cell>
-                            <Cell>{'Punch list'}</Cell>
-                        </Row>
-                        <Row key={'CDP06'}>
-                            <Cell>{'CDP06'}</Cell>
-                            <Cell>{'Concession Deviation Permit'}</Cell>
-                        </Row>
-                    </Body>
-                </Table>
-            </TableSection>
-            <TableSection>
-                <Typography variant="h5">Selected scope</Typography>
-                <Table>
-                    <Head>
-                        {getHeaders()}
-                    </Head>
-                    <Body>
-                        {mcPkgScope.length > 0 && mcPkgScope.map(mcPkg => getMcPkgScope(mcPkg))}
-                        {commPkgScope.length > 0 && commPkgScope.map(commPkg => getCommPkgScope(commPkg))}
-                    </Body>
-                </Table>
-            </TableSection>
+
+            {commPkgScope && generalInfo.projectName && commPkgScope.length > 0 && (
+                <>
+                    <Section>
+                        <Typography variant="h5">Included Comm Packages</Typography>
+                        <CommPkgsTable commPkgScope={commPkgScope} projectName={generalInfo.projectName} />
+                    </Section>
+                </>
+            )}
+            {mcPkgScope && generalInfo.projectName && mcPkgScope.length > 0 && (
+                <>
+                    <Section>
+                        <Typography variant="h5">Included MC Packages</Typography>
+                        <McPkgsTable mcPkgScope={mcPkgScope.map((mcPkg) => { return { mcPkgNo: mcPkg.mcPkgNo, description: mcPkg.description, commPkgNo: mcPkg.commPkgNo }; })} projectName={generalInfo.projectName} />
+                    </Section>
+                </>
+            )}
+
             <TableSection>
                 <Typography variant="h5">Participants</Typography>
                 <Table>

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Summary/__tests__/Summary.test.jsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Summary/__tests__/Summary.test.jsx
@@ -18,18 +18,12 @@ const mockMcPkgs = [
     {
         mcPkgNo: 'Mc pkg 1',
         description: 'Description 1',
-        status: 'OK',
-        tableData: {
-            checked: true,
-        }
+        commPkgNo: 'Comm pkg 1',
     },
     {
         mcPkgNo: 'Mc pkg 2',
         description: 'Very long description of a commpkg that is to be selected. Description should be displayed in accordion in selected scope component.Very long description of a commpkg that is to be selected. Description should be displayed in accordion in selected scope component.',
-        status: 'OK',
-        tableData: {
-            checked: true,
-        }
+        commPkgNo: 'Comm pkg 1',
     }
 ];
 
@@ -52,6 +46,15 @@ const participants = [
     }
 ];
     
+jest.mock('@procosys/core/PlantContext',() => ({
+    useCurrentPlant: () => {
+        return {
+            plant: {
+                pathId: 'HEIMDAL'
+            }
+        };
+    }
+}));
 
 describe('Module: <Summary />', () => {
 
@@ -60,7 +63,7 @@ describe('Module: <Summary />', () => {
         expect(getByText('General info')).toBeInTheDocument();
         expect(getByText('Date and time for punch round')).toBeInTheDocument();
         expect(getByText('Reports added')).toBeInTheDocument();
-        expect(getByText('Selected scope')).toBeInTheDocument();
+        expect(getByText('Included MC Packages')).toBeInTheDocument();
         expect(getByText('Participants')).toBeInTheDocument();
     });
 

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/ReportsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/ReportsTable/index.tsx
@@ -6,20 +6,20 @@ import React from 'react';
 import { ReportIdEnum } from '../../enums';
 import { useCurrentPlant } from '@procosys/core/PlantContext';
 
-const getReportParams = (mcScope: McPkgScope[], commScope: CommPkgScope[]): string => {
+const getReportParams = (mcPkgNumbers: string[], commPkgNumbers: string[]): string => {
     let reportParams = '';
 
-    if (mcScope && mcScope.length > 0) {
+    if (mcPkgNumbers && mcPkgNumbers.length > 0) {
         reportParams += '&mcPkgs=';
-        mcScope.forEach(mcPkg => {
-            reportParams += `${mcPkg.mcPkgNo},`;
+        mcPkgNumbers.forEach(mcPkgNo => {
+            reportParams += `${mcPkgNo},`;
         });
         reportParams = reportParams.slice(0, -1);
     }
-    if (commScope && commScope.length > 0) {
+    if (commPkgNumbers && commPkgNumbers.length > 0) {
         reportParams += '&commPkgs=';
-        commScope.forEach(commPkg => {
-            reportParams += `${commPkg.commPkgNo},`;
+        commPkgNumbers.forEach(commPkgNo => {
+            reportParams += `${commPkgNo},`;
         });
         reportParams = reportParams.slice(0, -1);
     }
@@ -30,13 +30,13 @@ const getReportParams = (mcScope: McPkgScope[], commScope: CommPkgScope[]): stri
 const { Head, Body, Cell, Row } = Table;
 
 interface ReportsTableProps {
-    mcPkgScope: McPkgScope[];
-    commPkgScope: CommPkgScope[];
+    mcPkgNumbers: string[];
+    commPkgNumbers: string[];
 }
 
-const ReportsTable = ({ mcPkgScope, commPkgScope }: ReportsTableProps): JSX.Element => {
+const ReportsTable = ({ mcPkgNumbers, commPkgNumbers }: ReportsTableProps): JSX.Element => {
     const { plant } = useCurrentPlant();
-    const reportParams = getReportParams(mcPkgScope, commPkgScope);
+    const reportParams = getReportParams(mcPkgNumbers, commPkgNumbers);
 
     const getReportUrl = (reportId: number): string => {
         if (reportId === ReportIdEnum.MC32D) {

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/index.tsx
@@ -20,7 +20,7 @@ const Scope = ({ mcPkgScope, commPkgScope, projectName }: ScopeProps): JSX.Eleme
                 <Typography variant="h5">Reports</Typography>
             </HeaderContainer>
             <TableContainer>
-                <ReportsTable commPkgScope={commPkgScope} mcPkgScope={mcPkgScope} />
+                <ReportsTable commPkgNumbers={commPkgScope.map((commPkg) => { return commPkg.commPkgNo; })} mcPkgNumbers={mcPkgScope.map((mcPkg) => { return mcPkg.mcPkgNo; })} />
             </TableContainer>
             {commPkgScope && commPkgScope.length > 0 && (
                 <>
@@ -28,7 +28,7 @@ const Scope = ({ mcPkgScope, commPkgScope, projectName }: ScopeProps): JSX.Eleme
                         <Typography variant="h5">Included Comm Packages</Typography>
                     </HeaderContainer>
                     <TableContainer>
-                        <CommPkgsTable commPkgScope={commPkgScope} projectName={projectName}/>
+                        <CommPkgsTable commPkgScope={commPkgScope} projectName={projectName} />
                     </TableContainer>
                 </>
             )}


### PR DESCRIPTION
# Description

Provide links to report, mcpkgs and commpkgs. Reuse components used in viewIPO

Completes: [AB#80393](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/80393)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [x] My code is covered by tests.
