### PR TITLE
Feature 88132: UI - Filter adjustments

### DIFF
--- a/src/core/DirtyContext.tsx
+++ b/src/core/DirtyContext.tsx
@@ -7,6 +7,7 @@ export interface IDirtyContext {
     isDirty: boolean;
     setDirtyStateFor: (componentName: string) => void;
     unsetDirtyStateFor: (componentName: string) => void;
+    unsetDirtyStateForMany: (componentNames: string[]) => void;
     clearDirtyState: () => void;
 }
 
@@ -31,6 +32,13 @@ export const DirtyContextProvider: React.FC = ({ children }): JSX.Element => {
         newDirtyList.delete(componentName) && setDirtyList(newDirtyList);
     }
 
+    function unsetDirtyStateForMany(componentNames: string[]): void {
+        const newDirtyList = new Set(dirtyList);
+        // Only changes the state if there actually was a item removed
+        componentNames.forEach(componentName => newDirtyList.delete(componentName));
+        setDirtyList(newDirtyList);
+    }
+
     function clearDirtyState(): void {
         setDirtyList(new Set());
     }
@@ -46,6 +54,7 @@ export const DirtyContextProvider: React.FC = ({ children }): JSX.Element => {
     return (<DirtyContext.Provider value={{
         setDirtyStateFor: setDirtyStateFor,
         unsetDirtyStateFor,
+        unsetDirtyStateForMany,
         clearDirtyState,
         isDirty,
     }}>

--- a/src/core/services/DateService.ts
+++ b/src/core/services/DateService.ts
@@ -1,47 +1,59 @@
 
+// THE COMMENTED FUNCTIONS HAVE BEEN USED BY PRESERVATION
+// KEEP FOR CONVENIENCE UNTIL EDS DATETIME STRATEGY IS IN PLACE
+
 /**
  * Return formatted date (dd.mm.yyyy). Empty string is returned if date is null.
  * @param date 
  */
-export const getFormattedDate = (date: Date | null): string => {
-    if (date === null) {
-        return '';
-    }
-    const newDate = new Date(date);
-    const d = newDate.getDate();
-    const m = newDate.getMonth() + 1;
-    const y = newDate.getFullYear();
-    return '' + (d <= 9 ? '0' + d : d) + '.' + (m <= 9 ? '0' + m : m) + '.' + y;
-};
+// export const getFormattedDate = (date: Date | null): string => {
+//     if (date === null) {
+//         return '';
+//     }
+//     const newDate = new Date(date);
+//     const d = newDate.getDate();
+//     const m = newDate.getMonth() + 1;
+//     const y = newDate.getFullYear();
+//     return '' + (d <= 9 ? '0' + d : d) + '.' + (m <= 9 ? '0' + m : m) + '.' + y;
+// };
 
 /**
  * Return formatted date and time (dd.mm.yyyy hh:mi). Empty string is returned if date is null.
  * @param date 
  */
-export const getFormattedDateAndTime = (date: Date | null): string => {
-    if (date === null) {
+// export const getFormattedDateAndTime = (date: Date | null): string => {
+//     if (date === null) {
+//         return '';
+//     }
+//     const newDate = new Date(date);
+//     const d = newDate.getDate();
+//     const m = newDate.getMonth() + 1;
+//     const y = newDate.getFullYear();
+//     const h = newDate.getHours();
+//     const min = newDate.getMinutes();
+//     return '' + (d <= 9 ? '0' + d : d) + '.' + (m <= 9 ? '0' + m : m) + '.' + y + ' ' + (h <= 9 ? '0' + h : h) + ':' + (min <= 9 ? '0' + min : min);
+// };
+
+export const getFormattedDateAndTime = (date: Date | string | undefined): string => {
+    if (!date) {
         return '';
     }
     const newDate = new Date(date);
-    const d = newDate.getDate();
-    const m = newDate.getMonth() + 1;
-    const y = newDate.getFullYear();
-    const h = newDate.getFullYear();
-    const min = newDate.getFullYear();
-    return '' + (d <= 9 ? '0' + d : d) + '.' + (m <= 9 ? '0' + m : m) + '.' + y + ' ' + (h <= 9 ? '0' + h : h) + ':' + (min <= 9 ? '0' + min : min);
+    return newDate.toLocaleString([], { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' });
 };
 
-
-export const getLocalDateAndTime = (date: Date | undefined): string => {
+export const getFormattedDate = (date: Date | string | undefined): string => {
     if (!date) {
         return '';
     }
-    return date.toLocaleString([], { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' });
+    const newDate = new Date(date);
+    return newDate.toLocaleString([], { year: 'numeric', month: '2-digit', day: '2-digit' });
 };
 
-export const getLocalDate = (date: Date | undefined): string => {
+export const getFormattedTime = (date: Date | string | null): string => {
     if (!date) {
         return '';
     }
-    return date.toLocaleString([], { year: 'numeric', month: '2-digit', day: '2-digit' });
+    const newDate = new Date(date);
+    return newDate.toLocaleString([], { hour: '2-digit', minute: '2-digit' });
 };

--- a/src/modules/InvitationForPunchOut/index.tsx
+++ b/src/modules/InvitationForPunchOut/index.tsx
@@ -1,10 +1,11 @@
+import React, { ReactElement } from 'react';
 import { Route, BrowserRouter as Router, Switch, useRouteMatch } from 'react-router-dom';
 
 import { Container } from './style';
 import CreateIPO from './views/CreateAndEditIPO/CreateIPO';
 import EditIPO from './views/CreateAndEditIPO/EditIPO';
+import { Helmet } from 'react-helmet';
 import { InvitationForPunchOutContextProvider } from './context/InvitationForPunchOutContext';
-import React from 'react';
 import SearchIPO from './views/SearchIPO';
 import ViewIPO from './views/ViewIPO/index';
 import withAccessControl from '@procosys/core/security/withAccessControl';
@@ -12,40 +13,72 @@ import withAccessControl from '@procosys/core/security/withAccessControl';
 const InvitationForPunchOut = (): JSX.Element => {
     const { url } = useRouteMatch();
     return (
-        <InvitationForPunchOutContextProvider>
-            <Container>
-                <Router basename={url}>
-                    <Switch>
-                        <Route
-                            path={'/'}
-                            exact
-                            component={SearchIPO}
-                        />
-                        <Route
-                            path={'/CreateIPO/:projectName?/:commPkgNo?'}
-                            exact
-                            component={CreateIPO}
-                        />
-                        <Route
-                            path={'/EditIPO/:ipoId'}
-                            exact
-                            component={EditIPO}
-                        />
+        <>
+            <Helmet titleTemplate={'ProCoSys - IPO - %s'}>
+            </Helmet>
+            <InvitationForPunchOutContextProvider>
+                <Container>
+                    <Router basename={url}>
+                        <Switch>
+                            <Route
+                                path={'/'}
+                                exact
+                                component={(): ReactElement => (
+                                    <>
+                                        <Helmet>
+                                            <title>{'Search'}</title>
+                                        </Helmet>
+                                        <SearchIPO />
+                                    </>)}
+                            />
+                            <Route
+                                path={'/CreateIPO/:projectName?/:commPkgNo?'}
+                                exact
+                                component={(): ReactElement => (
+                                    <>
+                                        <Helmet>
+                                            <title>{'Create'}</title>
+                                        </Helmet>
+                                        <CreateIPO />
+                                    </>)}
+                            />
+                            <Route
+                                path={'/EditIPO/:ipoId'}
+                                exact
+                                component={(): ReactElement => (
+                                    <>
+                                        <Helmet>
+                                            <title>{'Edit'}</title>
+                                        </Helmet>
+                                        <EditIPO />
+                                    </>)}
+                            />
 
-                        <Route
-                            path={'/:ipoId'}
-                            exact
-                            component={ViewIPO}
-                        />
-                        <Route
-                            component={(): JSX.Element =>
-                                (<h2>Sorry, this page does not exist</h2>)
-                            }
-                        />
-                    </Switch>
-                </Router>
-            </Container>
-        </InvitationForPunchOutContextProvider>
+                            <Route
+                                path={'/:ipoId'}
+                                exact
+                                component={(): ReactElement => (
+                                    <>
+                                        <Helmet>
+                                            <title>{'View'}</title>
+                                        </Helmet>
+                                        <ViewIPO />
+                                    </>)}
+                            />
+                            <Route
+                                component={(): ReactElement => (
+                                    <>
+                                        <Helmet>
+                                            <title>{'NotFound'}</title>
+                                        </Helmet>
+                                        <h2>Sorry, this page does not exist</h2>
+                                    </>)}
+                            />
+                        </Switch>
+                    </Router>
+                </Container>
+            </InvitationForPunchOutContextProvider>
+        </>
     );
 };
 

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Attachments/Attachments.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Attachments/Attachments.tsx
@@ -4,12 +4,14 @@ import React, { useRef } from 'react';
 import { getFileName, getFileTypeIconName } from '../../utils';
 
 import { Attachment } from '@procosys/modules/InvitationForPunchOut/types';
+import { ComponentName } from '../../enums';
 import EdsIcon from '@procosys/components/EdsIcon';
 import Table from '@procosys/components/Table';
 import fileTypeValidator from '@procosys/util/FileTypeValidator';
 import { getAttachmentDownloadLink } from '../utils';
 import { showSnackbarNotification } from '@procosys/core/services/NotificationService';
 import { tokens } from '@equinor/eds-tokens';
+import { useDirtyContext } from '@procosys/core/DirtyContext';
 
 interface AttachmentsProps {
     attachments: Attachment[];
@@ -21,6 +23,7 @@ const Attachments = ({
     setAttachments
 }: AttachmentsProps): JSX.Element => {
     const inputFileRef = useRef<HTMLInputElement>(null);
+    const { setDirtyStateFor } = useDirtyContext();
 
     const handleSubmitFile = (e: any): void => {
         e.preventDefault();
@@ -49,6 +52,7 @@ const Attachments = ({
                 [...currentAttachments.slice(0, index), ...currentAttachments.slice(index + 1)]
             );
         }
+        setDirtyStateFor(ComponentName.Attachments);
     };
 
     const addAttachments = (files: FileList | null): void => {
@@ -66,6 +70,7 @@ const Attachments = ({
             }
 
         });
+        setDirtyStateFor(ComponentName.Attachments);
     };
 
     const getAttachmentName = (attachment: Attachment): JSX.Element => {

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateIPO.tsx
@@ -104,7 +104,7 @@ const CreateIPO = (): JSX.Element => {
     const [projectNameFromMain] = useState<string | null>(params.projectName ? decodeURIComponent(params.projectName) : null);
     const [commPkgNoFromMain] = useState<string | null>(params.commPkgNo ? decodeURIComponent(params.commPkgNo) : null);
 
-    const { setDirtyStateFor, unsetDirtyStateFor } = useDirtyContext();
+    const { setDirtyStateFor, unsetDirtyStateFor, unsetDirtyStateForMany } = useDirtyContext();
     const analystics = useAnalytics();
 
     useEffect(() => {
@@ -268,7 +268,7 @@ const CreateIPO = (): JSX.Element => {
 
                 await uploadAllAttachments(newIpoId);
 
-                unsetDirtyStateFor(ComponentName.CreateAndEditIPO);
+                unsetDirtyStateForMany([ComponentName.Attachments, ComponentName.GeneralInfo]);
                 history.push('/' + newIpoId);
             } catch (error) {
                 console.error('Create IPO failed: ', error.message, error.data);
@@ -294,26 +294,28 @@ const CreateIPO = (): JSX.Element => {
         );
     };
 
-    return (<CreateAndEditIPO
-        saveIpo={createNewIpo}
-        steps={steps}
-        setSteps={setSteps}
-        generalInfo={generalInfo}
-        setGeneralInfo={setGeneralInfo}
-        selectedCommPkgScope={selectedCommPkgScope}
-        setSelectedCommPkgScope={setSelectedCommPkgScope}
-        selectedMcPkgScope={selectedMcPkgScope}
-        setSelectedMcPkgScope={setSelectedMcPkgScope}
-        participants={participants}
-        setParticipants={setParticipants}
-        attachments={attachments}
-        setAttachments={setAttachments}
-        availableRoles={availableRoles}
-        fromMain={fromMain}
-        confirmationChecked={confirmationChecked}
-        setConfirmationChecked={setConfirmationChecked}
-        commPkgNoFromMain={commPkgNoFromMain}
-    />);
+    return (
+        <CreateAndEditIPO
+            saveIpo={createNewIpo}
+            steps={steps}
+            setSteps={setSteps}
+            generalInfo={generalInfo}
+            setGeneralInfo={setGeneralInfo}
+            selectedCommPkgScope={selectedCommPkgScope}
+            setSelectedCommPkgScope={setSelectedCommPkgScope}
+            selectedMcPkgScope={selectedMcPkgScope}
+            setSelectedMcPkgScope={setSelectedMcPkgScope}
+            participants={participants}
+            setParticipants={setParticipants}
+            attachments={attachments}
+            setAttachments={setAttachments}
+            availableRoles={availableRoles}
+            fromMain={fromMain}
+            confirmationChecked={confirmationChecked}
+            setConfirmationChecked={setConfirmationChecked}
+            commPkgNoFromMain={commPkgNoFromMain}
+        />
+    );
 };
 
 export default CreateIPO;

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Summary/Summary.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Summary/Summary.tsx
@@ -2,6 +2,7 @@ import { Attachment, CommPkgRow, GeneralInfoDetails, Participant, Person } from 
 import { Container, FormContainer, Section, Subsection, TableSection } from './Summary.style';
 import { Table, Typography } from '@equinor/eds-core-react';
 import { getFileName, getFileTypeIconName } from '../../utils';
+import { getFormattedDate, getFormattedTime } from '@procosys/core/services/DateService';
 
 import CommPkgsTable from '../../ViewIPO/Scope/CommPkgsTable';
 import EdsIcon from '@procosys/components/EdsIcon';
@@ -9,7 +10,6 @@ import { McPkgScope } from '../../ViewIPO/types';
 import McPkgsTable from '../../ViewIPO/Scope/McPkgsTable';
 import React from 'react';
 import ReportsTable from '../../ViewIPO/Scope/ReportsTable';
-import { format } from 'date-fns';
 import { getAttachmentDownloadLink } from '../utils';
 
 const { Body, Row, Cell, Head } = Table;
@@ -111,15 +111,15 @@ const Summary = ({
                 <div className='timeContainer'>
                     <Subsection>
                         <Typography token={{ fontSize: '12px' }}>Date</Typography>
-                        <Typography variant="body_long">{format(generalInfo.startTime, 'dd/MM/yyyy')}</Typography>
+                        <Typography variant="body_long">{getFormattedDate(generalInfo.startTime)}</Typography>
                     </Subsection>
                     <Subsection>
                         <Typography token={{ fontSize: '12px' }}>Start</Typography>
-                        <Typography variant="body_long">{format(generalInfo.startTime, 'HH:mm')}</Typography>
+                        <Typography variant="body_long">{getFormattedTime(generalInfo.startTime)}</Typography>
                     </Subsection>
                     <Subsection>
                         <Typography token={{ fontSize: '12px' }}>End</Typography>
-                        <Typography variant="body_long">{format(generalInfo.endTime, 'HH:mm')}</Typography>
+                        <Typography variant="body_long">{getFormattedTime(generalInfo.endTime)}</Typography>
                     </Subsection>
                 </div>
                 <Subsection>

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Summary/__tests__/Summary.test.jsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Summary/__tests__/Summary.test.jsx
@@ -1,6 +1,7 @@
+import { getFormattedDate, getFormattedTime } from '@procosys/core/services/DateService';
+
 import React from 'react';
 import Summary from '../Summary';
-import { format } from 'date-fns';
 import { render } from '@testing-library/react';
 
 const generalInfo = {
@@ -73,9 +74,9 @@ describe('Module: <Summary />', () => {
         expect(getByText(generalInfo.poType.text)).toBeInTheDocument();
         expect(getByText(generalInfo.title)).toBeInTheDocument();
         expect(getByText(generalInfo.description)).toBeInTheDocument();
-        expect(getByText(format(generalInfo.startTime, 'dd/MM/yyyy'))).toBeInTheDocument();
-        expect(getAllByText(format(generalInfo.startTime, 'HH:mm')).length).toBeGreaterThan(0);
-        expect(getAllByText(format(generalInfo.endTime, 'HH:mm')).length).toBeGreaterThan(0);
+        expect(getByText(getFormattedDate(generalInfo.startTime))).toBeInTheDocument();
+        expect(getAllByText(getFormattedTime(generalInfo.startTime)).length).toBeGreaterThan(0);
+        expect(getAllByText(getFormattedTime(generalInfo.endTime)).length).toBeGreaterThan(0);
         expect(getByText(generalInfo.location)).toBeInTheDocument();
     });
 

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/utils.ts
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/utils.ts
@@ -34,9 +34,8 @@ export const getAttachmentDownloadLink = (attachment: Attachment): string | unde
     if (attachment.downloadUri) {
         return attachment.downloadUri;
     }
-
-    if (attachment.file && typeof window.URL.createObjectURL !== 'undefined') {
-        window.URL.createObjectURL(attachment.file);
+    if (attachment.file !== undefined && typeof window.URL.createObjectURL !== 'undefined') {
+        return window.URL.createObjectURL(attachment.file);
     }
 
     return undefined;

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/Filter/CheckboxFilterWithDates/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/Filter/CheckboxFilterWithDates/index.tsx
@@ -8,7 +8,7 @@ import EdsIcon from '@procosys/components/EdsIcon';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
 import { Typography } from '@equinor/eds-core-react';
-import { format } from 'date-fns';
+import { getFormattedDate } from '@procosys/core/services/DateService';
 
 interface CheckboxFilterWithDatesProps {
     title: string;
@@ -77,7 +77,7 @@ const CheckboxFilterWithDates = ({
                                             key={value.id}
                                             label={value.title}
                                             type='date'
-                                            value={dateValue ? format(dateValue, 'yyyy-MM-dd'): ''}
+                                            value={dateValue ? getFormattedDate(dateValue): ''}
                                             InputLabelProps={{
                                                 shrink: true,
                                             }}

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/Table/index.style.tsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/Table/index.style.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { tokens } from '@equinor/eds-tokens';
 
@@ -28,4 +29,8 @@ export const Container = styled.div`
         text-overflow: ellipsis;
         color: inherit;
     }
+`;
+
+export const CustomLink = styled(Link)`
+    color: ${tokens.colors.interactive.primary__resting.rgba};
 `;

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/Table/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/Table/index.tsx
@@ -40,7 +40,6 @@ const InvitationsTable = ({getIPOs, pageSize, setPageSize, shouldSelectFirstPage
 
     const getIdColumn = (data: string):JSX.Element => {
         return (
-            // TODO: meka link turquoise!!
             <CustomLink to={`/${data}`}>
                 {data}
             </CustomLink>

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/Table/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/Table/index.tsx
@@ -1,15 +1,14 @@
+import { Container, CustomLink } from './index.style';
 import { Query, QueryResult } from 'material-table';
 import React, { useEffect, useRef } from 'react';
 
-import { Container } from './index.style';
 import { IPO } from '../types';
 import { IpoStatusEnum } from '../../enums';
-import { Link } from 'react-router-dom';
 import Table from '@procosys/components/Table';
+import { Tooltip } from '@material-ui/core';
 import { Typography } from '@equinor/eds-core-react';
-import { getLocalDate } from '@procosys/core/services/DateService';
+import { getFormattedDate } from '@procosys/core/services/DateService';
 import { tokens } from '@equinor/eds-tokens';
-import { useCurrentPlant } from '@procosys/core/PlantContext';
 
 interface InvitationsTableProps {
     getIPOs: (page: number, pageSize: number, orderByField: string | null, orderDirection: string | null) => Promise<any>;
@@ -26,16 +25,6 @@ interface InvitationsTableProps {
 
 const InvitationsTable = ({getIPOs, pageSize, setPageSize, shouldSelectFirstPage, setFirstPageSelected, projectName, height, update, filterUpdate }: InvitationsTableProps): JSX.Element => {
     const refObject = useRef<any>();
-    const { plant } = useCurrentPlant();
- 
-
-    const getMcPkgUrl = (mcPkgNo: string): string => {
-        return `/${plant.pathId}/Completion#McPkg|?projectName=${projectName}&mcpkgno=${mcPkgNo}`;
-    };
-
-    const getCommPkgUrl = (commPkgNo: string): string => {
-        return `/${plant.pathId}/Completion#CommPkg|?projectName=${projectName}&commpkgno=${commPkgNo}`;
-    };
 
     useEffect(() => {
         if (refObject.current) {
@@ -51,45 +40,34 @@ const InvitationsTable = ({getIPOs, pageSize, setPageSize, shouldSelectFirstPage
 
     const getIdColumn = (data: string):JSX.Element => {
         return (
-            <div className='controlOverflow'>
-                <Link to={`/${data}`}>
-                    <Typography link>{data}</Typography>
-                </Link>
-            </div>
+            // TODO: meka link turquoise!!
+            <CustomLink to={`/${data}`}>
+                {data}
+            </CustomLink>
 
-        );
-
-    };
-
-    const getMcPkgColumn = (mcPkgs: string[] | undefined): JSX.Element => {
-        return (
-            <div>{mcPkgs?.map((pkgNo, index) => {
-                const separator: any = index < mcPkgs.length-1 ? 
-                    index % 2 ? <><span>{', '}</span><br /></> : <span>{', '}</span> : '';
-                return (
-                    <span key={pkgNo + index}><Typography link href={getMcPkgUrl(pkgNo)} key={pkgNo}>{pkgNo}</Typography>{separator}</span>
-                );  
-            })}
-            </div>
         );
     };
 
-    const getCommPkgColumn = (commPkgs: string[] | undefined): JSX.Element => {
+    const getPkgColumn = (pkgs: string[] | undefined): JSX.Element => {
+        const pkgsString = pkgs?.join(', ');
+
         return (
-            <div>{commPkgs?.map((pkgNo, index) => {
-                const separator: any = index < commPkgs.length-1 ? 
-                    index % 2 ? <><span>{', '}</span><br /></> : <span>{', '}</span> : '';
-                return (
-                    <span key={pkgNo + index}><Typography link href={getCommPkgUrl(pkgNo)} key={pkgNo}>{pkgNo}</Typography>{separator}</span>
-                );  
-            })}</div>
+            <Tooltip title={<div>{pkgsString}</div>} arrow={true} enterDelay={200} enterNextDelay={100}>
+                <Typography className='controlOverflow'>{pkgsString}</Typography>
+            </Tooltip>
+        );
+    };
+
+    const getTooltipColumn = (data: string): JSX.Element => {
+        return (
+            <Tooltip title={data} arrow={true} enterDelay={200} enterNextDelay={100}>
+                <Typography className='controlOverflow'>{data}</Typography>
+            </Tooltip>
         );
     };
 
     const getColumn = (data: string): JSX.Element => {
-        return (
-            <div className='controlOverflow'><Typography>{data}</Typography></div>
-        );
+        return <Typography>{data}</Typography>;
     };
 
 
@@ -137,17 +115,17 @@ const InvitationsTable = ({getIPOs, pageSize, setPageSize, shouldSelectFirstPage
                 tableRef={refObject} //reference will be used by parent, to trigger rendering
                 columns={[
                     { title: 'ID', render: (rowData: IPO): JSX.Element => getIdColumn(rowData.id.toString()) },
-                    { title: 'Title', render: (rowData: IPO): JSX.Element => getColumn(rowData.title) },
+                    { title: 'Title', render: (rowData: IPO): JSX.Element => getTooltipColumn(rowData.title), cellStyle: { minWidth: '220px', maxWidth: '220px'}},
                     { title: 'Status', render: (rowData: IPO): JSX.Element => getColumn(rowData.status) },
                     { title: 'Type', render: (rowData: IPO): JSX.Element => getColumn(rowData.type) },
-                    { title: 'Comm pkg', render: (rowData: IPO): JSX.Element => getCommPkgColumn(rowData.commPkgNos), cellStyle: { minWidth: '220px', maxWidth: '220px' }, sorting: false }, 
-                    { title: 'MC pkg', render: (rowData: IPO): JSX.Element => getMcPkgColumn(rowData.mcPkgNos), cellStyle: { minWidth: '220px', maxWidth: '220px' }, sorting: false },
-                    { title: 'Sent', render: (rowData: IPO): JSX.Element => getColumn(getLocalDate(new Date(rowData.createdAtUtc))), defaultSort: 'desc' },
-                    { title: 'Punch-out', render: (rowData: IPO): JSX.Element => getColumn(getLocalDate(new Date(rowData.startTimeUtc))) },
-                    { title: 'Completed', render: (rowData: IPO): JSX.Element => getColumn(rowData.completedAtUtc ? getLocalDate(new Date(rowData.completedAtUtc)) : '') },
-                    { title: 'Accepted', render: (rowData: IPO): JSX.Element => getColumn(rowData.acceptedAtUtc ? getLocalDate(new Date(rowData.acceptedAtUtc)): '') },
-                    { title: 'Contractor rep', render: (rowData: IPO): JSX.Element => getColumn(rowData.contractorRep) },
-                    { title: 'Construction rep', render: (rowData: IPO): JSX.Element => getColumn(rowData.constructionCompanyRep) },
+                    { title: 'Comm pkg', render: (rowData: IPO): JSX.Element => getPkgColumn(rowData.commPkgNos), cellStyle: { minWidth: '220px', maxWidth: '220px' }, sorting: false }, 
+                    { title: 'MC pkg', render: (rowData: IPO): JSX.Element => getPkgColumn(rowData.mcPkgNos), cellStyle: { minWidth: '220px', maxWidth: '220px' }, sorting: false },
+                    { title: 'Sent', render: (rowData: IPO): JSX.Element => getColumn(getFormattedDate(rowData.createdAtUtc)), defaultSort: 'desc' },
+                    { title: 'Punch-out', render: (rowData: IPO): JSX.Element => getColumn(getFormattedDate(rowData.startTimeUtc)) },
+                    { title: 'Completed', render: (rowData: IPO): JSX.Element => getColumn(rowData.completedAtUtc ? getFormattedDate(rowData.completedAtUtc) : '') },
+                    { title: 'Accepted', render: (rowData: IPO): JSX.Element => getColumn(rowData.acceptedAtUtc ? getFormattedDate(rowData.acceptedAtUtc): '') },
+                    { title: 'Contractor rep', render: (rowData: IPO): JSX.Element => getTooltipColumn(rowData.contractorRep), cellStyle: { minWidth: '220px', maxWidth: '220px'} },
+                    { title: 'Construction rep', render: (rowData: IPO): JSX.Element => getTooltipColumn(rowData.constructionCompanyRep), cellStyle: { minWidth: '220px', maxWidth: '220px'} },
                 ]}
                 data={getIPOsByQuery}
                 options={{
@@ -169,7 +147,6 @@ const InvitationsTable = ({getIPOs, pageSize, setPageSize, shouldSelectFirstPage
                     },
                     rowStyle: (rowData): any => ({
                         opacity: rowData.status === IpoStatusEnum.CANCELED && 0.5,
-                        color: rowData.status === IpoStatusEnum.CANCELED && tokens.colors.interactive.danger__text.rgba,
                     }),
                     thirdSortClick: false
                 }}

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/index.tsx
@@ -274,7 +274,6 @@ const SearchIPO = (): JSX.Element => {
                 )
             }
         </Container >
-
     );
 };
 

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/Attachments/__tests__/Attachments.test.jsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/Attachments/__tests__/Attachments.test.jsx
@@ -2,6 +2,7 @@ import { render, waitFor } from '@testing-library/react';
 
 import Attachments from '../index';
 import React from 'react';
+import { getFormattedDateAndTime } from '../../../../../../core/services/DateService';
 
 const attachment = {
     downloadUri: '',
@@ -47,7 +48,7 @@ describe('Module: <Attachments ipoId={} />', () => {
         const { getByText } = render(<Attachments ipoId={0} />);
 
         await waitFor(() => expect(getByText('file1')).toBeInTheDocument());
-        await waitFor(() => expect(getByText('11/12/2020 11:00')).toBeInTheDocument());
+        await waitFor(() => expect(getByText(getFormattedDateAndTime(attachment.uploadedAt))).toBeInTheDocument());
         await waitFor(() => expect(getByText(`${attachment.uploadedBy.firstName} ${attachment.uploadedBy.lastName}`)).toBeInTheDocument());
     });
 });

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/Attachments/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/Attachments/index.tsx
@@ -10,7 +10,7 @@ import EdsIcon from '@procosys/components/EdsIcon';
 import Spinner from '@procosys/components/Spinner';
 import { Table } from '@equinor/eds-core-react';
 import fileTypeValidator from '@procosys/util/FileTypeValidator';
-import { format } from 'date-fns';
+import { getFormattedDateAndTime } from '@procosys/core/services/DateService';
 import { showSnackbarNotification } from '@procosys/core/services/NotificationService';
 import { useInvitationForPunchOutContext } from '@procosys/modules/InvitationForPunchOut/context/InvitationForPunchOutContext';
 
@@ -162,7 +162,7 @@ const Attachments = ({ ipoId }: AttachmentsProps): JSX.Element => {
                                 </CustomTooltip>
                             </Cell>
                             <Cell as="td" style={{ verticalAlign: 'middle', lineHeight: '1em' }}>
-                                <Typography variant="body_short">{attachment.uploadedAt && format(new Date(attachment.uploadedAt), 'dd/MM/yyyy HH:mm')}</Typography>
+                                <Typography variant="body_short">{attachment.uploadedAt && getFormattedDateAndTime(attachment.uploadedAt)}</Typography>
                             </Cell>
                             <Cell as="td" style={{ verticalAlign: 'middle', lineHeight: '1em' }}>
                                 <Typography variant="body_short">{attachment.uploadedBy && `${attachment.uploadedBy.firstName} ${attachment.uploadedBy.lastName}`}</Typography>

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/Comments/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/Comments/index.tsx
@@ -7,6 +7,7 @@ import { IpoComment } from '../types';
 import Spinner from '@procosys/components/Spinner';
 import { TextField } from '@equinor/eds-core-react';
 import { Typography } from '@equinor/eds-core-react';
+import { getFormattedDateAndTime } from '@procosys/core/services/DateService';
 
 interface CommentsProps {
     comments: IpoComment[];
@@ -45,7 +46,7 @@ const Comments = ({ comments, addComment, loading, close }: CommentsProps): JSX.
                 <CommentContainer key={comment.id}>
                     <CommentHeaderContainer>
                         <Typography token={{ fontSize: '12px' }}>{`${comment.createdBy.firstName} ${comment.createdBy.lastName}`}</Typography>
-                        <Typography token={{ fontSize: '12px' }}>{(new Date(comment.createdAtUtc)).toLocaleString([], { year: 'numeric', month: '2-digit', day: 'numeric', hour: '2-digit', minute: '2-digit' })}</Typography>
+                        <Typography token={{ fontSize: '12px' }}>{getFormattedDateAndTime(comment.createdAtUtc)}</Typography>
                     </CommentHeaderContainer>
                     <Typography variant="body_long">{comment.comment}</Typography>
                 </CommentContainer>

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/__tests__/ParticipantsTable.test.jsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/__tests__/ParticipantsTable.test.jsx
@@ -6,6 +6,7 @@ import ParticipantsTable from '../index';
 import React from 'react';
 import { ThemeProvider } from 'styled-components';
 import { configure } from '@testing-library/dom';
+import { getFormattedDateAndTime } from '../../../../../../../core/services/DateService';
 import theme from '../../../../../../../assets/theme';
 
 configure({ testIdAttribute: 'id' });
@@ -324,7 +325,7 @@ describe('<ParticipantsTable />', () => {
         expect(queryByText('Update')).toBeInTheDocument();
         expect(queryByText('Sign punch-out')).not.toBeInTheDocument();
         expect(queryByText('Accept punch-out')).not.toBeInTheDocument();
-        expect(queryByText('06/12/2020 11:00')).toBeInTheDocument();
+        expect(queryByText(getFormattedDateAndTime(newParticipants[ParticipantIndex.COMPLETER].signedAtUtc))).toBeInTheDocument();
     });
 
     it('Renders completed status for accepter', async () => {
@@ -340,7 +341,7 @@ describe('<ParticipantsTable />', () => {
         expect(queryByText('Sign punch-out')).not.toBeInTheDocument();
         expect(queryByText('Accept punch-out')).toBeInTheDocument();
         expect(queryByText(newParticipants[ParticipantIndex.COMPLETER].signedBy.userName)).toBeInTheDocument();
-        expect(queryByText('06/12/2020 11:00')).toBeInTheDocument();
+        expect(queryByText(getFormattedDateAndTime(newParticipants[ParticipantIndex.COMPLETER].signedAtUtc))).toBeInTheDocument();
     });
 
     it('Renders completed status for signer', async () => {
@@ -356,7 +357,7 @@ describe('<ParticipantsTable />', () => {
         expect(queryByText('Sign punch-out')).toBeInTheDocument();
         expect(queryByText('Accept punch-out')).not.toBeInTheDocument();
         expect(getByText(newParticipants[ParticipantIndex.COMPLETER].signedBy.userName)).toBeInTheDocument();
-        expect(queryByText('06/12/2020 11:00')).toBeInTheDocument();
+        expect(queryByText(getFormattedDateAndTime(newParticipants[ParticipantIndex.COMPLETER].signedAtUtc))).toBeInTheDocument();
     });
 
     it('Renders accepted status for completer', async () => {
@@ -375,8 +376,8 @@ describe('<ParticipantsTable />', () => {
         expect(queryByText('Accept punch-out')).not.toBeInTheDocument();
         expect(queryByText(`${participants[ParticipantIndex.COMPLETER].signedBy.userName}`)).toBeInTheDocument();
         expect(queryByText('Unaccept punch-out')).not.toBeInTheDocument();
-        expect(queryByText('06/12/2020 11:00')).toBeInTheDocument();
-        expect(queryByText('06/12/2020 12:00')).toBeInTheDocument();
+        expect(queryByText(getFormattedDateAndTime(newParticipants[ParticipantIndex.COMPLETER].signedAtUtc))).toBeInTheDocument();
+        expect(queryByText(getFormattedDateAndTime(newParticipants[ParticipantIndex.ACCEPTER].signedAtUtc))).toBeInTheDocument();
     });
 
     it('Renders accepted status for accepter', async () => {
@@ -394,8 +395,8 @@ describe('<ParticipantsTable />', () => {
         expect(queryByText('Accept punch-out')).not.toBeInTheDocument();
         expect(queryByText(`${participants[ParticipantIndex.COMPLETER].signedBy.userName}`)).toBeInTheDocument();
         expect(queryByText('Unaccept punch-out')).toBeInTheDocument();
-        expect(queryByText('06/12/2020 11:00')).toBeInTheDocument();
-        expect(queryByText('06/12/2020 12:00')).toBeInTheDocument();
+        expect(queryByText(getFormattedDateAndTime(newParticipants[ParticipantIndex.COMPLETER].signedAtUtc))).toBeInTheDocument();
+        expect(queryByText(getFormattedDateAndTime(newParticipants[ParticipantIndex.ACCEPTER].signedAtUtc))).toBeInTheDocument();
     });
 
     it('Renders accepted status for signer', async () => {
@@ -411,8 +412,8 @@ describe('<ParticipantsTable />', () => {
         expect(queryByText('Accept punch-out')).not.toBeInTheDocument();
         expect(getByText(newParticipants[ParticipantIndex.COMPLETER].signedBy.userName)).toBeInTheDocument();
         expect(queryByText('Unaccept punch-out')).not.toBeInTheDocument();
-        expect(queryByText('06/12/2020 11:00')).toBeInTheDocument();
-        expect(queryByText('06/12/2020 12:00')).toBeInTheDocument();
+        expect(queryByText(getFormattedDateAndTime(newParticipants[ParticipantIndex.COMPLETER].signedAtUtc))).toBeInTheDocument();
+        expect(queryByText(getFormattedDateAndTime(newParticipants[ParticipantIndex.ACCEPTER].signedAtUtc))).toBeInTheDocument();
     });
 
 

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
@@ -1,19 +1,19 @@
 import { Button, Switch, TextField } from '@equinor/eds-core-react';
 import { ComponentName, IpoStatusEnum, OrganizationsEnum } from '../../../enums';
-import { Container, CustomTable, SpinnerContainer, ResponseWrapper } from './style';
+import { Container, CustomTable, ResponseWrapper, SpinnerContainer } from './style';
 import { ExternalEmail, FunctionalRole, Participant } from '../../types';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
+import CustomPopover from './CustomPopover/index';
 import CustomTooltip from './CustomTooltip';
 import { Organization } from '../../../../types';
 import { OrganizationMap } from '../../../utils';
 import { OutlookResponseType } from '../../enums';
 import Spinner from '@procosys/components/Spinner';
 import { Table } from '@equinor/eds-core-react';
-import { format } from 'date-fns';
+import { Typography } from '@equinor/eds-core-react';
+import { getFormattedDateAndTime } from '@procosys/core/services/DateService';
 import { useDirtyContext } from '@procosys/core/DirtyContext';
-
-import CustomPopover from './CustomPopover/index';
 
 const { Head, Body, Cell, Row } = Table;
 const tooltipComplete = <div>When punch round has been completed<br />and any punches have been added.<br />Complete and go to next step.</div>;
@@ -352,12 +352,20 @@ const ParticipantsTable = ({ participants, status, complete, accept, update, sig
                         return (
                             <Row key={participant.sortKey} as="tr">
                                 <Cell as="td" style={{ verticalAlign: 'middle' }}>
-                                    {OrganizationMap.get(participant.organization as Organization)}
+                                    <Typography variant="body_short">
+                                        {OrganizationMap.get(participant.organization as Organization)}
+                                    </Typography>
                                 </Cell>
-                                <Cell as="td" style={{ verticalAlign: 'middle' }}>{representative}</Cell>
+                                <Cell as="td" style={{ verticalAlign: 'middle' }}>
+                                    <Typography variant="body_short">
+                                        {representative}
+                                    </Typography>
+                                </Cell>
                                 <Cell as="td" style={{ verticalAlign: 'middle' }}>
                                     <ResponseWrapper> 
-                                        {response} 
+                                        <Typography variant="body_short">
+                                            {response} 
+                                        </Typography>
                                         {addPopover && <CustomPopover participant={participant} />}
                                     </ResponseWrapper>
                                 </Cell>
@@ -378,19 +386,23 @@ const ParticipantsTable = ({ participants, status, complete, accept, update, sig
                                         onChange={(e: any): void => handleEditNotes(e, id)} />
                                 </Cell>
                                 <Cell as="td" style={{ verticalAlign: 'middle', minWidth: '160px' }}>
-                                    {getSignedProperty(
-                                        participant, status,
-                                        () => handleCompletePunchOut(index),
-                                        () => handleAcceptPunchOut(index),
-                                        () => handleUpdateParticipants(),
-                                        () => handleSignPunchOut(index),
-                                        () => handleUnAcceptPunchOut(index))}
+                                    <Typography variant="body_short">
+                                        {getSignedProperty(
+                                            participant, status,
+                                            () => handleCompletePunchOut(index),
+                                            () => handleAcceptPunchOut(index),
+                                            () => handleUpdateParticipants(),
+                                            () => handleSignPunchOut(index),
+                                            () => handleUnAcceptPunchOut(index))}
+                                    </Typography>
                                 </Cell>
                                 <Cell as="td" style={{ verticalAlign: 'middle', minWidth: '150px' }}>
-                                    {participant.signedAtUtc ?
-                                        `${format(new Date(participant.signedAtUtc), 'dd/MM/yyyy HH:mm')}` :
-                                        '-'
-                                    }
+                                    <Typography variant="body_short">
+                                        {participant.signedAtUtc ?
+                                            `${getFormattedDateAndTime(new Date(participant.signedAtUtc))}` :
+                                            '-'
+                                        }
+                                    </Typography>
                                 </Cell>
                             </Row>
                         );

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/__tests__/GeneralInfo.test.jsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/__tests__/GeneralInfo.test.jsx
@@ -1,3 +1,5 @@
+import { getFormattedDate, getFormattedTime } from '../../../../../../core/services/DateService';
+
 import GeneralInfo from '../index';
 import React from 'react';
 import { ThemeProvider } from 'styled-components';
@@ -55,9 +57,9 @@ describe('<GeneralInfo />', () => {
         expect(queryByText(invitation.title)).toBeInTheDocument();
         expect(queryByText(invitation.description)).toBeInTheDocument();
         expect(queryByText(invitation.location)).toBeInTheDocument();
-        expect(queryByText('06/12/2020')).toBeInTheDocument();
-        expect(queryByText('11:00')).toBeInTheDocument();
-        expect(queryByText('13:00')).toBeInTheDocument();
+        expect(queryByText(getFormattedDate(invitation.startTimeUtc))).toBeInTheDocument();
+        expect(queryByText(getFormattedTime(invitation.startTimeUtc))).toBeInTheDocument();
+        expect(queryByText(getFormattedTime(invitation.endTimeUtc))).toBeInTheDocument();
     });
 });
 

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/index.tsx
@@ -1,10 +1,10 @@
 import { Container, DateTimeItem, DetailContainer, HeaderContainer, ProjectInfoContainer, ProjectInfoDetail } from './style';
 import { Invitation, Participant } from '../types';
 import ParticipantsTable, { AttNoteData } from './ParticipantsTable';
+import { getFormattedDate, getFormattedTime } from '@procosys/core/services/DateService';
 
 import React from 'react';
 import { Typography } from '@equinor/eds-core-react';
-import { format } from 'date-fns';
 
 interface GeneralInfoProps {
     invitation: Invitation;
@@ -49,15 +49,15 @@ const GeneralInfo = ({ invitation, complete, accept, update, sign, unaccept }: G
                     <DetailContainer>
                         <DateTimeItem>
                             <Typography token={{ fontSize: '12px' }}>Date</Typography>
-                            <Typography variant="body_long">{format(new Date(invitation.startTimeUtc), 'dd/MM/yyyy')}</Typography>
+                            <Typography variant="body_long">{getFormattedDate(invitation.startTimeUtc)}</Typography>
                         </DateTimeItem>
                         <DateTimeItem>
                             <Typography token={{ fontSize: '12px' }}>Start</Typography>
-                            <Typography variant="body_long">{format(new Date(invitation.startTimeUtc), 'HH:mm')}</Typography>
+                            <Typography variant="body_long">{getFormattedTime(invitation.startTimeUtc)}</Typography>
                         </DateTimeItem>
                         <DateTimeItem>
                             <Typography token={{ fontSize: '12px' }}>End</Typography>
-                            <Typography variant="body_long">{format(new Date(invitation.endTimeUtc), 'HH:mm')}</Typography>
+                            <Typography variant="body_long">{getFormattedTime(invitation.endTimeUtc)}</Typography>
                         </DateTimeItem>
                     </DetailContainer>
                 </ProjectInfoDetail>

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/History/__tests__/History.test.jsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/History/__tests__/History.test.jsx
@@ -2,6 +2,7 @@ import { render, waitFor } from '@testing-library/react';
 
 import History from '../index';
 import React from 'react';
+import { getFormattedDateAndTime } from '@procosys/core/services/DateService';
 
 const dummyHistory = [
     {
@@ -44,7 +45,8 @@ describe('Module: <History ipoId={} />', () => {
         const { getByText } = render(<History ipoId={0} />);
 
         await waitFor(() => expect(getByText(dummyHistory[1].description)).toBeInTheDocument());
-        await waitFor(() => expect(getByText('28/12/2020 10:24')).toBeInTheDocument());
+        await waitFor(() => expect(getByText(getFormattedDateAndTime(dummyHistory[0].createdAtUtc))).toBeInTheDocument());
+        await waitFor(() => expect(getByText(getFormattedDateAndTime(dummyHistory[1].createdAtUtc))).toBeInTheDocument());
         await waitFor(() => expect(getByText(`${dummyHistory[0].createdBy.userName}`)).toBeInTheDocument());
         await waitFor(() => expect(getByText(`${dummyHistory[1].createdBy.userName}`)).toBeInTheDocument());
     });

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/History/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/History/index.tsx
@@ -6,7 +6,7 @@ import { HistoryItem } from '../types';
 import Spinner from '@procosys/components/Spinner';
 import { Table } from '@equinor/eds-core-react';
 import { Typography } from '@equinor/eds-core-react';
-import { format } from 'date-fns';
+import { getFormattedDateAndTime } from '@procosys/core/services/DateService';
 import { showSnackbarNotification } from '@procosys/core/services/NotificationService';
 import { useInvitationForPunchOutContext } from '@procosys/modules/InvitationForPunchOut/context/InvitationForPunchOutContext';
 
@@ -66,13 +66,19 @@ const History = ({ ipoId }: HistoryProps): JSX.Element => {
                             {history && history.length > 0 ? history.map((historyItem) => (
                                 <Row key={historyItem.id}>
                                     <Cell as="td" style={{verticalAlign: 'middle', lineHeight: '1em'}}>
-                                        {format(new Date(historyItem.createdAtUtc), 'dd/MM/yyyy HH:mm')}
+                                        <Typography variant="body_short">
+                                            {getFormattedDateAndTime(new Date(historyItem.createdAtUtc))}
+                                        </Typography>
                                     </Cell>
                                     <Cell as="td" style={{verticalAlign: 'middle', lineHeight: '1em'}}>
-                                        {`${historyItem.createdBy.userName}`}
+                                        <Typography variant="body_short">
+                                            {`${historyItem.createdBy.userName}`}
+                                        </Typography>
                                     </Cell>
                                     <Cell as="td" style={{verticalAlign: 'middle', lineHeight: '1em'}}>
-                                        {`${historyItem.description}`}
+                                        <Typography variant="body_short">
+                                            {`${historyItem.description}`}
+                                        </Typography>
                                     </Cell>
                                 </Row>
                             )) : (

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/CommPkgsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/CommPkgsTable/index.tsx
@@ -35,8 +35,16 @@ const CommPkgsTable = ({ commPkgScope, projectName }: CommPkgsTableProps ): JSX.
                             <Cell as="td" style={{verticalAlign: 'middle', lineHeight: '1em'}}>
                                 <Typography href={getCommPkgUrl(commPkg.commPkgNo)} variant="body_short" link>{commPkg.commPkgNo}</Typography>
                             </Cell>
-                            <Cell as="td" style={{verticalAlign: 'middle'}}>{commPkg.description}</Cell>
-                            <Cell as="td" style={{verticalAlign: 'middle'}}>{commPkg.status}</Cell>
+                            <Cell as="td" style={{verticalAlign: 'middle'}}>
+                                <Typography variant="body_short">
+                                    {commPkg.description}
+                                </Typography>
+                            </Cell>
+                            <Cell as="td" style={{verticalAlign: 'middle'}}>
+                                <Typography variant="body_short">
+                                    {commPkg.status}
+                                </Typography>
+                            </Cell>
                         </Row>
                     )) : (
                         <Row>

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/McPkgsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/McPkgsTable/index.tsx
@@ -39,7 +39,11 @@ const McPkgsTable = ({ mcPkgScope, projectName }: McPkgsTableProps ): JSX.Elemen
                             <Cell as="td" style={{verticalAlign: 'middle', lineHeight: '1em'}}>
                                 <Typography href={getMcPkgUrl(mcPkg.mcPkgNo)} variant="body_short" link>{mcPkg.mcPkgNo}</Typography>
                             </Cell>
-                            <Cell as="td" style={{verticalAlign: 'middle'}}>{mcPkg.description}</Cell>
+                            <Cell as="td" style={{verticalAlign: 'middle'}}>
+                                <Typography variant="body_short">
+                                    {mcPkg.description}
+                                </Typography>
+                            </Cell>
                             <Cell as="td" style={{verticalAlign: 'middle', lineHeight: '1em'}}>
                                 <Typography href={getCommPkgUrl(mcPkg.commPkgNo)} variant="body_short" link>{mcPkg.commPkgNo}</Typography>
                             </Cell>

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/ReportsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/Scope/ReportsTable/index.tsx
@@ -63,7 +63,11 @@ const ReportsTable = ({ mcPkgNumbers, commPkgNumbers }: ReportsTableProps): JSX.
                         <Cell as="td" style={{ verticalAlign: 'middle', lineHeight: '1em' }}>
                             <Typography href={getReportUrl(ReportIdEnum.MC32D)} variant="body_short" link>MC32D</Typography>
                         </Cell>
-                        <Cell as="td" style={{ verticalAlign: 'middle' }}>MC Scope</Cell>
+                        <Cell as="td" style={{ verticalAlign: 'middle' }}>
+                            <Typography variant="body_short">
+                            MC Scope
+                            </Typography>
+                        </Cell>
                         <Cell as="td" style={{ verticalAlign: 'middle', lineHeight: '1em' }}>
                             {' '}
                         </Cell>
@@ -72,7 +76,11 @@ const ReportsTable = ({ mcPkgNumbers, commPkgNumbers }: ReportsTableProps): JSX.
                         <Cell as="td" style={{ verticalAlign: 'middle', lineHeight: '1em' }}>
                             <Typography href={getReportUrl(ReportIdEnum.MC84)} variant="body_short" link>MC84</Typography>
                         </Cell>
-                        <Cell as="td" style={{ verticalAlign: 'middle' }}>Punch List</Cell>
+                        <Cell as="td" style={{ verticalAlign: 'middle' }}>
+                            <Typography variant="body_short">
+                            Punch List
+                            </Typography>
+                        </Cell>
                         <Cell as="td" style={{ verticalAlign: 'middle', lineHeight: '1em' }}>
                             {' '}
                         </Cell>
@@ -81,7 +89,11 @@ const ReportsTable = ({ mcPkgNumbers, commPkgNumbers }: ReportsTableProps): JSX.
                         <Cell as="td" style={{ verticalAlign: 'middle', lineHeight: '1em' }}>
                             <Typography href={getReportUrl(ReportIdEnum.CDP06)} variant="body_short" link>CDP06</Typography>
                         </Cell>
-                        <Cell as="td" style={{ verticalAlign: 'middle' }}>Concession Deviation Permit</Cell>
+                        <Cell as="td" style={{ verticalAlign: 'middle' }}>
+                            <Typography variant="body_short">
+                            Concession Deviation Permit
+                            </Typography>
+                        </Cell>
                         <Cell as="td" style={{ verticalAlign: 'middle', lineHeight: '1em' }}>
                             {' '}
                         </Cell>

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
@@ -369,7 +369,8 @@ const ViewIPO = (): JSX.Element => {
                         <Typography>No invitation found</Typography>
                     )
             }
-        </Container >);
+        </Container>
+    );
 };
 
 export default ViewIPO;

--- a/src/modules/Preservation/index.tsx
+++ b/src/modules/Preservation/index.tsx
@@ -5,6 +5,7 @@ import AddScope from './views/AddScope/AddScope';
 import ClosedProjectWarning from './ClosedProjectWarning';
 import EditTagProperties from './views/EditTagProperties/EditTagProperties';
 import ErrorBoundary from '@procosys/components/ErrorBoundary';
+import { Helmet } from 'react-helmet';
 import { PreservationContextProvider } from './context/PreservationContext';
 import ScopeOverview from './views/ScopeOverview/ScopeOverview';
 import withAccessControl from '../../core/security/withAccessControl';
@@ -14,33 +15,55 @@ const Preservation = (): JSX.Element => {
     const { url } = useRouteMatch();
 
     return (
-        <PreservationContextProvider>
-            <ClosedProjectWarning />
-            <Router basename={url}>
-                <Switch>
-                    <Route
-                        path={'/AddScope/:method/:duplicateTagId?'}
-                        exact
-                        component={(): ReactElement => (<ErrorBoundary><AddScope /></ErrorBoundary>)}
-                    />
-                    <Route
-                        path={'/'}
-                        exact
-                        component={(): ReactElement => (<ErrorBoundary><ScopeOverview /></ErrorBoundary>)}
-                    />
-                    <Route
-                        path={'/EditTagProperties/:tagId'}
-                        exact
-                        component={(): ReactElement => (<ErrorBoundary><EditTagProperties /></ErrorBoundary>)}
-                    />
-                    <Route
-                        component={(): JSX.Element =>
-                            (<h2>Sorry, this page does not exist</h2>)
-                        }
-                    />
-                </Switch>
-            </Router>
-        </PreservationContextProvider >
+        <>
+            <Helmet titleTemplate={'ProCoSys - Preservation - %s'}>
+            </Helmet>
+            <PreservationContextProvider>
+                <ClosedProjectWarning />
+                <Router basename={url}>
+                    <Switch>
+                        <Route
+                            path={'/AddScope/:method/:duplicateTagId?'}
+                            exact
+                            component={(): ReactElement => (
+                                <>
+                                    <Helmet>
+                                        <title>{'AddScope'}</title>
+                                    </Helmet>
+                                    <ErrorBoundary><AddScope /></ErrorBoundary>
+                                </>)}
+                        />
+                        <Route
+                            path={'/'}
+                            exact
+                            component={(): ReactElement => (
+                                <>
+                                    <Helmet>
+                                        <title>{'ScopeOverview'}</title>
+                                    </Helmet>
+                                    <ErrorBoundary><ScopeOverview /></ErrorBoundary>
+                                </>)}
+                        />
+                        <Route
+                            path={'/EditTagProperties/:tagId'}
+                            exact
+                            component={(): ReactElement => (
+                                <>
+                                    <Helmet>
+                                        <title>{'EditTag'}</title>
+                                    </Helmet>
+                                    <ErrorBoundary><EditTagProperties /></ErrorBoundary>
+                                </>)}
+                        />
+                        <Route
+                            component={(): JSX.Element =>
+                                (<h2>Sorry, this page does not exist</h2>)
+                            }
+                        />
+                    </Switch>
+                </Router>
+            </PreservationContextProvider >
+        </>
     );
 };
 

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/ActionTab/__tests__/ActionTab.test.jsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/ActionTab/__tests__/ActionTab.test.jsx
@@ -1,6 +1,8 @@
-import { render, fireEvent} from '@testing-library/react';
-import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+
 import ActionTab from '../ActionTab';
+import React from 'react';
+import { getFormattedDate } from '../../../../../../../core/services/DateService';
 
 const mockActionList = [
     {
@@ -75,10 +77,10 @@ describe('<ActionTab />', () => {
         const clickableElement = await findByTestId('toggle-icon-1');
 
         fireEvent.click(clickableElement);
-        await findByText('01.05.2020');
+        await findByText(getFormattedDate('2020-05-01'));
 
-        expect(queryByText('01.05.2020')).toBeInTheDocument();
-        expect(queryByText('01.03.2020')).toBeInTheDocument();
+        expect(queryByText(getFormattedDate('2020-05-01'))).toBeInTheDocument();
+        expect(queryByText(getFormattedDate('2020-03-01'))).toBeInTheDocument();
         expect(queryByText('Donald Duck')).toBeInTheDocument();
         expect(queryByText('Description 1')).toBeInTheDocument();
         expect(queryByText('aFileAttachment.png')).toBeInTheDocument();

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/ActionTab/__tests__/ActionTab.test.jsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/ActionTab/__tests__/ActionTab.test.jsx
@@ -95,10 +95,10 @@ describe('<ActionTab />', () => {
         const clickableElement = await findByText('Action 1');
 
         fireEvent.click(clickableElement);
-        await findByText('01.05.2020');
+        await findByText(getFormattedDate('2020-05-01'));
 
-        expect(queryByText('01.05.2020')).toBeInTheDocument();
-        expect(queryByText('01.03.2020')).toBeInTheDocument();
+        expect(queryByText(getFormattedDate('2020-05-01'))).toBeInTheDocument();
+        expect(queryByText(getFormattedDate('2020-03-01'))).toBeInTheDocument();
         expect(queryByText('Donald Duck')).toBeInTheDocument();
         expect(queryByText('Description 1')).toBeInTheDocument();
         expect(queryByText('aFileAttachment.png')).toBeInTheDocument();


### PR DESCRIPTION
# Description

- Add adjustments to search table. Display invitation on single row with ellipsis for long text and tooltip.
- Add DateService formatting follow browser settings. Use DateService in all components and tests.
- Fix dirty state is only unset for one element when several should be cleared (Add 'unsetDirtyStateForMany' to context)
- Fix bug where attachment dirty state is set incorrectly in create and edit IPO
- Fix inconsequent typography in IPO tables
- Fix ugly console error caused by nested a tags in search table (<a><Typography link>)
- Fix attachment tab not actually returning objectURL for files.
- Add Helmet page titles for IPO and Preservation

Completes: AB#88132

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [x] My code is covered by tests.
