### PR TITLE
Display overlooked new-tag for new preservation tags in scope overview.

### DIFF
--- a/src/components/Table/__tests__/table.test.jsx
+++ b/src/components/Table/__tests__/table.test.jsx
@@ -1,8 +1,6 @@
 import ProcosysTable from '..';
 import React from 'react';
-import { ThemeProvider } from 'styled-components';
 import { render } from '@testing-library/react';
-import theme from '../../../assets/theme';
 
 const tags = require('./data.json');
 
@@ -39,15 +37,9 @@ const columns = [
 
 const maxRows = 10;
 
-const renderWithTheme = (Component) => {
-    return render(
-        <ThemeProvider theme={theme}>{Component}</ThemeProvider>
-    );
-};
-
 describe('<ProcosysTable />', () => {
     it('Render test', async () => {
-        const { queryAllByRole, queryAllByText } = renderWithTheme(
+        const { queryAllByRole, queryAllByText } = render(
 
             <ProcosysTable
                 setPageSize={() => { }}

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverviewTable.style.ts
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverviewTable.style.ts
@@ -8,7 +8,7 @@ export const Toolbar = styled.div`
 `;
 
 export const TagStatusLabel = styled.span`
-    margin-left: auto;
+    margin-left: 10px;
     border-radius: calc(var(--grid-unit) * 2);
     padding: calc(var(--grid-unit) / 2) var(--grid-unit);
     font-size: calc(var(--grid-unit) * 1.5);

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverviewTable.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverviewTable.tsx
@@ -1,4 +1,4 @@
-import { Container, SingleIconContainer, TagLink } from '@procosys/modules/Preservation/views/ScopeOverview/ScopeOverviewTable.style';
+import { Container, SingleIconContainer, TagLink, TagStatusLabel } from '@procosys/modules/Preservation/views/ScopeOverview/ScopeOverviewTable.style';
 import { PreservedTag, PreservedTags } from '@procosys/modules/Preservation/views/ScopeOverview/types';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { ColumnInstance, TableOptions, UseTableRowProps } from 'react-table';
@@ -133,6 +133,7 @@ const ScopeOverviewTable = (props: ScopeOverviewTableProps): JSX.Element => {
             <Tooltip title={tag.description || ''} arrow={true} enterDelay={200} enterNextDelay={100}>
                 <div className='controlOverflow' style={{ color: isTagOverdue(tag) ? tokens.colors.interactive.danger__text.rgba : 'rgba(0, 0, 0, 1)', opacity: tag.isVoided ? '0.5' : '1' }}>
                     {tag.description}
+                    {tag.isNew && <TagStatusLabel>new</TagStatusLabel>}
                 </div>
             </Tooltip>
         );

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverviewTable.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverviewTable.tsx
@@ -133,7 +133,7 @@ const ScopeOverviewTable = (props: ScopeOverviewTableProps): JSX.Element => {
             <Tooltip title={tag.description || ''} arrow={true} enterDelay={200} enterNextDelay={100}>
                 <div className='controlOverflow' style={{ color: isTagOverdue(tag) ? tokens.colors.interactive.danger__text.rgba : 'rgba(0, 0, 0, 1)', opacity: tag.isVoided ? '0.5' : '1' }}>
                     {tag.description}
-                    {tag.isNew && <TagStatusLabel>new</TagStatusLabel>}
+                    {tag.isNew && <TagStatusLabel role="new-indicator">new</TagStatusLabel>}
                 </div>
             </Tooltip>
         );

--- a/src/modules/Preservation/views/ScopeOverview/__tests__/ScopeOverviewTable.test.jsx
+++ b/src/modules/Preservation/views/ScopeOverview/__tests__/ScopeOverviewTable.test.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import ScopeOverviewTable from '../ScopeOverviewTable';
+import { screen, render } from '@testing-library/react';
+
+const mockTags = {
+    maxAvailable: 1,
+    tags: [{
+        actionStatus: 'active',
+        areaCode: 'areacode',
+        calloffNo: 'calloffno',
+        commPkgNo: 'commpkno',
+        description: 'descripotion',
+        disciplineCode: 'T',
+        id: 1,
+        isNew: true,
+        isVoided: false,
+        mcPkgNo: 'mcpkgno',
+        mode: 'mode',
+        nextMode: 'nextMode',
+        nextResponsibleCode: 'nextresp',
+        purchaseOrderNo: 'purchorderno',
+        readyToBePreserved: true,
+        readyToBeStarted: false,
+        readyToBeTransferred: true,
+        readyToBeCompleted: false,
+        readyToBeRescheduled: true,
+        isInUse: true,
+        requirements: [
+            {
+                id: 1,
+                requirementTypeCode: 'Area',
+                requirementTypeIcon: 'Area',
+                nextDueTimeUtc: '2020-06-24T07:41:29.8405826Z',
+                nextDueAsYearAndWeek: '2020w26',
+                nextDueWeeks: 10,
+                readyToBePreserved: true
+            }
+        ],
+        status: 'Active',
+        responsibleCode: '1',
+        responsibleDescription: 'respdesc',
+        tagFunctionCode: 'tfc',
+        tagNo: 'tagno',
+        tagType: 'Standard',
+        rowVersion: '1',
+    }]
+};
+
+
+var getData = jest.fn(async () => {
+    return mockTags;
+});
+
+describe('<ScopeOverviewTable />', () => {
+    it('Display new-indicator in table', async () => {
+        var propFunc = jest.fn();
+        render(
+            <ScopeOverviewTable
+                setOrderDirection={propFunc}
+                setOrderByField={propFunc}
+                selectedTags={[]}
+                setSelectedTags={propFunc}
+                showTagDetails={true}
+                getData={getData}
+                pageSize={10}
+                pageIndex={0}
+                setRefreshScopeListCallback={propFunc} />
+        );
+
+        let exists = false;
+        await screen.findByRole('new-indicator')
+            .then(() => {
+                exists = true;
+            })
+            .catch(() => {
+                exists = false;
+            });
+
+        expect(exists).toBeTruthy();
+    });
+});


### PR DESCRIPTION
# Description

Added overlooked 'new'-label to new preservation tags in Preservation scope overview. When a new tag is added to scope, a "new-indicator" should be displayed in the overview table.

Completes: [AB#82366](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/82366)

# Checklist:

- [X] I have performed a self-review of my own code.
- [X] I have linked my DevOps task using the AB# tag.
- [X] My code is easy to read, and comments are added where needed.
- [X] My code is covered by tests.
