### PR TITLE
Bug 83360-Handle non-existing App configuration setting for searchApi

### DIFF
--- a/src/modules/QuickSearch/http/QuickSearchApiClient.tsx
+++ b/src/modules/QuickSearch/http/QuickSearchApiClient.tsx
@@ -83,8 +83,8 @@ class QuickSearchApiClient extends ApiClient {
     constructor(authService: IAuthService) {
         super(
             authService,
-            ProCoSysSettings.searchApi.scope.join(' '),
-            ProCoSysSettings.searchApi.url
+            ProCoSysSettings.searchApi && ProCoSysSettings.searchApi.scope ? ProCoSysSettings.searchApi.scope.join(' ') : '',
+            ProCoSysSettings.searchApi && ProCoSysSettings.searchApi.url ? ProCoSysSettings.searchApi.url : ''
         );
         this.client.interceptors.request.use(
             config => {


### PR DESCRIPTION
# Description
Handle missing App configuration setting for searchApi.

Completes: [AB#83360](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/83360)

# Checklist:

- [X] I have performed a self-review of my own code.
- [X] I have linked my DevOps task using the AB# tag.
- [X] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
