### PR TITLE
Check canSign before showing unaccept button

### DIFF
--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/__tests__/ParticipantsTable.test.jsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/__tests__/ParticipantsTable.test.jsx
@@ -117,6 +117,71 @@ const participants = [
     }
 ];
 
+const participants_canSign = [
+    {
+        organization: OrganizationsEnum.Contractor,
+        sortKey: 0,
+        canSign: true,
+        person: {
+            person: {
+                id: 123,
+                firstName: 'Adwa',
+                lastName: 'ASdsklandasnd',
+                azureOid: 'azure1',
+                email: 'asdadasd@dwwdwd.com',
+                rowVersion: '123123',
+            },
+            required: true,
+            response: OutlookResponseType.ATTENDING,
+
+        },
+        externalEmail: null,        
+        functionalRole: null,
+        signedBy: {
+            id: 123,
+            firstName: 'Adwa',
+            lastName: 'ASdsklandasnd',
+            userName: 'signer1',
+            azureOid: 'azure1',
+            email: 'asdadasd@dwwdwd.com',
+            rowVersion: '123123'},          
+        signedAtUtc: new Date(2020, 11, 6, 11), 
+        attended: true,
+        note: ''
+    },
+    {
+        organization: OrganizationsEnum.ConstructionCompany,
+        sortKey: 1,
+        canSign: true,
+        person: {
+            person: {
+                id: 234,
+                firstName: 'Oakjfcv',
+                lastName: 'Alkjljsdf',
+                azureOid: 'azure2',
+                email: 'lkjlkjsdf@dwwdwd.com',
+                rowVersion: '123123',
+            },
+            required: true,
+            response: OutlookResponseType.ATTENDING,
+
+        },
+        externalEmail: null,
+        functionalRole: null,
+        signedBy:  {
+            id: 123,
+            userName: 'signer2',
+            firstName: 'Oakjfcv',
+            lastName: 'Alkjljsdf',
+            azureOid: 'azure2',
+            email: 'lkjlkjsdf@dwwdwd.com',
+            rowVersion: '123123',
+        },
+        signedAtUtc: new Date(2020, 11, 6, 12), 
+        attended: true,
+        note: ''
+    }
+];
 
 const completePunchOut = jest.fn();
 const acceptPunchOut = jest.fn();
@@ -154,7 +219,6 @@ describe('<ParticipantsTable />', () => {
         expect(queryByText(`${participants[ParticipantIndex.COMPLETER].person.person.firstName} ${participants[ParticipantIndex.COMPLETER].person.person.lastName}`)).toBeInTheDocument();
         expect(queryByText(`${participants[ParticipantIndex.ACCEPTER].person.person.firstName} ${participants[ParticipantIndex.ACCEPTER].person.person.lastName}`)).toBeInTheDocument();
         expect(queryByText(`${participants[ParticipantIndex.COMPLETER].signedBy.userName}`)).toBeInTheDocument();
-        expect(queryByText('Unaccept punch out')).toBeInTheDocument();
         expect(queryAllByText(participants[ParticipantIndex.COMPLETER].person.response).length).toBeGreaterThan(0);
         expect(queryAllByText(participants[ParticipantIndex.ACCEPTER].person.response).length).toBeGreaterThan(0);
         expect(queryAllByText('Did not attend').length).toBeGreaterThan(0);
@@ -266,7 +330,7 @@ describe('<ParticipantsTable />', () => {
         expect(queryByText('Sign punch out')).not.toBeInTheDocument();
         expect(queryByText('Accept punch out')).not.toBeInTheDocument();
         expect(queryByText(`${participants[ParticipantIndex.COMPLETER].signedBy.userName}`)).toBeInTheDocument();
-        expect(queryByText('Unaccept punch out')).toBeInTheDocument();
+        expect(queryByText('Unaccept punch out')).not.toBeInTheDocument();
         expect(queryByText('06/12/2020 11:00')).toBeInTheDocument();
         expect(queryByText('06/12/2020 12:00')).toBeInTheDocument();
     });
@@ -302,7 +366,7 @@ describe('<ParticipantsTable />', () => {
         expect(queryByText('Sign punch out')).toBeInTheDocument();
         expect(queryByText('Accept punch out')).not.toBeInTheDocument();
         expect(getByText(newParticipants[ParticipantIndex.COMPLETER].signedBy.userName)).toBeInTheDocument();
-        expect(queryByText('Unaccept punch out')).toBeInTheDocument();
+        expect(queryByText('Unaccept punch out')).not.toBeInTheDocument();
         expect(queryByText('06/12/2020 11:00')).toBeInTheDocument();
         expect(queryByText('06/12/2020 12:00')).toBeInTheDocument();
     });
@@ -399,6 +463,24 @@ describe('<ParticipantsTable />', () => {
         expect(mockSetDirtyStateFor).toBeCalledWith(ComponentName.ParticipantsTable);
         expect(mockUnsetDirtyStateFor).toBeCalledTimes(1);
         expect(mockUnsetDirtyStateFor).toBeCalledWith(ComponentName.ParticipantsTable);
+    });
+
+    it('User can accept', async () => {
+        const { queryByText } = renderWithTheme(<ParticipantsTable 
+            participants={participants_canSign} 
+            status={IpoStatusEnum.COMPLETED}
+            accept={acceptPunchOut}
+            complete={completePunchOut} />);
+        expect(queryByText('Accept punch out')).toBeInTheDocument();
+    });
+
+    it('User can unaccept', async () => {
+        const { queryByText } = renderWithTheme(<ParticipantsTable 
+            participants={participants_canSign} 
+            status={IpoStatusEnum.ACCEPTED}
+            accept={acceptPunchOut}
+            complete={completePunchOut} />);
+        expect(queryByText('Unaccept punch out')).toBeInTheDocument();
     });
     
 });

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
@@ -171,7 +171,7 @@ const ParticipantsTable = ({ participants, status, complete, accept, update, sig
                 break;
             case OrganizationsEnum.ConstructionCompany:
                 if (status == IpoStatusEnum.ACCEPTED) {
-                    if (participant.sortKey == 1) {
+                    if (participant.sortKey == 1 && participant.canSign) {
                         return getUnAcceptButton(handleUnAcceptPunchOut);
                     }
                     if (participant.signedBy) {
@@ -181,12 +181,17 @@ const ParticipantsTable = ({ participants, status, complete, accept, update, sig
 
                 if (participant.canSign && status !== IpoStatusEnum.CANCELED) {
                     if (participant.sortKey === 1) {
-                        if (status === IpoStatusEnum.COMPLETED) return getAcceptButton(handleAcceptPunchOut);
+                        if (status === IpoStatusEnum.COMPLETED) {
+                            return getAcceptButton(handleAcceptPunchOut);
+                        }
                     } else {
                         return getSignButton(handleSignPunchOut);
                     }
                 }
 
+                if (participant.signedBy) {
+                    return <span>{`${participant.signedBy.userName}`}</span>;
+                }
                 break;
             case OrganizationsEnum.Operation:
             case OrganizationsEnum.TechnicalIntegrity:


### PR DESCRIPTION
# Description

Ensure that the unaccept button does not show if user cannot sign (already implemented for accept button). Also ensure that signers name is shown, when  user cannot sign. 
 
Completes: [AB#80598](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/80598)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [x] My code is covered by tests.
