### PR TITLE
Feature/81774 UI new ipo button from search uses project name

### DIFF
--- a/src/modules/InvitationForPunchOut/views/SearchIPO/__tests__/SearchIPO.test.jsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/__tests__/SearchIPO.test.jsx
@@ -1,17 +1,26 @@
-import { render, waitFor } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 
 import React from 'react';
 import SearchIPO from '../../SearchIPO';
 import { createMemoryHistory } from 'history';
 import { Router } from 'react-router';
 
+const mockProject = [
+    {
+        id: 1,
+        name: '886',
+        description: 'Test'
+    }
+];
+
 jest.mock('../../../context/InvitationForPunchOutContext', () => ({
     useInvitationForPunchOutContext: () => {
         return {
             apiClient: {
                 getIPOs: () => Promise.resolve({maxAvailable: 0, invitations: []}),
-                getAllProjectsForUserAsync: () => Promise.resolve([]),
-                getFunctionalRolesAsync: () => Promise.resolve([])
+                getAllProjectsForUserAsync: () => Promise.resolve(mockProject),
+                getFunctionalRolesAsync: () => Promise.resolve([]),
+                getSavedIPOFilters: () => Promise.resolve([])
             }
         };
     }
@@ -29,5 +38,30 @@ describe('<SearchIPO />', () => {
         await waitFor(() => expect(getByText('Select project')).toBeInTheDocument());
         await waitFor(() => expect(getByText('No records to display')).toBeInTheDocument());
         await waitFor(() => expect(getByText('New IPO')).toBeInTheDocument());
+    });
+
+    it('Should render "New IPO" button with correct link', async () => {
+        const history = createMemoryHistory();
+        const { getByText } = render(
+            <Router history={history}>
+                <SearchIPO />
+            </Router>
+        );          
+        await waitFor(() => expect(getByText('New IPO')).toBeInTheDocument());
+        await waitFor(() => expect(getByText('New IPO').closest('a')).toHaveAttribute('href', '/CreateIPO'));
+    });
+
+    it('Should change the link in the "New IPO" button when project is changed', async () => {
+        const history = createMemoryHistory();
+        const { getByText } = render(
+            <Router history={history}>
+                <SearchIPO />
+            </Router>
+        );          
+        await waitFor(() => expect(getByText('Select project')).toBeInTheDocument());
+        fireEvent.click(getByText('Select project'));
+        await waitFor(() => expect(getByText('886')).toBeInTheDocument());
+        fireEvent.click(getByText('886'));
+        await waitFor(() => expect(getByText('New IPO').closest('a')).toHaveAttribute('href', '/CreateIPO/886'));
     });
 });

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/index.tsx
@@ -327,7 +327,7 @@ const SearchIPO = (): JSX.Element => {
                                     );
                                 })}
                             </Dropdown>}
-                            <Link to={'/CreateIPO'}>
+                            <Link to={project? `/CreateIPO/${project.name}`:'/CreateIPO'}>
                                 <Button variant='ghost' >
                                     {addIcon} New IPO
                                 </Button>

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/index.tsx
@@ -64,7 +64,7 @@ const SearchIPO = (): JSX.Element => {
         setIsLoading(true);
         if(project === undefined){
             console.error('The project is of type undefined');
-            showSnackbarNotification('Get saved filters failed: The project is of type undefined', 5000);
+            showSnackbarNotification('Get saved filters failed: The project is of type undefined');
             setIsLoading(false);
             return;
         }
@@ -73,7 +73,7 @@ const SearchIPO = (): JSX.Element => {
             setSavedFilters(response);
         } catch (error) {
             console.error('Get saved filters failed: ', error.message, error.data);
-            showSnackbarNotification(error.message, 5000);
+            showSnackbarNotification(error.message);
         }
         setIsLoading(false);
     };
@@ -83,8 +83,8 @@ const SearchIPO = (): JSX.Element => {
             updateSavedFilters();
         }
     }, [project]);
-
     
+
     const getDefaultFilter = (): SavedIPOFilter | undefined => {
         if (savedFilters) {
             const defaultFilter = savedFilters.find((filter) => filter.defaultFilter);
@@ -117,8 +117,8 @@ const SearchIPO = (): JSX.Element => {
             setHasProjectChanged(false);
         }
     }, [savedFilters]);
-
     
+
     /**
      * Fetch available functional roles 
      */
@@ -246,7 +246,7 @@ const SearchIPO = (): JSX.Element => {
     }, [filter]);
 
 
-
+    
     const toggleFilter = (): void => {
         setDisplayFilter(!displayFilter);
     };

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/index.tsx
@@ -29,7 +29,6 @@ const emptyFilter: IPOFilter = {
     punchOutDates: []
 };
 
-
 const SearchIPO = (): JSX.Element => {
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const [displayFilter, setDisplayFilter] = useState<boolean>(false);
@@ -84,7 +83,6 @@ const SearchIPO = (): JSX.Element => {
         }
     }, [project]);
     
-
     const getDefaultFilter = (): SavedIPOFilter | undefined => {
         if (savedFilters) {
             const defaultFilter = savedFilters.find((filter) => filter.defaultFilter);
@@ -118,7 +116,6 @@ const SearchIPO = (): JSX.Element => {
         }
     }, [savedFilters]);
     
-
     /**
      * Fetch available functional roles 
      */
@@ -139,7 +136,6 @@ const SearchIPO = (): JSX.Element => {
             showSnackbarNotification(error.message);
         }
     }, []);
-
 
     useEffect(() => {
         let requestCanceler: Canceler;
@@ -216,7 +212,6 @@ const SearchIPO = (): JSX.Element => {
         };
     }, []);
 
-
     /** Update module header height on module header resize */
     useEffect(() => {
         updateModuleHeaderHeightReference();
@@ -245,12 +240,9 @@ const SearchIPO = (): JSX.Element => {
         forceFilterUpdate();
     }, [filter]);
 
-
-    
     const toggleFilter = (): void => {
         setDisplayFilter(!displayFilter);
     };
-
 
     const getIPOs = async (page: number, pageSize: number, orderBy: string | null, orderDirection: string | null): Promise<IPOs> => {
         if (project) {  //to avoid getting ipos before we have set previous-/default filter (include savedFilters if used)


### PR DESCRIPTION
# Description

If a project has been chosen the project name is added to the href in the new IPO button. This pre-fills the project into the general info in create IPO. It is possible to change the project once in create IPO if the user has chosen the wrong project. 

Completes: [AB#81774](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/81774)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [x] My code is covered by tests.
