### PR TITLE
bug/82198 Preservation - check box state not updated

### DIFF
--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
@@ -1,13 +1,13 @@
-import React, { useState, useEffect } from 'react';
-
 import { Button, TextField, Typography } from '@equinor/eds-core-react';
+import { Container, Field, NextInfo, Section } from './Requirements.style';
+import React, { useEffect, useState } from 'react';
 import { TagRequirement, TagRequirementField, TagRequirementRecordValues } from './../types';
-import RequirementNumberField from './RequirementNumberField';
-import RequirementCheckboxField from './RequirementCheckboxField';
+
 import PreservationIcon from '../../../../../../components/PreservationIcon';
-import { Container, Section, Field, NextInfo } from './Requirements.style';
-import { showSnackbarNotification } from './../../../../../../core/services/NotificationService';
 import RequirementAttachmentField from './RequirementAttachmentField';
+import RequirementCheckboxField from './RequirementCheckboxField';
+import RequirementNumberField from './RequirementNumberField';
+import { showSnackbarNotification } from './../../../../../../core/services/NotificationService';
 import { useDirtyContext } from '@procosys/core/DirtyContext';
 
 interface RequirementProps {
@@ -197,13 +197,13 @@ const Requirements = ({
 
     const getCheckboxValue = (requirementId: number, field: TagRequirementField): boolean | undefined => {
         const requirement = requirementValues.find(value => value.requirementId == requirementId);
-        if (requirement && field.currentValue) {
+        if (requirement) {
             const fieldIndex = requirement.checkBoxValues.findIndex(f => f.fieldId == field.id);
             if (fieldIndex > -1) {
                 return requirement.checkBoxValues[fieldIndex].isChecked;
             }
         }
-        return field.currentValue && field.currentValue.isChecked;
+        return field.currentValue ? field.currentValue.isChecked : false;
     };
 
     const getRequirementField = (requirementId: number, field: TagRequirementField): JSX.Element => {


### PR DESCRIPTION
# Description

- When field currentValue is null, return false to avoid uncontrolled to controlled react component error message
- When requirement is not undefined, return checkbox value

Completes: [AB#82198](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/82198)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
