### PR TITLE
82282 - Workaround for datetime picker

### DIFF
--- a/src/app/index.style.ts
+++ b/src/app/index.style.ts
@@ -2,6 +2,18 @@ import { Breakpoints } from '@procosys/core/styling';
 import styled from 'styled-components';
 
 export const ProCoSysRootLayout = styled.div`
+input::-webkit-datetime-edit-ampm-field:focus,
+input::-webkit-datetime-edit-day-field:focus,
+input::-webkit-datetime-edit-hour-field:focus,
+input::-webkit-datetime-edit-millisecond-field:focus,
+input::-webkit-datetime-edit-minute-field:focus,
+input::-webkit-datetime-edit-month-field:focus,
+input::-webkit-datetime-edit-second-field:focus,
+input::-webkit-datetime-edit-week-field:focus,
+input::-webkit-datetime-edit-year-field:focus {
+ background-color: highlight;
+ color: highlighttext;
+}
     display: flex;
     flex-direction: column;
     //max-height: calc(100vh);


### PR DESCRIPTION
# Description
Add general styling to highlight dates and times in datetime picker which has been not working due to a bug in the new Chrome version 90.

Completes: [AB#82282](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/82282)

# Checklist:

- [x ] I have performed a self-review of my own code.
- [x ] I have linked my DevOps task using the AB# tag.
- [x ] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
