### PR TITLE
Feature/87775 ipo add unsign button to optional participants

### DIFF
--- a/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
+++ b/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
@@ -966,7 +966,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
     }
 
     /**
-     * SignPunchOut
+     * UnsignPunchOut
      *
      * @param setRequestCanceller Returns a function that can be called to cancel the request
      */

--- a/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
+++ b/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
@@ -942,6 +942,32 @@ class InvitationForPunchOutApiClient extends ApiClient {
     }
 
     /**
+     * SignPunchOut
+     *
+     * @param setRequestCanceller Returns a function that can be called to cancel the request
+     */
+    async unsignPunchOut(
+        id: number,
+        participantId: number,
+        participantRowVersion: string,
+        setRequestCanceller?: RequestCanceler
+    ): Promise<PersonResponse[]> {
+        const endpoint = `/Invitations/${id}/Unsign`;
+        const settings: AxiosRequestConfig = {};
+        this.setupRequestCanceler(settings, setRequestCanceller);
+        try {
+            const result = await this.client.put(endpoint, {
+                participantId,
+                participantRowVersion,
+                settings,
+            });
+            return result.data;
+        } catch (error) {
+            throw new IpoApiError(error);
+        }
+    }
+
+    /**
      * Cancel PunchOut
      *
      * @param setRequestCanceller Returns a function that can be called to cancel the request

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButton.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButton.tsx
@@ -4,13 +4,19 @@ import React from 'react';
 interface SignatureButtonProps {
     name: string;
     onClick: () => void;
+    disabled: boolean;
 }
 
 const SignatureButton = ({
     name,
     onClick,
+    disabled,
 }: SignatureButtonProps): JSX.Element => {
-    return <Button onClick={onClick}>{name}</Button>;
+    return (
+        <Button onClick={onClick} disabled={disabled}>
+            {name}
+        </Button>
+    );
 };
 
 export default SignatureButton;

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButton.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButton.tsx
@@ -1,0 +1,16 @@
+import { Button } from '@equinor/eds-core-react';
+import React from 'react';
+
+interface SignatureButtonProps {
+    name: string;
+    onClick: () => void;
+}
+
+const SignatureButton = ({
+    name,
+    onClick,
+}: SignatureButtonProps): JSX.Element => {
+    return <Button onClick={onClick}>{name}</Button>;
+};
+
+export default SignatureButton;

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButton.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButton.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 interface SignatureButtonProps {
     name: string;
-    onClick: () => void;
+    onClick: () => Promise<void>;
     disabled: boolean;
 }
 

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtonWithTooltip.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtonWithTooltip.tsx
@@ -6,17 +6,21 @@ interface SignatureButtonWithTooltipProps {
     name: string;
     tooltip: JSX.Element;
     onClick: () => void;
+    disabled: boolean;
 }
 
 const SignatureButtonWithTooltip = ({
     name,
     tooltip,
     onClick,
+    disabled,
 }: SignatureButtonWithTooltipProps): JSX.Element => {
     return (
         <CustomTooltip title={tooltip} arrow>
             <span>
-                <Button onClick={onClick}>{name}</Button>
+                <Button onClick={onClick} disabled={disabled}>
+                    {name}
+                </Button>
             </span>
         </CustomTooltip>
     );

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtonWithTooltip.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtonWithTooltip.tsx
@@ -1,0 +1,25 @@
+import { Button } from '@equinor/eds-core-react';
+import React from 'react';
+import CustomTooltip from '../CustomTooltip';
+
+interface SignatureButtonWithTooltipProps {
+    name: string;
+    tooltip: JSX.Element;
+    onClick: () => void;
+}
+
+const SignatureButtonWithTooltip = ({
+    name,
+    tooltip,
+    onClick,
+}: SignatureButtonWithTooltipProps): JSX.Element => {
+    return (
+        <CustomTooltip title={tooltip} arrow>
+            <span>
+                <Button onClick={onClick}>{name}</Button>
+            </span>
+        </CustomTooltip>
+    );
+};
+
+export default SignatureButtonWithTooltip;

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtonWithTooltip.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtonWithTooltip.tsx
@@ -1,6 +1,6 @@
-import { Button } from '@equinor/eds-core-react';
 import React, { useEffect, useState } from 'react';
 import CustomTooltip from '../CustomTooltip';
+import SignatureButton from './SignatureButton';
 
 interface SignatureButtonWithTooltipProps {
     name: string;
@@ -31,9 +31,11 @@ const SignatureButtonWithTooltip = ({
             arrow
         >
             <span>
-                <Button onClick={onClick} disabled={disabled}>
-                    {name}
-                </Button>
+                <SignatureButton
+                    name={name}
+                    onClick={onClick}
+                    disabled={disabled}
+                />
             </span>
         </CustomTooltip>
     );

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtonWithTooltip.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtonWithTooltip.tsx
@@ -5,7 +5,7 @@ import SignatureButton from './SignatureButton';
 interface SignatureButtonWithTooltipProps {
     name: string;
     tooltip: JSX.Element;
-    onClick: () => void;
+    onClick: () => Promise<void>;
     disabled: boolean;
 }
 

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtonWithTooltip.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtonWithTooltip.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@equinor/eds-core-react';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import CustomTooltip from '../CustomTooltip';
 
 interface SignatureButtonWithTooltipProps {
@@ -15,8 +15,21 @@ const SignatureButtonWithTooltip = ({
     onClick,
     disabled,
 }: SignatureButtonWithTooltipProps): JSX.Element => {
+    const [show, setShow] = useState<boolean>(false);
+
+    useEffect(() => {
+        if (disabled) setShow(false);
+    }, [disabled]);
+
     return (
-        <CustomTooltip title={tooltip} arrow>
+        <CustomTooltip
+            title={tooltip}
+            open={show}
+            disableHoverListener
+            onMouseEnter={(): void => (disabled ? undefined : setShow(true))}
+            onMouseLeave={(): void => setShow(false)}
+            arrow
+        >
             <span>
                 <Button onClick={onClick} disabled={disabled}>
                     {name}

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtons.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtons.tsx
@@ -41,6 +41,7 @@ interface SignatureButtonsProps {
     unaccept: (p: Participant) => Promise<any>;
     uncomplete: (p: Participant) => Promise<any>;
     unsign: (p: Participant) => Promise<any>;
+    canUpdate: boolean;
 }
 
 const SignatureButtons = ({
@@ -58,6 +59,7 @@ const SignatureButtons = ({
     unaccept,
     uncomplete,
     unsign,
+    canUpdate,
 }: SignatureButtonsProps): JSX.Element => {
     // TODO: are buttons disabled while loading in current?
     const handleCompletePunchOut = async (): Promise<any> => {
@@ -108,18 +110,19 @@ const SignatureButtons = ({
     };
 
     const getUnCompleteAndUpdateParticipantsButtons = (): JSX.Element => {
-        // TODO: handle enabled/disabled state of update button.
         return (
             <>
                 <SignatureButtonWithTooltip
                     name={'Update'}
                     tooltip={tooltipUpdate}
                     onClick={handleUpdateParticipants}
+                    disabled={!canUpdate || loading}
                 />
                 <span> </span>
                 <SignatureButton
                     name={'Uncomplete'}
                     onClick={handleUnCompletePunchOut}
+                    disabled={loading}
                 />
             </>
         );
@@ -130,6 +133,7 @@ const SignatureButtons = ({
             <SignatureButton
                 name={'Sign punch-out'}
                 onClick={handleSignPunchOut}
+                disabled={loading}
             />
         );
     };
@@ -138,6 +142,7 @@ const SignatureButtons = ({
             <SignatureButton
                 name={'Unsign punch-out'}
                 onClick={handleUnsignPunchOut}
+                disabled={loading}
             />
         );
     };
@@ -151,6 +156,7 @@ const SignatureButtons = ({
                             name={'Complete punch-out'}
                             tooltip={tooltipComplete}
                             onClick={handleCompletePunchOut}
+                            disabled={loading}
                         />
                     );
                 } else if (
@@ -177,6 +183,7 @@ const SignatureButtons = ({
                         <SignatureButton
                             name={'Unaccept punch-out'}
                             onClick={handleUnAcceptPunchOut}
+                            disabled={loading}
                         />
                     );
                 } else if (
@@ -188,6 +195,7 @@ const SignatureButtons = ({
                             name={'Accept punch-out'}
                             tooltip={tooltipAccept}
                             onClick={handleAcceptPunchOut}
+                            disabled={loading}
                         />
                     );
                 }

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtons.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtons.tsx
@@ -40,6 +40,7 @@ interface SignatureButtonsProps {
     sign: (p: Participant) => Promise<any>;
     unaccept: (p: Participant) => Promise<any>;
     uncomplete: (p: Participant) => Promise<any>;
+    unsign: (p: Participant) => Promise<any>;
 }
 
 const SignatureButtons = ({
@@ -56,6 +57,7 @@ const SignatureButtons = ({
     sign,
     unaccept,
     uncomplete,
+    unsign,
 }: SignatureButtonsProps): JSX.Element => {
     const handleCompletePunchOut = async (): Promise<any> => {
         setLoading(true);
@@ -98,6 +100,12 @@ const SignatureButtons = ({
         setLoading(false);
     };
 
+    const handleUnsignPunchOut = async (): Promise<any> => {
+        setLoading(true);
+        await unsign(participant);
+        setLoading(false);
+    };
+
     const getUnCompleteAndUpdateParticipantsButtons = (): JSX.Element => {
         return (
             <>
@@ -123,26 +131,19 @@ const SignatureButtons = ({
             />
         );
     };
-
+    const getUnsignButton = (): JSX.Element => {
+        return (
+            <SignatureButton
+                name={'Unsign punch-out'}
+                onClick={handleUnsignPunchOut}
+            />
+        );
+    };
+    if (status === IpoStatusEnum.CANCELED) return <></>;
     switch (participant.organization) {
         case OrganizationsEnum.Contractor:
             if (participant.sortKey === 0) {
-                if (
-                    (participant.signedBy &&
-                        status === IpoStatusEnum.ACCEPTED) ||
-                    (!participant.canSign && status === IpoStatusEnum.COMPLETED)
-                ) {
-                    return (
-                        <span>
-                            {participant.signedBy
-                                ? `${participant.signedBy.userName}`
-                                : ''}
-                        </span>
-                    );
-                } else if (
-                    participant.canSign &&
-                    status === IpoStatusEnum.PLANNED
-                ) {
+                if (participant.canSign && status === IpoStatusEnum.PLANNED) {
                     return (
                         <SignatureButtonWithTooltip
                             name={'Complete punch-out'}
@@ -158,7 +159,7 @@ const SignatureButtons = ({
                 }
             } else {
                 if (participant.signedBy) {
-                    return <span>{`${participant.signedBy.userName}`}</span>;
+                    return getUnsignButton();
                 } else if (
                     participant.canSign &&
                     status !== IpoStatusEnum.CANCELED
@@ -187,16 +188,11 @@ const SignatureButtons = ({
                             onClick={handleAcceptPunchOut}
                         />
                     );
-                } else if (participant.signedBy) {
-                    return <span>{`${participant.signedBy.userName}`}</span>;
                 }
             } else {
                 if (participant.signedBy) {
-                    return <span>{`${participant.signedBy.userName}`}</span>;
-                } else if (
-                    participant.canSign &&
-                    status != IpoStatusEnum.CANCELED
-                ) {
+                    return getUnsignButton();
+                } else if (participant.canSign) {
                     return getSignButton();
                 }
             }
@@ -205,11 +201,8 @@ const SignatureButtons = ({
         case OrganizationsEnum.TechnicalIntegrity:
         case OrganizationsEnum.Commissioning:
             if (participant.signedBy) {
-                return <span>{`${participant.signedBy.userName}`}</span>;
-            } else if (
-                participant.canSign &&
-                status !== IpoStatusEnum.CANCELED
-            ) {
+                return getUnsignButton();
+            } else if (participant.canSign) {
                 return getSignButton();
             }
             break;

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtons.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtons.tsx
@@ -58,50 +58,20 @@ const SignatureButtons = ({
     unsign,
     canUpdate,
 }: SignatureButtonsProps): JSX.Element => {
-    const handleCompletePunchOut = async (): Promise<any> => {
+    const handleButtonClick = async (
+        buttonAction: () => Promise<any>
+    ): Promise<void> => {
         setLoading(true);
-        await complete(participant, attNoteData);
+        await buttonAction();
         setLoading(false);
         unsetDirtyStateFor(ComponentName.ParticipantsTable);
     };
 
-    const handleUnCompletePunchOut = async (): Promise<any> => {
+    const handleSignButtonClick = async (
+        buttonAction: () => Promise<any>
+    ): Promise<void> => {
         setLoading(true);
-        await uncomplete(participant);
-        setLoading(false);
-        unsetDirtyStateFor(ComponentName.ParticipantsTable);
-    };
-
-    const handleAcceptPunchOut = async (): Promise<any> => {
-        setLoading(true);
-        await accept(participant, attNoteData);
-        setLoading(false);
-        unsetDirtyStateFor(ComponentName.ParticipantsTable);
-    };
-
-    const handleUnAcceptPunchOut = async (): Promise<any> => {
-        setLoading(true);
-        await unaccept(participant);
-        setLoading(false);
-        unsetDirtyStateFor(ComponentName.ParticipantsTable);
-    };
-
-    const handleUpdateParticipants = async (): Promise<any> => {
-        setLoading(true);
-        await update(attNoteData);
-        setLoading(false);
-        unsetDirtyStateFor(ComponentName.ParticipantsTable);
-    };
-
-    const handleSignPunchOut = async (): Promise<any> => {
-        setLoading(true);
-        await sign(participant);
-        setLoading(false);
-    };
-
-    const handleUnsignPunchOut = async (): Promise<any> => {
-        setLoading(true);
-        await unsign(participant);
+        await buttonAction();
         setLoading(false);
     };
 
@@ -111,13 +81,21 @@ const SignatureButtons = ({
                 <SignatureButtonWithTooltip
                     name={'Update'}
                     tooltip={tooltipUpdate}
-                    onClick={handleUpdateParticipants}
+                    onClick={(): Promise<void> =>
+                        handleButtonClick(async (): Promise<any> => {
+                            return await update(attNoteData);
+                        })
+                    }
                     disabled={!canUpdate || loading}
                 />
                 <span> </span>
                 <SignatureButton
                     name={'Uncomplete'}
-                    onClick={handleUnCompletePunchOut}
+                    onClick={(): Promise<void> =>
+                        handleButtonClick(async (): Promise<any> => {
+                            return await uncomplete(participant);
+                        })
+                    }
                     disabled={loading}
                 />
             </>
@@ -128,7 +106,11 @@ const SignatureButtons = ({
         return (
             <SignatureButton
                 name={'Sign punch-out'}
-                onClick={handleSignPunchOut}
+                onClick={(): Promise<void> =>
+                    handleSignButtonClick(async (): Promise<any> => {
+                        return await sign(participant);
+                    })
+                }
                 disabled={loading}
             />
         );
@@ -137,7 +119,11 @@ const SignatureButtons = ({
         return (
             <SignatureButton
                 name={'Unsign punch-out'}
-                onClick={handleUnsignPunchOut}
+                onClick={(): Promise<void> =>
+                    handleSignButtonClick(async (): Promise<any> => {
+                        return await unsign(participant);
+                    })
+                }
                 disabled={loading}
             />
         );
@@ -151,7 +137,14 @@ const SignatureButtons = ({
                         <SignatureButtonWithTooltip
                             name={'Complete punch-out'}
                             tooltip={tooltipComplete}
-                            onClick={handleCompletePunchOut}
+                            onClick={(): Promise<void> =>
+                                handleButtonClick(async (): Promise<any> => {
+                                    return await complete(
+                                        participant,
+                                        attNoteData
+                                    );
+                                })
+                            }
                             disabled={loading}
                         />
                     );
@@ -178,7 +171,11 @@ const SignatureButtons = ({
                     return (
                         <SignatureButton
                             name={'Unaccept punch-out'}
-                            onClick={handleUnAcceptPunchOut}
+                            onClick={(): Promise<void> =>
+                                handleButtonClick(async (): Promise<any> => {
+                                    return await unaccept(participant);
+                                })
+                            }
                             disabled={loading}
                         />
                     );
@@ -190,7 +187,14 @@ const SignatureButtons = ({
                         <SignatureButtonWithTooltip
                             name={'Accept punch-out'}
                             tooltip={tooltipAccept}
-                            onClick={handleAcceptPunchOut}
+                            onClick={(): Promise<void> =>
+                                handleButtonClick(async (): Promise<any> => {
+                                    return await accept(
+                                        participant,
+                                        attNoteData
+                                    );
+                                })
+                            }
                             disabled={loading}
                         />
                     );
@@ -206,12 +210,12 @@ const SignatureButtons = ({
         case OrganizationsEnum.Operation:
         case OrganizationsEnum.TechnicalIntegrity:
         case OrganizationsEnum.Commissioning:
+            if (!participant.canSign) break;
             if (participant.signedBy) {
                 return getUnsignButton();
-            } else if (participant.canSign) {
+            } else {
                 return getSignButton();
             }
-            break;
     }
 
     return <span>-</span>;

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtons.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtons.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@equinor/eds-core-react';
 import React from 'react';
 import { AttNoteData } from '..';
 import {
@@ -29,7 +28,6 @@ const tooltipAccept = <div>Punch round has been checked by company.</div>;
 interface SignatureButtonsProps {
     participant: Participant;
     status: string;
-    index: number;
     attNoteData: AttNoteData[];
     loading: boolean;
     setLoading: (isLoasing: boolean) => void;
@@ -47,7 +45,6 @@ interface SignatureButtonsProps {
 const SignatureButtons = ({
     participant,
     status,
-    index,
     attNoteData,
     loading,
     setLoading,
@@ -61,7 +58,6 @@ const SignatureButtons = ({
     unsign,
     canUpdate,
 }: SignatureButtonsProps): JSX.Element => {
-    // TODO: are buttons disabled while loading in current?
     const handleCompletePunchOut = async (): Promise<any> => {
         setLoading(true);
         await complete(participant, attNoteData);

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtons.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtons.tsx
@@ -59,6 +59,7 @@ const SignatureButtons = ({
     uncomplete,
     unsign,
 }: SignatureButtonsProps): JSX.Element => {
+    // TODO: are buttons disabled while loading in current?
     const handleCompletePunchOut = async (): Promise<any> => {
         setLoading(true);
         await complete(participant, attNoteData);
@@ -107,6 +108,7 @@ const SignatureButtons = ({
     };
 
     const getUnCompleteAndUpdateParticipantsButtons = (): JSX.Element => {
+        // TODO: handle enabled/disabled state of update button.
         return (
             <>
                 <SignatureButtonWithTooltip

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtons.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtons.tsx
@@ -1,0 +1,221 @@
+import { Button } from '@equinor/eds-core-react';
+import React from 'react';
+import { AttNoteData } from '..';
+import {
+    ComponentName,
+    IpoStatusEnum,
+    OrganizationsEnum,
+} from '../../../../enums';
+import { Participant } from '../../../types';
+import SignatureButton from './SignatureButton';
+import SignatureButtonWithTooltip from './SignatureButtonWithTooltip';
+
+const tooltipComplete = (
+    <div>
+        When punch round has been completed
+        <br />
+        and any punches have been added.
+        <br />
+        Complete and go to next step.
+    </div>
+);
+
+const tooltipUpdate = (
+    <div>Update attended status and notes for participants.</div>
+);
+
+const tooltipAccept = <div>Punch round has been checked by company.</div>;
+
+interface SignatureButtonsProps {
+    participant: Participant;
+    status: string;
+    index: number;
+    attNoteData: AttNoteData[];
+    loading: boolean;
+    setLoading: (isLoasing: boolean) => void;
+    unsetDirtyStateFor: (componentName: string) => void;
+    complete: (p: Participant, attNoteData: AttNoteData[]) => Promise<any>;
+    accept: (p: Participant, attNoteData: AttNoteData[]) => Promise<any>;
+    update: (attNoteData: AttNoteData[]) => Promise<any>;
+    sign: (p: Participant) => Promise<any>;
+    unaccept: (p: Participant) => Promise<any>;
+    uncomplete: (p: Participant) => Promise<any>;
+}
+
+const SignatureButtons = ({
+    participant,
+    status,
+    index,
+    attNoteData,
+    loading,
+    setLoading,
+    unsetDirtyStateFor,
+    complete,
+    accept,
+    update,
+    sign,
+    unaccept,
+    uncomplete,
+}: SignatureButtonsProps): JSX.Element => {
+    const handleCompletePunchOut = async (): Promise<any> => {
+        setLoading(true);
+        await complete(participant, attNoteData);
+        setLoading(false);
+        unsetDirtyStateFor(ComponentName.ParticipantsTable);
+    };
+
+    const handleUnCompletePunchOut = async (): Promise<any> => {
+        setLoading(true);
+        await uncomplete(participant);
+        setLoading(false);
+        unsetDirtyStateFor(ComponentName.ParticipantsTable);
+    };
+
+    const handleAcceptPunchOut = async (): Promise<any> => {
+        setLoading(true);
+        await accept(participant, attNoteData);
+        setLoading(false);
+        unsetDirtyStateFor(ComponentName.ParticipantsTable);
+    };
+
+    const handleUnAcceptPunchOut = async (): Promise<any> => {
+        setLoading(true);
+        await unaccept(participant);
+        setLoading(false);
+        unsetDirtyStateFor(ComponentName.ParticipantsTable);
+    };
+
+    const handleUpdateParticipants = async (): Promise<any> => {
+        setLoading(true);
+        await update(attNoteData);
+        setLoading(false);
+        unsetDirtyStateFor(ComponentName.ParticipantsTable);
+    };
+
+    const handleSignPunchOut = async (): Promise<any> => {
+        setLoading(true);
+        await sign(participant);
+        setLoading(false);
+    };
+
+    const getUnCompleteAndUpdateParticipantsButtons = (): JSX.Element => {
+        return (
+            <>
+                <SignatureButtonWithTooltip
+                    name={'Update'}
+                    tooltip={tooltipUpdate}
+                    onClick={handleUpdateParticipants}
+                />
+                <span> </span>
+                <SignatureButton
+                    name={'Uncomplete'}
+                    onClick={handleUnCompletePunchOut}
+                />
+            </>
+        );
+    };
+
+    const getSignButton = (): JSX.Element => {
+        return (
+            <SignatureButton
+                name={'Sign punch-out'}
+                onClick={handleSignPunchOut}
+            />
+        );
+    };
+
+    switch (participant.organization) {
+        case OrganizationsEnum.Contractor:
+            if (participant.sortKey === 0) {
+                if (
+                    (participant.signedBy &&
+                        status === IpoStatusEnum.ACCEPTED) ||
+                    (!participant.canSign && status === IpoStatusEnum.COMPLETED)
+                ) {
+                    return (
+                        <span>
+                            {participant.signedBy
+                                ? `${participant.signedBy.userName}`
+                                : ''}
+                        </span>
+                    );
+                } else if (
+                    participant.canSign &&
+                    status === IpoStatusEnum.PLANNED
+                ) {
+                    return (
+                        <SignatureButtonWithTooltip
+                            name={'Complete punch-out'}
+                            tooltip={tooltipComplete}
+                            onClick={handleCompletePunchOut}
+                        />
+                    );
+                } else if (
+                    participant.canSign &&
+                    status === IpoStatusEnum.COMPLETED
+                ) {
+                    return getUnCompleteAndUpdateParticipantsButtons();
+                }
+            } else {
+                if (participant.signedBy) {
+                    return <span>{`${participant.signedBy.userName}`}</span>;
+                } else if (
+                    participant.canSign &&
+                    status !== IpoStatusEnum.CANCELED
+                ) {
+                    return getSignButton();
+                }
+            }
+            break;
+        case OrganizationsEnum.ConstructionCompany:
+            if (participant.sortKey === 1) {
+                if (participant.canSign && status === IpoStatusEnum.ACCEPTED) {
+                    return (
+                        <SignatureButton
+                            name={'Unaccept punch-out'}
+                            onClick={handleUnAcceptPunchOut}
+                        />
+                    );
+                } else if (
+                    participant.canSign &&
+                    status === IpoStatusEnum.COMPLETED
+                ) {
+                    return (
+                        <SignatureButtonWithTooltip
+                            name={'Accept punch-out'}
+                            tooltip={tooltipAccept}
+                            onClick={handleAcceptPunchOut}
+                        />
+                    );
+                } else if (participant.signedBy) {
+                    return <span>{`${participant.signedBy.userName}`}</span>;
+                }
+            } else {
+                if (participant.signedBy) {
+                    return <span>{`${participant.signedBy.userName}`}</span>;
+                } else if (
+                    participant.canSign &&
+                    status != IpoStatusEnum.CANCELED
+                ) {
+                    return getSignButton();
+                }
+            }
+            break;
+        case OrganizationsEnum.Operation:
+        case OrganizationsEnum.TechnicalIntegrity:
+        case OrganizationsEnum.Commissioning:
+            if (participant.signedBy) {
+                return <span>{`${participant.signedBy.userName}`}</span>;
+            } else if (
+                participant.canSign &&
+                status !== IpoStatusEnum.CANCELED
+            ) {
+                return getSignButton();
+            }
+            break;
+    }
+
+    return <span>-</span>;
+};
+
+export default SignatureButtons;

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
@@ -59,9 +59,9 @@ const ParticipantsTable = ({
     const [editAttendedDisabled, setEditAttendedDisabled] =
         useState<boolean>(true);
     const [editNotesDisabled, setEditNotesDisabled] = useState<boolean>(true);
-    const btnUpdateRef = useRef<HTMLButtonElement>();
     const [attNoteData, setAttNoteData] = useState<AttNoteData[]>([]);
     const [cleanData, setCleanData] = useState<AttNoteData[]>([]);
+    const [canUpdate, setCanUpdate] = useState<boolean>(false);
     const { setDirtyStateFor, unsetDirtyStateFor } = useDirtyContext();
 
     useEffect(() => {
@@ -87,14 +87,16 @@ const ParticipantsTable = ({
     }, [participants, status]);
 
     useEffect(() => {
+        console.log(JSON.stringify(attNoteData));
+        console.log(JSON.stringify(cleanData));
         if (JSON.stringify(attNoteData) !== JSON.stringify(cleanData)) {
             setDirtyStateFor(ComponentName.ParticipantsTable);
-            if (btnUpdateRef.current)
-                btnUpdateRef.current.removeAttribute('disabled');
+            setCanUpdate(true);
+            console.log('can update');
         } else {
             unsetDirtyStateFor(ComponentName.ParticipantsTable);
-            if (btnUpdateRef.current)
-                btnUpdateRef.current.setAttribute('disabled', 'disabled');
+            setCanUpdate(false);
+            console.log('cannot update');
         }
     }, [attNoteData]);
 
@@ -133,7 +135,10 @@ const ParticipantsTable = ({
         (
             participant: Participant,
             status: string,
-            index: number
+            index: number,
+            canUpdate: boolean,
+            attNoteData: AttNoteData[],
+            loading: boolean
         ): JSX.Element => (
             <SignatureButtons
                 participant={participant}
@@ -150,12 +155,14 @@ const ParticipantsTable = ({
                 unaccept={unaccept}
                 uncomplete={uncomplete}
                 unsign={unsign}
+                canUpdate={canUpdate}
             />
         ),
         [status]
     );
 
     const handleEditAttended = (id: number): void => {
+        console.log('handle edit attended');
         const updateData = [...attNoteData];
         const index = updateData.findIndex((x) => x.id === id);
         updateData[index] = {
@@ -390,7 +397,10 @@ const ParticipantsTable = ({
                                             {getSignatureButton(
                                                 participant,
                                                 status,
-                                                index
+                                                index,
+                                                canUpdate,
+                                                attNoteData,
+                                                loading
                                             )}
                                         </Typography>
                                     </Table.Cell>

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
@@ -87,16 +87,12 @@ const ParticipantsTable = ({
     }, [participants, status]);
 
     useEffect(() => {
-        console.log(JSON.stringify(attNoteData));
-        console.log(JSON.stringify(cleanData));
         if (JSON.stringify(attNoteData) !== JSON.stringify(cleanData)) {
             setDirtyStateFor(ComponentName.ParticipantsTable);
             setCanUpdate(true);
-            console.log('can update');
         } else {
             unsetDirtyStateFor(ComponentName.ParticipantsTable);
             setCanUpdate(false);
-            console.log('cannot update');
         }
     }, [attNoteData]);
 
@@ -135,7 +131,6 @@ const ParticipantsTable = ({
         (
             participant: Participant,
             status: string,
-            index: number,
             canUpdate: boolean,
             attNoteData: AttNoteData[],
             loading: boolean
@@ -143,7 +138,6 @@ const ParticipantsTable = ({
             <SignatureButtons
                 participant={participant}
                 status={status}
-                index={index}
                 attNoteData={attNoteData}
                 loading={loading}
                 setLoading={setLoading}
@@ -162,7 +156,6 @@ const ParticipantsTable = ({
     );
 
     const handleEditAttended = (id: number): void => {
-        console.log('handle edit attended');
         const updateData = [...attNoteData];
         const index = updateData.findIndex((x) => x.id === id);
         updateData[index] = {
@@ -397,7 +390,6 @@ const ParticipantsTable = ({
                                             {getSignatureButton(
                                                 participant,
                                                 status,
-                                                index,
                                                 canUpdate,
                                                 attNoteData,
                                                 loading

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
@@ -23,20 +23,7 @@ import { Table } from '@equinor/eds-core-react';
 import { Typography } from '@equinor/eds-core-react';
 import { getFormattedDateAndTime } from '@procosys/core/services/DateService';
 import { useDirtyContext } from '@procosys/core/DirtyContext';
-
-const tooltipComplete = (
-    <div>
-        When punch round has been completed
-        <br />
-        and any punches have been added.
-        <br />
-        Complete and go to next step.
-    </div>
-);
-const tooltipUpdate = (
-    <div>Update attended status and notes for participants.</div>
-);
-const tooltipAccept = <div>Punch round has been checked by company.</div>;
+import SignatureButtons from './Buttons/SignatureButtons';
 
 export type AttNoteData = {
     id: number;
@@ -95,14 +82,9 @@ const ParticipantsTable = ({
     const [editAttendedDisabled, setEditAttendedDisabled] =
         useState<boolean>(true);
     const [editNotesDisabled, setEditNotesDisabled] = useState<boolean>(true);
-    const btnCompleteRef = useRef<HTMLButtonElement>();
-    const btnUnCompleteRef = useRef<HTMLButtonElement>();
-    const btnAcceptRef = useRef<HTMLButtonElement>();
-    const btnUnAcceptRef = useRef<HTMLButtonElement>();
     const btnUpdateRef = useRef<HTMLButtonElement>();
     const [attNoteData, setAttNoteData] = useState<AttNoteData[]>(cleanData);
     const { setDirtyStateFor, unsetDirtyStateFor } = useDirtyContext();
-    const btnSignRef = useRef<HTMLButtonElement>();
 
     useEffect(() => {
         const participant = participants.find((p) => p.canSign);
@@ -138,271 +120,30 @@ const ParticipantsTable = ({
         }
     }, [attNoteData]);
 
-    const getCompleteButton = (
-        completePunchout: (index: number) => void
-    ): JSX.Element => {
-        return (
-            <CustomTooltip title={tooltipComplete} arrow>
-                <span>
-                    <Button ref={btnCompleteRef} onClick={completePunchout}>
-                        Complete punch-out
-                    </Button>
-                </span>
-            </CustomTooltip>
-        );
-    };
-
-    const getUnCompleteAndUpdateParticipantsButton = (
-        updateParticipants: (index: number) => void,
-        unCompletePunchout: (index: number) => void
-    ): JSX.Element => {
-        return (
-            <>
-                <CustomTooltip title={tooltipUpdate} arrow>
-                    <span>
-                        <Button ref={btnUpdateRef} onClick={updateParticipants}>
-                            Update
-                        </Button>
-                    </span>
-                </CustomTooltip>
-                <span> </span>
-                <Button ref={btnUnCompleteRef} onClick={unCompletePunchout}>
-                    Uncomplete
-                </Button>
-            </>
-        );
-    };
-
-    const getAcceptButton = (
-        acceptPunchout: (index: number) => void
-    ): JSX.Element => {
-        return (
-            <CustomTooltip title={tooltipAccept} arrow>
-                <span>
-                    <Button ref={btnAcceptRef} onClick={acceptPunchout}>
-                        Accept punch-out
-                    </Button>
-                </span>
-            </CustomTooltip>
-        );
-    };
-
-    const getUnAcceptButton = (
-        unAcceptPunchout: (index: number) => void
-    ): JSX.Element => {
-        return (
-            <Button ref={btnUnAcceptRef} onClick={unAcceptPunchout}>
-                Unaccept punch-out
-            </Button>
-        );
-    };
-
-    const getSignButton = (
-        signPunchOut: (index: number) => void
-    ): JSX.Element => {
-        return (
-            <Button ref={btnSignRef} onClick={signPunchOut}>
-                Sign punch-out
-            </Button>
-        );
-    };
-
-    const getSignedProperty = useCallback(
+    const getSignatureButton = useCallback(
         (
             participant: Participant,
             status: string,
-            handleCompletePunchOut: (index: number) => void,
-            handleAcceptPunchOut: (index: number) => void,
-            handleUpdateParticipants: (index: number) => void,
-            handleSignPunchOut: (index: number) => void,
-            handleUnAcceptPunchOut: (index: number) => void,
-            handleUnCompletePunchOut: (index: number) => void
-        ): JSX.Element => {
-            switch (participant.organization) {
-                case OrganizationsEnum.Contractor:
-                    if (participant.sortKey === 0) {
-                        if (
-                            (participant.signedBy &&
-                                status === IpoStatusEnum.ACCEPTED) ||
-                            (!participant.canSign &&
-                                status === IpoStatusEnum.COMPLETED)
-                        ) {
-                            return (
-                                <span>
-                                    {participant.signedBy
-                                        ? `${participant.signedBy.userName}`
-                                        : ''}
-                                </span>
-                            );
-                        } else if (
-                            participant.canSign &&
-                            status === IpoStatusEnum.PLANNED
-                        ) {
-                            return getCompleteButton(handleCompletePunchOut);
-                        } else if (
-                            participant.canSign &&
-                            status === IpoStatusEnum.COMPLETED
-                        ) {
-                            return getUnCompleteAndUpdateParticipantsButton(
-                                handleUpdateParticipants,
-                                handleUnCompletePunchOut
-                            );
-                        }
-                    } else {
-                        if (participant.signedBy) {
-                            return (
-                                <span>{`${participant.signedBy.userName}`}</span>
-                            );
-                        } else if (
-                            participant.canSign &&
-                            status !== IpoStatusEnum.CANCELED
-                        ) {
-                            return getSignButton(handleSignPunchOut);
-                        }
-                    }
-                    break;
-                case OrganizationsEnum.ConstructionCompany:
-                    if (participant.sortKey === 1) {
-                        if (
-                            participant.canSign &&
-                            status === IpoStatusEnum.ACCEPTED
-                        ) {
-                            return getUnAcceptButton(handleUnAcceptPunchOut);
-                        } else if (
-                            participant.canSign &&
-                            status === IpoStatusEnum.COMPLETED
-                        ) {
-                            return getAcceptButton(handleAcceptPunchOut);
-                        } else if (participant.signedBy) {
-                            return (
-                                <span>{`${participant.signedBy.userName}`}</span>
-                            );
-                        }
-                    } else {
-                        if (participant.signedBy) {
-                            return (
-                                <span>{`${participant.signedBy.userName}`}</span>
-                            );
-                        } else if (
-                            participant.canSign &&
-                            status != IpoStatusEnum.CANCELED
-                        ) {
-                            return getSignButton(handleSignPunchOut);
-                        }
-                    }
-                    break;
-                case OrganizationsEnum.Operation:
-                case OrganizationsEnum.TechnicalIntegrity:
-                case OrganizationsEnum.Commissioning:
-                    if (participant.signedBy) {
-                        return (
-                            <span>{`${participant.signedBy.userName}`}</span>
-                        );
-                    } else if (
-                        participant.canSign &&
-                        status !== IpoStatusEnum.CANCELED
-                    ) {
-                        return getSignButton(handleSignPunchOut);
-                    }
-                    break;
-            }
-
-            return <span>-</span>;
-        },
+            index: number
+        ): JSX.Element => (
+            <SignatureButtons
+                participant={participant}
+                status={status}
+                index={index}
+                attNoteData={attNoteData}
+                loading={loading}
+                setLoading={setLoading}
+                unsetDirtyStateFor={unsetDirtyStateFor}
+                complete={complete}
+                accept={accept}
+                update={update}
+                sign={sign}
+                unaccept={unaccept}
+                uncomplete={uncomplete}
+            />
+        ),
         [status]
     );
-
-    const handleCompletePunchOut = async (index: number): Promise<any> => {
-        setLoading(true);
-        if (btnCompleteRef.current) {
-            btnCompleteRef.current.setAttribute('disabled', 'disabled');
-        }
-        await complete(participants[index], attNoteData);
-
-        if (btnCompleteRef.current) {
-            btnCompleteRef.current.removeAttribute('disabled');
-        }
-        setLoading(false);
-        unsetDirtyStateFor(ComponentName.ParticipantsTable);
-    };
-
-    const handleUnCompletePunchOut = async (index: number): Promise<any> => {
-        setLoading(true);
-        if (btnUnCompleteRef.current) {
-            btnUnCompleteRef.current.setAttribute('disabled', 'disabled');
-        }
-        await uncomplete(participants[index]);
-
-        if (btnCompleteRef.current) {
-            btnCompleteRef.current.removeAttribute('disabled');
-        }
-        if (btnUnCompleteRef.current) {
-            btnUnCompleteRef.current.removeAttribute('disabled');
-        }
-        setLoading(false);
-        unsetDirtyStateFor(ComponentName.ParticipantsTable);
-    };
-
-    const handleAcceptPunchOut = async (index: number): Promise<any> => {
-        setLoading(true);
-        if (btnAcceptRef.current) {
-            btnAcceptRef.current.setAttribute('disabled', 'disabled');
-        }
-        await accept(participants[index], attNoteData);
-
-        if (btnUnAcceptRef.current) {
-            btnUnAcceptRef.current.removeAttribute('disabled');
-        }
-        if (btnAcceptRef.current) {
-            btnAcceptRef.current.removeAttribute('disabled');
-        }
-        setLoading(false);
-        unsetDirtyStateFor(ComponentName.ParticipantsTable);
-    };
-
-    const handleUnAcceptPunchOut = async (index: number): Promise<any> => {
-        setLoading(true);
-        if (btnUnAcceptRef.current) {
-            btnUnAcceptRef.current.setAttribute('disabled', 'disabled');
-        }
-        await unaccept(participants[index]);
-
-        if (btnAcceptRef.current) {
-            btnAcceptRef.current.removeAttribute('disabled');
-        }
-        if (btnUnAcceptRef.current) {
-            btnUnAcceptRef.current.removeAttribute('disabled');
-        }
-        setLoading(false);
-        unsetDirtyStateFor(ComponentName.ParticipantsTable);
-    };
-
-    const handleUpdateParticipants = async (): Promise<any> => {
-        setLoading(true);
-        if (btnUpdateRef.current) {
-            btnUpdateRef.current.setAttribute('disabled', 'disabled');
-        }
-
-        await update(attNoteData);
-        if (btnUpdateRef.current) {
-            btnUpdateRef.current.removeAttribute('disabled');
-        }
-        setLoading(false);
-        unsetDirtyStateFor(ComponentName.ParticipantsTable);
-    };
-
-    const handleSignPunchOut = async (index: number): Promise<any> => {
-        setLoading(true);
-        if (btnSignRef.current) {
-            btnSignRef.current.setAttribute('disabled', 'disabled');
-        }
-
-        await sign(participants[index]);
-        if (btnSignRef.current) {
-            btnSignRef.current.removeAttribute('disabled');
-        }
-        setLoading(false);
-    };
 
     const handleEditAttended = (id: number): void => {
         const updateData = [...attNoteData];
@@ -483,6 +224,11 @@ const ParticipantsTable = ({
                         >
                             Notes
                         </Table.Cell>
+                        <Table.Cell
+                            as="th"
+                            scope="col"
+                            style={{ verticalAlign: 'middle' }}
+                        ></Table.Cell>
                         <Table.Cell
                             as="th"
                             scope="col"
@@ -623,27 +369,26 @@ const ParticipantsTable = ({
                                         }}
                                     >
                                         <Typography variant="body_short">
-                                            {getSignedProperty(
+                                            {getSignatureButton(
                                                 participant,
                                                 status,
-                                                () =>
-                                                    handleCompletePunchOut(
-                                                        index
-                                                    ),
-                                                () =>
-                                                    handleAcceptPunchOut(index),
-                                                () =>
-                                                    handleUpdateParticipants(),
-                                                () => handleSignPunchOut(index),
-                                                () =>
-                                                    handleUnAcceptPunchOut(
-                                                        index
-                                                    ),
-                                                () =>
-                                                    handleUnCompletePunchOut(
-                                                        index
-                                                    )
+                                                index
                                             )}
+                                        </Typography>
+                                    </Table.Cell>
+                                    <Table.Cell
+                                        as="td"
+                                        style={{
+                                            verticalAlign: 'middle',
+                                            minWidth: '160px',
+                                        }}
+                                    >
+                                        <Typography variant="body_short">
+                                            <span>
+                                                {participant.signedBy
+                                                    ? `${participant.signedBy.userName}`
+                                                    : ''}
+                                            </span>
                                         </Typography>
                                     </Table.Cell>
                                     <Table.Cell

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
@@ -41,6 +41,7 @@ interface ParticipantsTableProps {
     sign: (p: Participant) => Promise<any>;
     unaccept: (p: Participant) => Promise<any>;
     uncomplete: (p: Participant) => Promise<any>;
+    unsign: (p: Participant) => Promise<any>;
 }
 
 const ParticipantsTable = ({
@@ -52,6 +53,7 @@ const ParticipantsTable = ({
     sign,
     unaccept,
     uncomplete,
+    unsign,
 }: ParticipantsTableProps): JSX.Element => {
     const cleanData = participants.map((p) => {
         const x = p.person
@@ -140,6 +142,7 @@ const ParticipantsTable = ({
                 sign={sign}
                 unaccept={unaccept}
                 uncomplete={uncomplete}
+                unsign={unsign}
             />
         ),
         [status]

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/style.ts
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/style.ts
@@ -5,6 +5,7 @@ export const Container = styled.div`
     margin: 0;
     padding: 0;
     width: 100%;
+    overflow: auto;
 `;
 
 export const CustomTable = styled.table`

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/index.tsx
@@ -24,6 +24,7 @@ interface GeneralInfoProps {
     sign: (p: Participant) => Promise<any>;
     unaccept: (p: Participant) => Promise<any>;
     uncomplete: (p: Participant) => Promise<any>;
+    unsign: (p: Participant) => Promise<any>;
 }
 
 const GeneralInfo = ({
@@ -34,6 +35,7 @@ const GeneralInfo = ({
     sign,
     unaccept,
     uncomplete,
+    unsign,
 }: GeneralInfoProps): JSX.Element => {
     const participants = invitation.participants.sort(
         (p1, p2): number => p1.sortKey - p2.sortKey
@@ -130,6 +132,7 @@ const GeneralInfo = ({
                 sign={sign}
                 unaccept={unaccept}
                 uncomplete={uncomplete}
+                unsign={unsign}
             />
         </Container>
     );

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
@@ -392,6 +392,33 @@ const ViewIPO = (): JSX.Element => {
         }
     };
 
+    const unsignPunchOut = async (participant: Participant): Promise<any> => {
+        const signer = participant.person
+            ? participant.person.person
+            : participant.functionalRole
+            ? participant.functionalRole
+            : undefined;
+
+        if (!signer || !invitation) return;
+
+        try {
+            await apiClient.unsignPunchOut(
+                params.ipoId,
+                signer.id,
+                signer.rowVersion
+            );
+            analytics.trackUserAction(IpoCustomEvents.UNSIGNED, {
+                project: invitation.projectName,
+                type: invitation.type,
+            });
+            await getInvitation();
+            showSnackbarNotification('Punch-out unsigned');
+        } catch (error) {
+            console.error(error.message, error.data);
+            showSnackbarNotification(error.message);
+        }
+    };
+
     const cancelPunchOut = async (): Promise<any> => {
         if (invitation) {
             try {
@@ -464,6 +491,7 @@ const ViewIPO = (): JSX.Element => {
                                                 update={updateParticipants}
                                                 unaccept={unacceptPunchOut}
                                                 uncomplete={uncompletePunchOut}
+                                                unsign={unsignPunchOut}
                                             />
                                         </Tabs.Panel>
                                         <Tabs.Panel>

--- a/src/modules/InvitationForPunchOut/views/enums.ts
+++ b/src/modules/InvitationForPunchOut/views/enums.ts
@@ -34,5 +34,6 @@ export enum IpoCustomEvents {
     UNACCEPTED = 'IPO_Unaccepted',
     UPDATED_PARTICIPANTS = 'IPO_UpdatedParticipants',
     SIGNED = 'IPO_Signed',
+    UNSIGNED = 'IPO_Unsigned',
     COMMENT_ADDED = 'IPO_CommentAdded',
 }


### PR DESCRIPTION
# Description

Added Unsign button to optional participants, also split the signature buttons into its own component to improve readability. The signature buttons has been moved to their own column in the table to be able to show the signed by information.

Completes: [AB#87775](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/87775)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
