### PR TITLE
Add Helmet package and favicon linking

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "@types/qs": "^6.9.4",
         "@types/react": "^17.0.0",
         "@types/react-dom": "^17.0.0",
+        "@types/react-helmet": "^6.1.0",
         "@types/react-router-dom": "^5.1.7",
         "@types/styled-components": "^5.1.3",
         "@typescript-eslint/eslint-plugin": "^4.0.1",
@@ -90,6 +91,7 @@
         "qs": "^6.9.4",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
+        "react-helmet": "^6.1.0",
         "react-router-dom": "^5.1.2",
         "styled-components": "^5.2.0"
     }

--- a/src/app/Root.tsx
+++ b/src/app/Root.tsx
@@ -9,6 +9,7 @@ import Error from '@procosys/components/Error';
 import { IAuthService } from 'src/auth/AuthService';
 import Loading from '@procosys/components/Loading';
 import { hot } from 'react-hot-loader';
+import { Helmet } from 'react-helmet';
 
 type AppProps = {
     authService: IAuthService;
@@ -56,6 +57,9 @@ const Root = (props: AppProps): JSX.Element => {
 
     return (
         <ProcosysContext.Provider value={context}>
+            <Helmet>
+                <title>&nbsp;</title>
+            </Helmet>
             <div id="procosys-root" ref={rootRef}>
                 <App />
             </div>

--- a/src/declarations/globals.d.ts
+++ b/src/declarations/globals.d.ts
@@ -1,1 +1,2 @@
 declare const __DEV__: boolean;
+declare module '*.png';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,6 @@
 import ProCoSysSettings, {AsyncState} from '@procosys/core/ProCoSysSettings';
+// const favicon = require('./assets/icons/ProCoSys_favicon16x16.png');
+import favicon from './assets/icons/ProCoSys_favicon16x16.png';
 
 import AuthService from './auth/AuthService';
 import Error from './components/Error';
@@ -7,13 +9,23 @@ import Login from './modules/Login';
 import React from 'react';
 import Root from './app/Root';
 import { render } from 'react-dom';
+import Helmet from 'react-helmet';
 
 const element = document.createElement('div');
 element.setAttribute('id', 'app-container');
 document.body.appendChild(element);
 
+const getHelmetBaseConfig = (): JSX.Element => {
+    return <Helmet titleTemplate="ProCoSys - %s">
+        <title>Authenticating</title>
+        <link rel="icon" type="image/png" href={favicon} sizes="16x16" />
+    </Helmet>;
+};
+
 render(
-    <Loading title="Loading configuration" />,
+    <>{getHelmetBaseConfig()}
+        <Loading title="Loading configuration" />
+    </>,
     element);
 
 const validateConfigurationState = async (): Promise<void> => {
@@ -22,7 +34,10 @@ const validateConfigurationState = async (): Promise<void> => {
 
     if (ProCoSysSettings.authConfigState == AsyncState.ERROR) {
         render(
-            <Error title="Failed to initialize auth config" large />,
+            <>
+                {getHelmetBaseConfig()}
+                <Error title="Failed to initialize auth config" large />
+            </>,
             element);
     } else {
         const authService = new AuthService();
@@ -37,11 +52,17 @@ const validateConfigurationState = async (): Promise<void> => {
             if (authService.getCurrentUser() === null) {
                 authService.login();
                 render(
-                    <Login />,
+                    <>
+                        {getHelmetBaseConfig()}
+                        <Login />
+                    </>,
                     element);
             } else {
                 render(
-                    <Root authService={authService} />,
+                    <>
+                        {getHelmetBaseConfig()}
+                        <Root authService={authService} />
+                    </>,
                     element);
             }
         }

--- a/webpack.development.config.js
+++ b/webpack.development.config.js
@@ -10,7 +10,13 @@ module.exports = {
         rules: [
             {
                 test: /\.(jpe?g|png|gif|svg)$/,
-                loader: 'file-loader',
+                use: [{
+                    loader: 'file-loader', 
+                    options: {
+                        name: '[name].[ext]',
+                        outputPath: 'v2-assets/images/'
+                    }
+                }]
             },
             {
                 test: /\.(ts|tsx)$/,
@@ -90,7 +96,6 @@ module.exports = {
         /* Automatically creates our index.html page */
         new HtmlWebpackPlugin({
             title: 'ProCoSys',
-            favicon: 'src/assets/icons/ProCoSys_favicon16x16.png',
             meta: {
                 viewport: 'width=device-width, height=device-height, initial-scale=1'
             }

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -10,7 +10,13 @@ module.exports = {
         rules: [
             {
                 test: /\.(jpe?g|png|gif|svg)$/,
-                loader: 'file-loader'
+                use: [{
+                    loader: 'file-loader', 
+                    options: {
+                        name: '[name].[ext]',
+                        outputPath: 'v2-assets/images/'
+                    }
+                }]
             },
             {
                 test: /\.(ts|tsx)$/,
@@ -89,7 +95,6 @@ module.exports = {
         /* Automatically creates our index.html page */
         new HtmlWebpackPlugin({
             title: 'ProCoSys',
-            favicon: 'src/assets/icons/ProCoSys_favicon16x16.png',
             meta: {
                 viewport: 'width=device-width, height=device-height, initial-scale=1'
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1685,6 +1685,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-helmet@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@types/react-helmet/-/react-helmet-6.1.0.tgz#af586ed685f4905e2adc7462d1d65ace52beee7a"
+  integrity sha512-PYRoU1XJFOzQ3BHvWL1T8iDNbRjdMDJMT5hFmZKGbsq09kbSqJy61uwEpTrbTNWDopVphUT34zUSVLK9pjsgYQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-router-dom@^5.1.7":
   version "5.1.7"
   resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.1.7.tgz#a126d9ea76079ffbbdb0d9225073eb5797ab7271"
@@ -7292,6 +7299,21 @@ react-double-scrollbar@0.0.15:
   resolved "https://registry.yarnpkg.com/react-double-scrollbar/-/react-double-scrollbar-0.0.15.tgz#e915ab8cb3b959877075f49436debfdb04288fe4"
   integrity sha1-6RWrjLO5WYdwdfSUNt6/2wQoj+Q=
 
+react-fast-compare@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
+react-helmet@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
+  integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.1.1"
+    react-side-effect "^2.1.0"
+
 react-hot-loader@^4.13.0:
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.13.0.tgz#c27e9408581c2a678f5316e69c061b226dc6a202"
@@ -7360,6 +7382,11 @@ react-router@5.2.0:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
+
+react-side-effect@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.1.tgz#66c5701c3e7560ab4822a4ee2742dee215d72eb3"
+  integrity sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==
 
 react-transition-group@^4.0.0, react-transition-group@^4.4.0:
   version "4.4.1"


### PR DESCRIPTION
# Description
Fixes Favicon not loading from relative path. 

Early introduction of Helmet package due to webpack issues with using favicon relative to the correct output bundle path. 

Helmet will allow us to set page titles in our different components, which is related to [AB#80915](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/80915) . 
By introducing this now, we fix our favicon issue and we are all set for starting to add page titles. 

Completes: [AB#79147](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/79147)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [x] My code is covered by tests. (N/A)
