### PR TITLE
bug/81916 Users without the ipo_sign privilege group can be added as …

### DIFF
--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Participants/Participants.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Participants/Participants.tsx
@@ -237,11 +237,11 @@ const Participants = ({
     };
 
     const isSignerParticipant = (index: number): boolean => {
-        if ((participants[index].organization.value == Organizations[0].value ||
+        if (participants[index].organization.value == Organizations[0].value ||
             participants[index].organization.value == Organizations[1].value ||
             participants[index].organization.value == Organizations[2].value ||
             participants[index].organization.value == Organizations[3].value ||
-            participants[index].organization.value == Organizations[4].value)) {
+            participants[index].organization.value == Organizations[4].value) {
             return true;
         }
         return false;

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Participants/Participants.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Participants/Participants.tsx
@@ -237,17 +237,11 @@ const Participants = ({
     };
 
     const isSignerParticipant = (index: number): boolean => {
-        if(index < 2){
-            return true;
-        }
-        if (index < 5 && (participants[index].organization.value == Organizations[0].value ||
+        if ((participants[index].organization.value == Organizations[0].value ||
+            participants[index].organization.value == Organizations[1].value ||
+            participants[index].organization.value == Organizations[2].value ||
             participants[index].organization.value == Organizations[3].value ||
             participants[index].organization.value == Organizations[4].value)) {
-            for (let i = 2; i < index; i++) {
-                if (participants[i].organization.value == participants[index].organization.value) {
-                    return false;
-                }
-            }
             return true;
         }
         return false;


### PR DESCRIPTION
…a participant in signer organizations

# Description

Persons without the ipo_sign privilege group can no longer be added as a person participant in an organization type that can sign an IPO even if the organization isn't the first of it's kind. 

Completes: [AB#81916](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/81916)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
