### PR TITLE
Bug/80319 preservering edit

### DIFF
--- a/src/modules/Preservation/views/EditTagProperties/EditTagProperties.tsx
+++ b/src/modules/Preservation/views/EditTagProperties/EditTagProperties.tsx
@@ -41,6 +41,7 @@ const EditTagProperties = (): JSX.Element => {
     const remarkInputRef = useRef<HTMLInputElement>(null);
     const storageAreaInputRef = useRef<HTMLInputElement>(null);
 
+    const [description, setDescription] = useState<string | null>(null);
     const [tag, setTag] = useState<TagDetails>();
     const [requirementTypes, setRequirementTypes] = useState<RequirementType[]>([]);
     const [requirements, setRequirements] = useState<RequirementFormInput[]>([]);
@@ -73,6 +74,7 @@ const EditTagProperties = (): JSX.Element => {
                         setPoTag(true);
                     }
                     setRowVersion(details.rowVersion);
+                    setDescription(details.description);
                 } catch (error) {
                     console.error('Get tag details failed: ', error.message, error.data);
                     showSnackbarNotification(error.message);
@@ -278,14 +280,6 @@ const EditTagProperties = (): JSX.Element => {
         }
     };
 
-    const tagDescriptionChange = (): void => {
-        if (tag && tagDescriptionInputRef.current && tagDescriptionInputRef.current.value != tag.description) {
-            setTagJourneyOrRequirementsEdited(true);
-        } else {
-            setTagJourneyOrRequirementsEdited(false);
-        }
-    };
-
     /**
      * Check if any changes have been made to journey, step or requirements
      */
@@ -295,7 +289,7 @@ const EditTagProperties = (): JSX.Element => {
         } else {
             setTagJourneyOrRequirementsEdited(false);
         }
-    }, [requirements, step, journey, originalRequirements]);
+    }, [requirements, step, journey, originalRequirements, description]);
 
     const updateRemarkAndStorageArea = async (): Promise<string> => {
         try {
@@ -313,7 +307,7 @@ const EditTagProperties = (): JSX.Element => {
 
     const updateTagJourneyAndRequirements = async (currentRowVersion: string): Promise<void> => {
         try {
-            if (tag && step && tagDescriptionInputRef.current) {
+            if (tag && step && description) {
                 let newRequirements: RequirementFormInput[] = [];
                 const numberOfNewReq = requirements.length - originalRequirements.length;
                 if (requirements.length > originalRequirements.length) {
@@ -327,7 +321,7 @@ const EditTagProperties = (): JSX.Element => {
                         rowVersion: req.rowVersion
                     };
                 });
-                await apiClient.updateTagStepAndRequirements(tag.id, tagDescriptionInputRef.current.value, step.id, currentRowVersion, updatedRequirements, newRequirements);
+                await apiClient.updateTagStepAndRequirements(tag.id, description, step.id, currentRowVersion, updatedRequirements, newRequirements);
             }
         } catch (error) {
             handleErrorFromBackend(error, 'Error updating journey, step or requirements');
@@ -400,10 +394,9 @@ const EditTagProperties = (): JSX.Element => {
                                     id={'Description'}
                                     label='Tag description'
                                     defaultValue={tag ? tag.description : ''}
-                                    inputRef={tagDescriptionInputRef}
                                     disabled={tag && !dummyTagTypes.includes(tag.tagType)}
                                     placeholder={'Write here'}
-                                    onChange={tagDescriptionChange}
+                                    onChange={(e: React.ChangeEvent<HTMLInputElement>): void => setDescription(e.target.value)}
                                 />
                             </InputContainer>
                             <InputContainer>

--- a/src/modules/Preservation/views/EditTagProperties/EditTagProperties.tsx
+++ b/src/modules/Preservation/views/EditTagProperties/EditTagProperties.tsx
@@ -37,7 +37,6 @@ const EditTagProperties = (): JSX.Element => {
     const [mappedSteps, setMappedSteps] = useState<SelectItem[]>([]);
     const [step, setStep] = useState<Step | null>();
 
-    const tagDescriptionInputRef = useRef<HTMLInputElement>(null);
     const remarkInputRef = useRef<HTMLInputElement>(null);
     const storageAreaInputRef = useRef<HTMLInputElement>(null);
 
@@ -281,10 +280,10 @@ const EditTagProperties = (): JSX.Element => {
     };
 
     /**
-     * Check if any changes have been made to journey, step or requirements
+     * Check if any changes have been made to journey, step requirements, or description
      */
     useEffect(() => {
-        if (tag && ((newJourney && newJourney != tag.journey.title) || (step && step.id != tag.step.id) || JSON.stringify(requirements) != JSON.stringify(originalRequirements))) {
+        if (tag && ((newJourney && newJourney != tag.journey.title) || (step && step.id != tag.step.id) || JSON.stringify(requirements) != JSON.stringify(originalRequirements) || (description && description != tag.description))) {
             setTagJourneyOrRequirementsEdited(true);
         } else {
             setTagJourneyOrRequirementsEdited(false);
@@ -324,7 +323,7 @@ const EditTagProperties = (): JSX.Element => {
                 await apiClient.updateTagStepAndRequirements(tag.id, description, step.id, currentRowVersion, updatedRequirements, newRequirements);
             }
         } catch (error) {
-            handleErrorFromBackend(error, 'Error updating journey, step or requirements');
+            handleErrorFromBackend(error, 'Error updating journey, step, requirements, or description');
         }
     };
 


### PR DESCRIPTION
# Description

Fixed users not being able to edit all fields in a tag at once. Changed tag description into a state field instead of a reference, as the description reference was nulled if there was an API call to update the remark and/or storage area.

Completes: [AB#80319](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/80319)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
