### PR TITLE
Bug 80407: Can not click attachments before create

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,7 @@
 import '@testing-library/jest-dom/extend-expect';
 
-window.URL.createObjectURL = function() {};
+function noOp () { }
+
+if (typeof window.URL.createObjectURL === 'undefined') { 
+  Object.defineProperty(window.URL, 'createObjectURL', { value: noOp})
+}

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,3 @@
 import '@testing-library/jest-dom/extend-expect';
+
+window.URL.createObjectURL = function() {};

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Attachments/Attachments.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Attachments/Attachments.tsx
@@ -3,12 +3,12 @@ import { Button, Typography } from '@equinor/eds-core-react';
 import React, { useRef } from 'react';
 import { getFileName, getFileTypeIconName } from '../../utils';
 
+import { Attachment } from '@procosys/modules/InvitationForPunchOut/types';
 import EdsIcon from '@procosys/components/EdsIcon';
 import Table from '@procosys/components/Table';
 import fileTypeValidator from '@procosys/util/FileTypeValidator';
 import { showSnackbarNotification } from '@procosys/core/services/NotificationService';
 import { tokens } from '@equinor/eds-tokens';
-import { Attachment } from '@procosys/modules/InvitationForPunchOut/types';
 
 interface AttachmentsProps {
     attachments: Attachment[];
@@ -69,7 +69,7 @@ const Attachments = ({
 
     const getAttachmentName = (attachment: Attachment): JSX.Element => {
         return (
-            <div>{getFileName(attachment.fileName)}</div>
+            <Typography link target='_blank' href={URL.createObjectURL(attachment.file)}>{getFileName(attachment.fileName)}</Typography>
         );
     };
 

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Summary/Summary.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Summary/Summary.tsx
@@ -2,13 +2,14 @@ import { Attachment, CommPkgRow, GeneralInfoDetails, Participant, Person } from 
 import { Container, FormContainer, Section, Subsection, TableSection } from './Summary.style';
 import { Table, Typography } from '@equinor/eds-core-react';
 import { getFileName, getFileTypeIconName } from '../../utils';
-import EdsIcon from '@procosys/components/EdsIcon';
-import React from 'react';
-import { format } from 'date-fns';
-import ReportsTable from '../../ViewIPO/Scope/ReportsTable';
-import McPkgsTable from '../../ViewIPO/Scope/McPkgsTable';
+
 import CommPkgsTable from '../../ViewIPO/Scope/CommPkgsTable';
+import EdsIcon from '@procosys/components/EdsIcon';
 import { McPkgScope } from '../../ViewIPO/types';
+import McPkgsTable from '../../ViewIPO/Scope/McPkgsTable';
+import React from 'react';
+import ReportsTable from '../../ViewIPO/Scope/ReportsTable';
+import { format } from 'date-fns';
 
 const { Body, Row, Cell, Head } = Table;
 
@@ -75,7 +76,9 @@ const Summary = ({
     const attachmentList = attachments.filter((attachment) => !attachment.toBeDeleted).map((attachment, index) => (
         <Row key={index}>
             <Cell><EdsIcon name={getFileTypeIconName(attachment.fileName)} /></Cell>
-            <Cell>{getFileName(attachment.fileName)}</Cell>
+            <Cell>
+                <Typography link target='_blank' href={URL.createObjectURL(attachment.file)}>{getFileName(attachment.fileName)}</Typography>
+            </Cell>
         </Row>
     ));
 


### PR DESCRIPTION
# Description

- Add URL.createObjectURL on file object to retrieve file before upload

Completes: [AB#80407](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/80407)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [x] My code is covered by tests.
