### PR TITLE
bug/83256-Search for IPO role returns blank page

### DIFF
--- a/src/components/EdsIcon/index.tsx
+++ b/src/components/EdsIcon/index.tsx
@@ -60,7 +60,8 @@ import {
     vertical_split,
     warning_filled,
     warning_outlined,
-    world
+    world,
+    clear
 } from '@equinor/eds-icons';
 
 import { Icon } from '@equinor/eds-core-react';
@@ -71,7 +72,8 @@ const icons = {
     notifications, chevron_down, chevron_up, edit, delete_to_trash, calendar_today, person, alarm_on, world, link,
     place, pressure, vertical_split, category, search, bookmark_collection, add, arrow_down, arrow_up, file, file_description, image, filter_list, more_vertical,
     warning_filled, delete_forever, restore_from_trash, edit_text, account_circle, lock, info_circle, iphone, print, fast_forward, play,
-    copy, star_filled, star_outlined, microsoft_excel, done, chevron_right, arrow_back, warning_outlined, more_horizontal, microsoft_outlook, microsoft_powerpoint, microsoft_word, calendar_date_range, menu, calendar_reject, launch, share
+    copy, star_filled, star_outlined, microsoft_excel, done, chevron_right, arrow_back, warning_outlined, more_horizontal, microsoft_outlook,
+    microsoft_powerpoint, microsoft_word, calendar_date_range, menu, calendar_reject, launch, share, clear
 };
 
 Icon.add(icons);


### PR DESCRIPTION
# Description
Added "clear" to eds icon imports to prevent white screen when a role or person is chosen in IPO search filter.

Completes: [AB#83256](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/83256)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
