### PR TITLE
Bug/83361 edit ipo - participants page goes blank when a functional role no longer exists

### DIFF
--- a/src/modules/InvitationForPunchOut/components/RoleSelector/index.tsx
+++ b/src/modules/InvitationForPunchOut/components/RoleSelector/index.tsx
@@ -44,6 +44,7 @@ const RoleSelector = ({
     const [allRoles, setAllRoles] = useState<RoleParticipant[]>(roles);
     const [filteredRoles, setFilteredRoles] = useState<RoleParticipant[]>(roles);
     const [pickedRoleValue, setPickedRoleValue] = useState<string | null>(null);
+    const [functionalRoleExists, setFunctionalRoleExists] = useState<boolean>(true);
 
     useEffect(() => {
         if (roles.length != allRoles.length) {
@@ -54,6 +55,11 @@ const RoleSelector = ({
     useEffect(() => {
         if (selectedRole && selectedRole.notify) {
             const index = roles.findIndex(r => r.code == selectedRole.code);
+            if (index === -1) {
+                setFunctionalRoleExists(false);
+                setFilteredRoles(roles);
+                return;
+            }
             setFilteredRoles(() => {
                 const rolesCopy = [...roles];
                 rolesCopy[index].notify = true;
@@ -69,6 +75,17 @@ const RoleSelector = ({
             setFilteredRoles(roles);
         }
     }, [selectedRole]);
+
+    useEffect(() => {
+        if (selectedRole) {
+            const pickedRoleExists = allRoles.find(r => r.code == pickedRoleValue);
+            if(pickedRoleExists){
+                setFunctionalRoleExists(true);
+            } else {
+                setFunctionalRoleExists(false);
+            }
+        };
+    }, [pickedRoleValue]);
 
     useClickOutsideNotifier(() => {
         setIsOpen(false);
@@ -312,6 +329,7 @@ const RoleSelector = ({
                 disabled={disabled}
                 role="listbox"
                 isOpen={isOpen}
+                error={!functionalRoleExists}
                 aria-expanded={isOpen}
                 aria-haspopup={true}
             >
@@ -321,6 +339,9 @@ const RoleSelector = ({
                     <EdsIcon name='chevron_down' />
                 </DropdownIcon>
             </DropdownButton>
+            {
+                functionalRoleExists? null : <Label error>This functional role has been deleted or renamed. Please choose another one.</Label>
+            }
             {isOpen && !disabled && (
                 <ul ref={listRef}
                     className='container'

--- a/src/modules/InvitationForPunchOut/components/RoleSelector/index.tsx
+++ b/src/modules/InvitationForPunchOut/components/RoleSelector/index.tsx
@@ -27,9 +27,6 @@ type RoleSelectorProps = {
     label?: string;
 };
 
-const KEYCODE_ENTER = 13;
-const KEYCODE_ESCAPE = 27;
-
 const RoleSelector = ({
     selectedRole,
     disabled = false,
@@ -250,7 +247,7 @@ const RoleSelector = ({
             tabIndex={0}
             data-value={parentItem.code}
             onKeyDown={(e): void => {
-                e.keyCode === KEYCODE_ENTER &&
+                e.code === 'Enter' &&
                     selectItem(parentItem, parentIndex);
             }}
             onClick={(): void => {
@@ -273,7 +270,7 @@ const RoleSelector = ({
                     role="option"
                     tabIndex={0}
                     onKeyDown={(e): void => {
-                        e.keyCode === KEYCODE_ENTER &&
+                        e.code === 'Enter' &&
                             selectItem(itm, index);
                     }}
                     onClick={(): void => {
@@ -328,7 +325,7 @@ const RoleSelector = ({
                 <ul ref={listRef}
                     className='container'
                     onKeyDown={(e): void => {
-                        e.keyCode === KEYCODE_ESCAPE && setIsOpen(false);
+                        e.code === 'Escape' && setIsOpen(false);
                     }}
                 >
                     <FilterContainer>

--- a/src/modules/InvitationForPunchOut/components/RoleSelector/style.ts
+++ b/src/modules/InvitationForPunchOut/components/RoleSelector/style.ts
@@ -60,10 +60,12 @@ export const DropdownIcon = styled.div<IconProps>`
 
 interface DropdownButtonProps {
     readonly isOpen: boolean;
+    readonly error?: boolean;
 }
 
 export const DropdownButton = styled.button<DropdownButtonProps>`
-    border: none;
+    border: ${(props): string => props.error? 'solid' : 'none'};
+    border-color: ${tokens.colors.interactive.danger__resting.rgba};
     display: flex;
     width: 100%;
     align-items: center;
@@ -221,8 +223,11 @@ export const TitleContent = styled.div<TitleContentProps>`
     }
 `;
 
-export const Label = styled.div`
+export const Label = styled.div<{ error?: boolean; }>`
     font-size: 12px;
+    ${(props): any => props.error && css`
+        color: ${tokens.colors.interactive.danger__resting.rgba};
+    `}
 `;
 
 export const FilterContainer = styled.li`

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Participants/Participants.style.ts
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Participants/Participants.style.ts
@@ -35,7 +35,6 @@ export const ParticipantRowsContainer = styled.div`
     grid-template-columns: 250px 180px 300px auto; 
     width: fit-content;
     padding: var(--grid-unit);
-    //align-items: flex-end;
     > div {
         display: flex;
         margin-right: calc(var(--grid-unit) * 2);

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Participants/Participants.style.ts
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Participants/Participants.style.ts
@@ -35,7 +35,7 @@ export const ParticipantRowsContainer = styled.div`
     grid-template-columns: 250px 180px 300px auto; 
     width: fit-content;
     padding: var(--grid-unit);
-    align-items: flex-end;
+    //align-items: flex-end;
     > div {
         display: flex;
         margin-right: calc(var(--grid-unit) * 2);


### PR DESCRIPTION
# Description

The participants page went to white screen when a functional role participant (set to use personal emails) had been deleted or renamed since the IPO was created.
Added a check for removed/renamed participants on load and added an error indication to field(s) with removed/renamed functional role.

Usage of the deprecated keyCode was also removed from the RoleSelector component.

Completes: [AB#83361](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/83361)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
