### PR TITLE
Hotfix 81134: Attachment list links in edit mode

### DIFF
--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Attachments/Attachments.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Attachments/Attachments.tsx
@@ -7,6 +7,7 @@ import { Attachment } from '@procosys/modules/InvitationForPunchOut/types';
 import EdsIcon from '@procosys/components/EdsIcon';
 import Table from '@procosys/components/Table';
 import fileTypeValidator from '@procosys/util/FileTypeValidator';
+import { getAttachmentDownloadLink } from '../utils';
 import { showSnackbarNotification } from '@procosys/core/services/NotificationService';
 import { tokens } from '@equinor/eds-tokens';
 
@@ -68,8 +69,10 @@ const Attachments = ({
     };
 
     const getAttachmentName = (attachment: Attachment): JSX.Element => {
+        const link = getAttachmentDownloadLink(attachment);
+
         return (
-            <Typography link target='_blank' href={URL.createObjectURL(attachment.file)}>{getFileName(attachment.fileName)}</Typography>
+            <Typography link={!!link} target='_blank' href={link}>{getFileName(attachment.fileName)}</Typography>
         );
     };
 

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Summary/Summary.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Summary/Summary.tsx
@@ -10,6 +10,7 @@ import McPkgsTable from '../../ViewIPO/Scope/McPkgsTable';
 import React from 'react';
 import ReportsTable from '../../ViewIPO/Scope/ReportsTable';
 import { format } from 'date-fns';
+import { getAttachmentDownloadLink } from '../utils';
 
 const { Body, Row, Cell, Head } = Table;
 
@@ -73,14 +74,16 @@ const Summary = ({
             </Row>);
     };
 
-    const attachmentList = attachments.filter((attachment) => !attachment.toBeDeleted).map((attachment, index) => (
-        <Row key={index}>
+    const attachmentList = attachments.filter((attachment) => !attachment.toBeDeleted).map((attachment, index) => {
+        const link = getAttachmentDownloadLink(attachment);
+
+        return (<Row key={index}>
             <Cell><EdsIcon name={getFileTypeIconName(attachment.fileName)} /></Cell>
             <Cell>
-                <Typography link target='_blank' href={URL.createObjectURL(attachment.file)}>{getFileName(attachment.fileName)}</Typography>
+                <Typography link={!!link} target='_blank' href={link}>{getFileName(attachment.fileName)}</Typography>
             </Cell>
-        </Row>
-    ));
+        </Row>);
+    });
 
     return (<Container>
         <FormContainer>

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/utils.ts
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/utils.ts
@@ -1,5 +1,7 @@
 import { addDays, addHours, addMinutes, set } from 'date-fns';
 
+import { Attachment } from '../../types';
+
 export const getEndTime = (date: Date): Date => {
     if (date.getHours() === 23) {
         const minutes = date.getMinutes();
@@ -26,4 +28,16 @@ export const getNextHalfHourTimeString = (date: Date): Date => {
 
 export const isEmptyObject = (obj: Record<string, string>): boolean => {
     return Object.keys(obj).length === 0 && obj.constructor === Object;
+};
+
+export const getAttachmentDownloadLink = (attachment: Attachment): string | undefined => {
+    if (attachment.downloadUri) {
+        return attachment.downloadUri;
+    }
+
+    if (attachment.file && typeof window.URL.createObjectURL !== 'undefined') {
+        window.URL.createObjectURL(attachment.file);
+    }
+
+    return undefined;
 };


### PR DESCRIPTION
# Description

When editing an invitation, already uploaded files hav a downloadUri which should be handled as a href. Additional check is made for newly uploaded attachments for window.URL.createObjectUrl support.

Completes: [AB#81134](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/81134)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [x] My code is covered by tests.
