### PR TITLE
includes instead of startswith for functional role filter

### DIFF
--- a/src/modules/InvitationForPunchOut/components/RoleSelector/index.tsx
+++ b/src/modules/InvitationForPunchOut/components/RoleSelector/index.tsx
@@ -112,7 +112,7 @@ const RoleSelector = ({
     const filterRoles = (input: string): void => {
         setFilter(input);
         if (input.length > 0) {
-            setFilteredRoles(allRoles.filter(role => role.code.toLocaleLowerCase().startsWith(input.toLocaleLowerCase())));
+            setFilteredRoles(allRoles.filter(role => role.code.toLocaleLowerCase().includes(input.toLocaleLowerCase())));
         } else {
             setFilteredRoles(allRoles);
         }


### PR DESCRIPTION
Use includes instead of startswith in functional role filter 
[AB#87218](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/87218)

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
