### PR TITLE
Bug/82594 - Too much space below table component

### DIFF
--- a/src/app/index.style.ts
+++ b/src/app/index.style.ts
@@ -1,4 +1,3 @@
-import { Breakpoints } from '@procosys/core/styling';
 import styled from 'styled-components';
 
 export const ProCoSysRootLayout = styled.div`

--- a/src/app/index.style.ts
+++ b/src/app/index.style.ts
@@ -23,11 +23,5 @@ input::-webkit-datetime-edit-year-field:focus {
     #root-content {
         overflow: auto;
         height: 100%;
-        ${Breakpoints.TABLET} {
-            margin-bottom: 50px;
-        }
-        ${Breakpoints.MOBILE} {
-            margin-bottom: 100px;
-        }
     }   
 `;

--- a/src/components/AttachmentList/index.tsx
+++ b/src/components/AttachmentList/index.tsx
@@ -238,6 +238,8 @@ const AttachmentList = ({
                     clientPagination={true}
                     clientSorting={true}
                     rowSelect={false}
+                    maxRowCount={large ? attachments.length : undefined}
+                    pageCount={large ? Math.ceil(attachments.length / 25) : undefined}
                     toolbar={determineToolbarButtonRender()}
                 />
             </TableContainer>

--- a/src/core/services/ModalDialogService/style.ts
+++ b/src/core/services/ModalDialogService/style.ts
@@ -47,7 +47,6 @@ export const Content = styled.div`
     display: flex;
     flex-direction: column;
     flex-grow: 1;
-    height: 80%;
     padding-right: calc(var(--grid-unit) * 2);
     padding-left: calc(var(--grid-unit) * 2);
     padding-bottom: calc(var(--grid-unit) * 2);

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/SelectScope/SelectScope.style.ts
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/SelectScope/SelectScope.style.ts
@@ -24,7 +24,7 @@ export const Header = styled.header`
 
 export const Divider = styled.div`
     margin-top: calc(var(--grid-unit) * -3);
-    margin-bottom: -1000px;
+    margin-bottom: calc((var(--grid-unit) * -2) - 20px);
     margin-right: calc(var(--grid-unit) * 2);
     margin-left: calc(var(--grid-unit) * 5);
     border-left: solid 1px ${tokens.colors.ui.background__medium.rgba};

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/Table/index.style.tsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/Table/index.style.tsx
@@ -4,8 +4,10 @@ import { tokens } from '@equinor/eds-tokens';
 
 export const Container = styled.div`
     margin-top: var(--margin-module--top);
-    height: calc(100% - 100px);
-    
+    min-height: 200px;
+    flex-grow: 1;
+    margin-bottom: 52px;
+
     tbody, thead {
         .MuiButtonBase-root {
             :hover {

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/Table/index.style.tsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/Table/index.style.tsx
@@ -4,7 +4,7 @@ import { tokens } from '@equinor/eds-tokens';
 
 export const Container = styled.div`
     margin-top: var(--margin-module--top);
-    height: calc(100% - 120px);
+    height: calc(100% - 100px);
     
     tbody, thead {
         .MuiButtonBase-root {

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/index.style.tsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/index.style.tsx
@@ -2,6 +2,7 @@ import styled, { FlattenSimpleInterpolation, css } from 'styled-components';
 
 import { Button } from '@equinor/eds-core-react';
 import { tokens } from '@equinor/eds-tokens';
+import { Breakpoints } from '@procosys/core/styling';
 
 export const Container = styled.div`
     display: flex;
@@ -23,6 +24,9 @@ export const ContentContainer = styled.div<{ withSidePanel?: boolean }>`
         }
     }};
     overflow: hidden;
+    ${Breakpoints.MOBILE} {
+            overflow-y: scroll;
+    }
     flex-direction: column;
     margin-top: var(--margin-module--top);
     min-height: 400px; /* min-height to ensure that project dropdown (max 300px) is not cut off if empty table */

--- a/src/modules/Preservation/views/AddScope/AddScope.style.ts
+++ b/src/modules/Preservation/views/AddScope/AddScope.style.ts
@@ -3,9 +3,9 @@ import { tokens } from '@equinor/eds-tokens';
 
 export const Container = styled.div`
     display: flex;
-    height: calc(100% - 70px);
+    height: calc( 100% - var(--grid-unit) * 4);
     overflow: hidden;
-    margin: var(--margin-module--top) var(--margin-module--right) var(--margin-module--bottom) var(--margin-module--left) 
+    margin: calc(var(--grid-unit) * 2);
 `;
 
 export const LargerComponent = styled.div`

--- a/src/modules/Preservation/views/AddScope/SelectMigrateTags/SelectMigrateTags.style.ts
+++ b/src/modules/Preservation/views/AddScope/SelectMigrateTags/SelectMigrateTags.style.ts
@@ -35,7 +35,9 @@ export const Container = styled.div`
 `;
 
 export const TableContainer = styled.div`
-    height: calc(100% - 260px);
+    min-height: 200px;
+    flex-grow:1;
+    margin-bottom: 100px;
 `;
 
 export const Header = styled.header`

--- a/src/modules/Preservation/views/AddScope/SelectTags/SelectTags.style.ts
+++ b/src/modules/Preservation/views/AddScope/SelectTags/SelectTags.style.ts
@@ -5,8 +5,6 @@ export const Container = styled.div`
     display: flex;
     flex-direction: column;
     width:100%;
-    flex-grow: 1;
-    max-height: calc(100% - 200px);
 
     input + svg {
         width: 24px;
@@ -94,7 +92,9 @@ export const LoadingContainer = styled.div`
 `;
 
 export const TableContainer = styled.div`
-    height: calc(100% - 90px);
+    min-height: 200px;
+    flex-grow: 1;
+    margin-bottom: 100px;
 `;
 
 export const OverflowColumn = styled.div`

--- a/src/modules/Preservation/views/ScopeOverview/CompleteDialog.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/CompleteDialog.tsx
@@ -65,10 +65,6 @@ const MainContainer = styled.div`
     height: 70vh;
 `;
 
-const TableContainer = styled.div`
-    height: 50%;
-`;
-
 const CompleteDialog = ({
     completableTags,
     nonCompletableTags
@@ -76,15 +72,13 @@ const CompleteDialog = ({
     return (
         <MainContainer>
             {nonCompletableTags.length > 0 && (
-                <TableContainer>
+                <>
                     <Typography variant="meta">{nonCompletableTags.length} tag(s) cannot be completed. Tags are not started, already completed or voided.</Typography>
                     <DialogTable tags={nonCompletableTags} columns={columns} toolbarText='tag(s) will not be completed' toolbarColor={tokens.colors.interactive.danger__text.rgba} />
-                </TableContainer>
+                </>
             )}
             {completableTags.length > 0 && (
-                <TableContainer>
-                    <DialogTable tags={completableTags} columns={columns} toolbarText='tag(s) will be completed' toolbarColor={tokens.colors.interactive.primary__resting.rgba} />
-                </TableContainer>
+                <DialogTable tags={completableTags} columns={columns} toolbarText='tag(s) will be completed' toolbarColor={tokens.colors.interactive.primary__resting.rgba} />
             )}
         </MainContainer>
     );

--- a/src/modules/Preservation/views/ScopeOverview/CompleteDialog.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/CompleteDialog.tsx
@@ -7,6 +7,7 @@ import DialogTable from './DialogTable';
 import { TableOptions, UseTableRowProps } from 'react-table';
 import styled from 'styled-components';
 import { Tooltip } from '@material-ui/core';
+import { MainContainer, TableContainer } from './Dialogs.style';
 
 interface CompleteDialogProps {
     completableTags: PreservedTag[];
@@ -17,7 +18,6 @@ const OverflowColumn = styled.div`
     text-overflow: ellipsis;
     overflow: hidden;
 `;
-
 
 const getRequirementIcons = (row: TableOptions<PreservedTag>): JSX.Element => {
     const tag = row.value as PreservedTag;
@@ -61,10 +61,6 @@ const columns = [
     { Header: 'Req type', accessor: (d: UseTableRowProps<PreservedTag>): UseTableRowProps<PreservedTag> => d, id: 'reqtype', Cell: getRequirementIcons }
 ];
 
-const MainContainer = styled.div`
-    height: 70vh;
-`;
-
 const CompleteDialog = ({
     completableTags,
     nonCompletableTags
@@ -72,13 +68,15 @@ const CompleteDialog = ({
     return (
         <MainContainer>
             {nonCompletableTags.length > 0 && (
-                <>
+                <TableContainer isHalfSize={completableTags.length > 0}>
                     <Typography variant="meta">{nonCompletableTags.length} tag(s) cannot be completed. Tags are not started, already completed or voided.</Typography>
                     <DialogTable tags={nonCompletableTags} columns={columns} toolbarText='tag(s) will not be completed' toolbarColor={tokens.colors.interactive.danger__text.rgba} />
-                </>
+                </TableContainer>
             )}
             {completableTags.length > 0 && (
-                <DialogTable tags={completableTags} columns={columns} toolbarText='tag(s) will be completed' toolbarColor={tokens.colors.interactive.primary__resting.rgba} />
+                <TableContainer isHalfSize={nonCompletableTags.length > 0}>
+                    <DialogTable tags={completableTags} columns={columns} toolbarText='tag(s) will be completed' toolbarColor={tokens.colors.interactive.primary__resting.rgba} />
+                </TableContainer>
             )}
         </MainContainer>
     );

--- a/src/modules/Preservation/views/ScopeOverview/DialogTable.style.ts
+++ b/src/modules/Preservation/views/ScopeOverview/DialogTable.style.ts
@@ -9,11 +9,13 @@ export const Toolbar = styled.div`
 export const Container = styled.div`
     height: 100%;
     display: flex;
+    background-color: red;
 
     > div {
         max-height: 464px;
         flex-grow: 1;
         margin-bottom: 68px;
+        background-color: blue;
     }
     
     ${Breakpoints.TABLET} {

--- a/src/modules/Preservation/views/ScopeOverview/DialogTable.style.ts
+++ b/src/modules/Preservation/views/ScopeOverview/DialogTable.style.ts
@@ -8,9 +8,12 @@ export const Toolbar = styled.div`
 
 export const Container = styled.div`
     height: 100%;
+    display: flex;
 
     > div {
-        height: 65%;
+        max-height: 464px;
+        flex-grow: 1;
+        margin-bottom: 68px;
     }
     
     ${Breakpoints.TABLET} {

--- a/src/modules/Preservation/views/ScopeOverview/DialogTable.style.ts
+++ b/src/modules/Preservation/views/ScopeOverview/DialogTable.style.ts
@@ -9,13 +9,11 @@ export const Toolbar = styled.div`
 export const Container = styled.div`
     height: 100%;
     display: flex;
-    background-color: red;
 
     > div {
         max-height: 464px;
         flex-grow: 1;
-        margin-bottom: 68px;
-        background-color: blue;
+        margin-bottom: 52px;
     }
     
     ${Breakpoints.TABLET} {

--- a/src/modules/Preservation/views/ScopeOverview/DialogTable.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/DialogTable.tsx
@@ -35,7 +35,8 @@ const DialogTable = ({
                     toolbarColor={toolbarColor}
                 />
             </div>
-        </Container>);
+        </Container>
+    );
 };
 
 export default DialogTable;

--- a/src/modules/Preservation/views/ScopeOverview/Dialogs.style.ts
+++ b/src/modules/Preservation/views/ScopeOverview/Dialogs.style.ts
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+export const MainContainer = styled.div`
+    height: 70vh;
+`;
+
+export const TableContainer = styled.div<{ isHalfSize: boolean }>`
+    height: ${(props): string => props.isHalfSize? '50%' : '100%' };
+`;

--- a/src/modules/Preservation/views/ScopeOverview/PreservedDialog.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/PreservedDialog.tsx
@@ -28,6 +28,8 @@ const columns = [
 
 const Container = styled.div`
     height: 65vh;
+    /* display: flex;
+    flex-direction: column; */
 `;
 
 const PreservedDialog = ({

--- a/src/modules/Preservation/views/ScopeOverview/PreservedDialog.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/PreservedDialog.tsx
@@ -6,6 +6,7 @@ import RequirementIcons from './RequirementIcons';
 import DialogTable from './DialogTable';
 import { TableOptions, UseTableRowProps } from 'react-table';
 import styled from 'styled-components';
+import { MainContainer, TableContainer } from './Dialogs.style';
 
 interface PreservedDialogProps {
     preservableTags: PreservedTag[];
@@ -26,29 +27,25 @@ const columns = [
     { Header: 'Req type', accessor: (d: UseTableRowProps<PreservedTag>): UseTableRowProps<PreservedTag> => d, id: 'reqtype', Cell: getRequirementIcons }
 ];
 
-const Container = styled.div`
-    height: 65vh;
-    /* display: flex;
-    flex-direction: column; */
-`;
-
 const PreservedDialog = ({
     preservableTags,
     nonPreservableTags
 }: PreservedDialogProps): JSX.Element => {
 
     return (
-        <Container>
+        <MainContainer>
             {nonPreservableTags.length > 0 && (
-                <div>
+                <TableContainer isHalfSize={preservableTags.length > 0}>
                     <Typography variant="meta">{nonPreservableTags.length} tag(s) cannot be preserved this week.</Typography>
                     <DialogTable tags={nonPreservableTags} columns={columns} toolbarText='tag(s) will not be preserved for this week' toolbarColor={tokens.colors.interactive.danger__text.rgba} />
-                </div>
+                </TableContainer>
             )}
             {preservableTags.length > 0 && (
-                <DialogTable tags={preservableTags} columns={columns} toolbarText='tag(s) will be preserved for this week' toolbarColor={tokens.colors.interactive.primary__resting.rgba} />
+                <TableContainer isHalfSize={nonPreservableTags.length > 0}>
+                    <DialogTable tags={preservableTags} columns={columns} toolbarText='tag(s) will be preserved for this week' toolbarColor={tokens.colors.interactive.primary__resting.rgba} />
+                </TableContainer>
             )}
-        </Container>
+        </MainContainer>
     );
 };
 

--- a/src/modules/Preservation/views/ScopeOverview/RemoveDialog.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/RemoveDialog.tsx
@@ -6,6 +6,7 @@ import RequirementIcons from './RequirementIcons';
 import DialogTable from './DialogTable';
 import { TableOptions, UseTableRowProps } from 'react-table';
 import styled from 'styled-components';
+import { MainContainer, TableContainer } from './Dialogs.style';
 
 interface RemoveDialogProps {
     removableTags: PreservedTag[];
@@ -35,18 +36,19 @@ const RemoveDialog = ({
     nonRemovableTags: nonRemovableTags
 }: RemoveDialogProps): JSX.Element => {
     return (
-
-        <Container>
+        <MainContainer>
             {nonRemovableTags.length > 0 && (
-                <div>
+                <TableContainer isHalfSize={removableTags.length > 0}>
                     <Typography variant="meta">{nonRemovableTags.length} tag(s)  cannot be removed. Tags are not voided, or are in use.</Typography>
                     <DialogTable tags={nonRemovableTags} columns={columns} toolbarText='tag(s) will not be removed' toolbarColor={tokens.colors.interactive.danger__text.rgba} />
-                </div>
+                </TableContainer>
             )}
             {removableTags.length > 0 && (
-                <DialogTable tags={removableTags} columns={columns} toolbarText='tag(s) will be removed' toolbarColor={tokens.colors.interactive.primary__resting.rgba} />
+                <TableContainer isHalfSize={nonRemovableTags.length > 0}>
+                    <DialogTable tags={removableTags} columns={columns} toolbarText='tag(s) will be removed' toolbarColor={tokens.colors.interactive.primary__resting.rgba} />
+                </TableContainer>
             )}
-        </Container>
+        </MainContainer>
     );
 };
 

--- a/src/modules/Preservation/views/ScopeOverview/RescheduleDialog.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/RescheduleDialog.tsx
@@ -16,6 +16,7 @@ import { useDirtyContext } from '@procosys/core/DirtyContext';
 import { TableOptions, UseTableRowProps } from 'react-table';
 import { Tooltip } from '@material-ui/core';
 import styled from 'styled-components';
+import { MainContainer, TableContainer } from './Dialogs.style';
 
 const errorIcon = <EdsIcon name='error_filled' size={16} color={tokens.colors.interactive.danger__text.rgba} />;
 const moduleName = 'PreservationRescheduleDialog';
@@ -85,10 +86,10 @@ const columns = [
 
 const directionItems: SelectItem[] = [
     { text: 'Earlier', value: 'Earlier' },
-    { text: 'Later', value: 'Later' }];
+    { text: 'Later', value: 'Later' }
+];
 
 const RescheduleDialog = (props: RescheduleDialogProps): JSX.Element | null => {
-
     const [directionItem, setDirectionItem] = useState<SelectItem | null>();
     const [noOfWeeks, setNoOfWeeks] = useState<string>('');
     const [noOfWeeksIsValid, setNoOfWeeksIsValid] = useState<boolean>(false);
@@ -144,7 +145,6 @@ const RescheduleDialog = (props: RescheduleDialogProps): JSX.Element | null => {
         setNonReschedulableTags(nonReschedulableTags);
     }, [props.tags]);
 
-
     const hasUnsavedChanges = (): boolean => {
         return (noOfWeeks || (directionItem && directionItem.text) || (comment && comment.length > 0)) ? true : false;
     };
@@ -193,8 +193,6 @@ const RescheduleDialog = (props: RescheduleDialogProps): JSX.Element | null => {
             setError('Has to be a number');
         }
     };
-
-    
 
     return (
         <Scrim>
@@ -251,17 +249,22 @@ const RescheduleDialog = (props: RescheduleDialogProps): JSX.Element | null => {
                             </InputContainer>
                         )
                     }
+                    <MainContainer>
                     {
                         nonReschedulableTags.length > 0 && (
+                            <TableContainer isHalfSize={reschedulableTags.length > 0}>
                                 <DialogTable tags={nonReschedulableTags} columns={columns} toolbarText='tag(s) will not be rescheduled' toolbarColor={tokens.colors.interactive.danger__text.rgba} />
+                            </TableContainer>
                         )
                     }
                     {
                         reschedulableTags.length > 0 && (
+                            <TableContainer isHalfSize={nonReschedulableTags.length > 0}>
                                 <DialogTable tags={reschedulableTags} columns={columns} toolbarText='tag(s) will be rescheduled' toolbarColor={tokens.colors.interactive.primary__resting.rgba} />
+                            </TableContainer>
                         )
                     }
-
+                    </MainContainer>
                 </Content >
 
                 <ButtonContainer>

--- a/src/modules/Preservation/views/ScopeOverview/RescheduleDialog.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/RescheduleDialog.tsx
@@ -20,12 +20,6 @@ import styled from 'styled-components';
 const errorIcon = <EdsIcon name='error_filled' size={16} color={tokens.colors.interactive.danger__text.rgba} />;
 const moduleName = 'PreservationRescheduleDialog';
 
-const TableContainer = styled.div<{ restrictHeight?: boolean }>`
-        ${(props): any => `
-            height: ${props.restrictHeight ? '40%' : '100%'};
-        `}
-    `;
-
 interface RescheduleDialogProps {
     tags: PreservedTag[];
     open: boolean;
@@ -259,16 +253,12 @@ const RescheduleDialog = (props: RescheduleDialogProps): JSX.Element | null => {
                     }
                     {
                         nonReschedulableTags.length > 0 && (
-                            <TableContainer restrictHeight={reschedulableTags.length > 0}>
                                 <DialogTable tags={nonReschedulableTags} columns={columns} toolbarText='tag(s) will not be rescheduled' toolbarColor={tokens.colors.interactive.danger__text.rgba} />
-                            </TableContainer>
                         )
                     }
                     {
                         reschedulableTags.length > 0 && (
-                            <TableContainer restrictHeight={nonReschedulableTags.length > 0}>
                                 <DialogTable tags={reschedulableTags} columns={columns} toolbarText='tag(s) will be rescheduled' toolbarColor={tokens.colors.interactive.primary__resting.rgba} />
-                            </TableContainer>
                         )
                     }
 

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.style.ts
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.style.ts
@@ -23,6 +23,9 @@ export const ContentContainer = styled.div<{ withSidePanel?: boolean }>`
         }
     }};
     overflow: hidden;
+    ${Breakpoints.MOBILE} {
+        overflow-y: scroll;
+    }
     flex-direction: column;
     margin-top: var(--margin-module--top);
     min-height: 400px; /* min-height to ensure that project dropdown (max 300px) is not cut off if empty table */

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverviewTable.style.ts
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverviewTable.style.ts
@@ -41,7 +41,7 @@ export const Container = styled.div`
     flex-grow: 1;
     flex-direction: column;
     min-height: 200px;
-    margin-bottom: 52px;
+    margin-bottom: 76px;
     
     input + svg {
         width: 24px;

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverviewTable.style.ts
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverviewTable.style.ts
@@ -40,20 +40,12 @@ export const Container = styled.div`
     display: flex;
     flex-grow: 1;
     flex-direction: column;
-
-    max-height: calc(100% - 160px);
-        ${Breakpoints.TABLET} {
-            margin-bottom: 60px;
-            max-height: calc(100% - 140px);
-        }
-        ${Breakpoints.MOBILE} {
-            max-height: calc(100% - 100px);
-            margin-bottom: 60px;
-        }
+    min-height: 200px;
+    margin-bottom: 52px;
     
     input + svg {
         width: 24px;
-        height: 24px;       
+        height: 24px;
     }
     
     tbody, thead {

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverviewTable.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverviewTable.tsx
@@ -297,9 +297,7 @@ const ScopeOverviewTable = (props: ScopeOverviewTableProps): JSX.Element => {
                 orderBy={sortBy}
                 pageCount={0} />
         </Container>
-
     );
-
 };
 
 export default ScopeOverviewTable;

--- a/src/modules/Preservation/views/ScopeOverview/StartPreservationDialog.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/StartPreservationDialog.tsx
@@ -7,6 +7,7 @@ import DialogTable from './DialogTable';
 import { TableOptions, UseTableRowProps } from 'react-table';
 import styled from 'styled-components';
 import { Tooltip } from '@material-ui/core';
+import { MainContainer, TableContainer } from './Dialogs.style';
 
 interface StartPreservationDialogProps {
     startableTags: PreservedTag[];
@@ -64,18 +65,20 @@ const StartPreservationDialog = ({
     startableTags,
     nonStartableTags
 }: StartPreservationDialogProps): JSX.Element => {
-
-    return (<div style={{height: '65vh'}}>
-        {nonStartableTags.length > 0 && (
-            <div>
-                <Typography variant="meta">{nonStartableTags.length} tag(s) cannot be started. Tags are already started, or are voided.</Typography>
-                <DialogTable tags={nonStartableTags} columns={columns} toolbarText='tag(s) will not be started' toolbarColor={tokens.colors.interactive.danger__text.rgba} />
-            </div>
-        )}
-        {startableTags.length > 0 && (
-            <DialogTable tags={startableTags} columns={columns} toolbarText='tag(s) will be started' toolbarColor={tokens.colors.interactive.primary__resting.rgba} />
-        )}
-    </div>
+    return (
+        <MainContainer>
+            {nonStartableTags.length > 0 && (
+                <TableContainer isHalfSize={startableTags.length > 0}>
+                    <Typography variant="meta">{nonStartableTags.length} tag(s) cannot be started. Tags are already started, or are voided.</Typography>
+                    <DialogTable tags={nonStartableTags} columns={columns} toolbarText='tag(s) will not be started' toolbarColor={tokens.colors.interactive.danger__text.rgba} />
+                </TableContainer>
+            )}
+            {startableTags.length > 0 && (
+                <TableContainer isHalfSize={nonStartableTags.length > 0}>
+                    <DialogTable tags={startableTags} columns={columns} toolbarText='tag(s) will be started' toolbarColor={tokens.colors.interactive.primary__resting.rgba} />
+                </TableContainer>
+            )}
+        </MainContainer>
     );
 };
 

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/HistoryTab/HistoryTab.style.ts
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/HistoryTab/HistoryTab.style.ts
@@ -2,8 +2,8 @@ import styled, { css } from 'styled-components';
 import { tokens } from '@equinor/eds-tokens';
 
 export const Container = styled.div`
-    padding: calc(var(--grid-unit) * 2); 
-    height: 500px;
+    padding: calc(var(--grid-unit) * 2);
+    height: calc(100vh - 250px);
 `;
 
 export const DetailsContainer = styled.div`

--- a/src/modules/Preservation/views/ScopeOverview/TransferDialog.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TransferDialog.tsx
@@ -103,8 +103,8 @@ const MainContainer = styled.div`
     height: 70vh;
 `;
 
-const TableContainer = styled.div`
-    height: 50%;
+const TableContainer = styled.div<{ isHalfScreen: boolean }>`
+    height: ${(props): string => props.isHalfScreen? '50%' : '100%' };
 `;
 
 const TransferDialog = ({
@@ -115,13 +115,13 @@ const TransferDialog = ({
     return (
         <MainContainer>
             {nonTransferableTags.length > 0 && (
-                <TableContainer>
+                <TableContainer isHalfScreen={transferableTags.length > 0}>
                     <Typography variant="meta">{nonTransferableTags.length} tag(s) cannot be transferred. Tags are not started, already completed or voided.</Typography>
                     <DialogTable tags={nonTransferableTags} columns={columns} toolbarText='tag(s) cannot be transferred' toolbarColor={tokens.colors.interactive.danger__text.rgba} />
                 </TableContainer>
             )}
             {transferableTags.length > 0 && (
-                <TableContainer>
+                <TableContainer isHalfScreen={nonTransferableTags.length > 0} >
                     <DialogTable tags={transferableTags} columns={columns} toolbarText='tag(s) will be transferred' toolbarColor={tokens.colors.interactive.primary__resting.rgba} />
                 </TableContainer>
             )}

--- a/src/modules/Preservation/views/ScopeOverview/TransferDialog.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TransferDialog.tsx
@@ -7,6 +7,7 @@ import DialogTable from './DialogTable';
 import { TableOptions, UseTableRowProps } from 'react-table';
 import styled from 'styled-components';
 import { Tooltip } from '@material-ui/core';
+import { MainContainer, TableContainer } from './Dialogs.style';
 
 interface TransferDialogProps {
     transferableTags: PreservedTag[];
@@ -99,14 +100,6 @@ const columns = [
     { Header: 'Req type', accessor: (d: UseTableRowProps<PreservedTag>): UseTableRowProps<PreservedTag> => d, Cell: getRequirementIcons }
 ];
 
-const MainContainer = styled.div`
-    height: 70vh;
-`;
-
-const TableContainer = styled.div<{ isHalfScreen: boolean }>`
-    height: ${(props): string => props.isHalfScreen? '50%' : '100%' };
-`;
-
 const TransferDialog = ({
     transferableTags,
     nonTransferableTags
@@ -115,13 +108,13 @@ const TransferDialog = ({
     return (
         <MainContainer>
             {nonTransferableTags.length > 0 && (
-                <TableContainer isHalfScreen={transferableTags.length > 0}>
+                <TableContainer isHalfSize={transferableTags.length > 0}>
                     <Typography variant="meta">{nonTransferableTags.length} tag(s) cannot be transferred. Tags are not started, already completed or voided.</Typography>
                     <DialogTable tags={nonTransferableTags} columns={columns} toolbarText='tag(s) cannot be transferred' toolbarColor={tokens.colors.interactive.danger__text.rgba} />
                 </TableContainer>
             )}
             {transferableTags.length > 0 && (
-                <TableContainer isHalfScreen={nonTransferableTags.length > 0} >
+                <TableContainer isHalfSize={nonTransferableTags.length > 0} >
                     <DialogTable tags={transferableTags} columns={columns} toolbarText='tag(s) will be transferred' toolbarColor={tokens.colors.interactive.primary__resting.rgba} />
                 </TableContainer>
             )}

--- a/src/modules/Preservation/views/ScopeOverview/VoidDialog.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/VoidDialog.tsx
@@ -9,6 +9,7 @@ import EdsIcon from '@procosys/components/EdsIcon';
 import { TableOptions, UseTableRowProps } from 'react-table';
 import { Tooltip } from '@material-ui/core';
 import { OverflowColumn } from './RescheduleDialog.style';
+import { MainContainer, TableContainer } from './Dialogs.style';
 
 interface VoidDialogProps {
     voidableTags: PreservedTag[];
@@ -117,16 +118,6 @@ const columns = [
     { Header: 'Req type', accessor: (d: UseTableRowProps<PreservedTag>): UseTableRowProps<PreservedTag> => d, Cell: getRequirementIcons }
 ];
 
-const MainContainer = styled.div`
-    height: 70vh;
-`;
-
-const TableContainer = styled.div<{ restrictHeight?: boolean }>`
-${(props): any => `
-    height: ${props.restrictHeight ? '50%' : '100%'};
-`}
-`;
-
 const VoidDialog = ({
     voidableTags,
     unvoidableTags,
@@ -141,12 +132,12 @@ const VoidDialog = ({
     return (
         <MainContainer>
             {topTable.length > 0 && (
-                <TableContainer restrictHeight={bottomTable.length > 0}>
+                <TableContainer isHalfSize={bottomTable.length > 0}>
                     <Typography variant="meta">{`${topTable.length} tag(s) cannot be ${voiding ? 'voided' : 'unvoided'}.`}</Typography>
                     <DialogTable tags={topTable} columns={columns} toolbarText={`tag(s) are already ${voiding ? 'voided' : 'unvoided'}`} toolbarColor={tokens.colors.interactive.danger__text.rgba} />
                 </TableContainer>)}
             {bottomTable.length > 0 && (
-                <TableContainer restrictHeight={topTable.length > 0}>
+                <TableContainer isHalfSize={topTable.length > 0}>
                     <TopText>
                         <EdsIcon name='warning_filled' color={tokens.colors.interactive.danger__text.rgba} />
                         <Typography variant='h6' style={{ color: tokens.colors.interactive.danger__text.rgba }}>{voiding ? voidingText : unvoidingText}</Typography>


### PR DESCRIPTION
# Description
Removed bottom margin on smaller screens, without the bottom of the table being hidden.
Allowed tables on preservation dialogs to fill whole space if only one of the tables is shown. 
Removed space below pages in AddScope preservation view. 
Removed large white space below McPkg-/CommPkgTable in Create/Edit IPO.

Completes: [AB#82594](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/82594) and [AB#82599](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/82599)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
