### PR TITLE
Bug/88664 ipo not handling concurrency update

### DIFF
--- a/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
+++ b/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
@@ -109,7 +109,7 @@ type AttachmentResponse = {
     fileName: string;
     rowVersion: string;
     uploadedAt: Date;
-    uploadedBy: PersonResponse;
+    uploadedBy: PersonResponseWithRowVersion;
 };
 
 type ProjectResponse = {
@@ -141,6 +141,16 @@ interface PersonResponse {
     firstName: string;
     lastName: string;
     email: string;
+}
+
+interface PersonResponseWithRowVersion {
+    id: number;
+    azureOid: string;
+    userName: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+    rowVersion: string;
 }
 
 //This interface is used for objects comming from main, and does not have an id or rowVersion
@@ -213,13 +223,11 @@ export type PersonDto = {
     id?: number;
     azureOid: string | null;
     email: string;
-    rowVersion?: string;
     required: boolean;
 };
 
 export type FunctionalRoleDto = {
     id?: number;
-    rowVersion?: string;
     code: string;
     persons: PersonDto[] | null;
 };
@@ -227,12 +235,12 @@ export type FunctionalRoleDto = {
 export type ExternalEmailDto = {
     id: number | null;
     email: string;
-    rowVersion: string | null;
 };
 
 export type ParticipantDto = {
     organization: string;
     sortKey: number;
+    rowVersion?: string;
     externalEmail: ExternalEmailDto | null;
     person: PersonDto | null;
     functionalRole: FunctionalRoleDto | null;

--- a/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
+++ b/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
@@ -54,6 +54,7 @@ type ParticipantInvitationResponse = {
     organization: string;
     sortKey: number;
     canSign: boolean;
+    rowVersion: string;
     externalEmail: ExternalEmailInvitationResponse;
     person: PersonInvitationResponse;
     functionalRole: FunctionalRoleInvitationResponse;
@@ -81,7 +82,6 @@ type PersonInvitationResponse = {
 type ExternalEmailInvitationResponse = {
     id: number;
     externalEmail: string;
-    rowVersion: string;
 };
 
 type CommentResponse = {
@@ -141,7 +141,6 @@ interface PersonResponse {
     firstName: string;
     lastName: string;
     email: string;
-    rowVersion: string;
 }
 
 //This interface is used for objects comming from main, and does not have an id or rowVersion

--- a/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
+++ b/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
@@ -68,8 +68,19 @@ type FunctionalRoleInvitationResponse = {
     id: number;
     code: string;
     email: string;
-    persons: PersonInvitationResponse[];
+    persons: PersonInFunctionalRoleResponse[];
     response?: string;
+};
+
+type PersonInFunctionalRoleResponse = {
+    response?: string;
+    id: number;
+    firstName: string;
+    lastName: string;
+    userName: string;
+    azureOid: string;
+    email: string;
+    required: boolean;
     rowVersion: string;
 };
 
@@ -82,14 +93,12 @@ type PersonInvitationResponse = {
     azureOid: string;
     email: string;
     required: boolean;
-    rowVersion: string;
 };
 
 type ExternalEmailInvitationResponse = {
     id: number;
     externalEmail: string;
     response?: string;
-    rowVersion: string;
 };
 
 type CommentResponse = {
@@ -223,20 +232,26 @@ export type PersonDto = {
     azureOid: string | null;
     email: string;
     required: boolean;
+};
+
+export type PersonInRoleDto = {
+    id?: number;
+    azureOid: string | null;
+    email: string;
+    required: boolean;
     rowVersion?: string;
 };
 
 export type FunctionalRoleDto = {
     id?: number;
     code: string;
-    persons: PersonDto[] | null;
+    persons: PersonInRoleDto[] | null;
     rowVersion?: string;
 };
 
 export type ExternalEmailDto = {
     id: number | null;
     email: string;
-    rowVersion: string | null;
 };
 
 export type ParticipantDto = {

--- a/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
+++ b/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
@@ -88,6 +88,8 @@ type PersonInvitationResponse = {
 type ExternalEmailInvitationResponse = {
     id: number;
     externalEmail: string;
+    response?: string;
+    rowVersion: string;
 };
 
 type CommentResponse = {
@@ -115,7 +117,7 @@ type AttachmentResponse = {
     fileName: string;
     rowVersion: string;
     uploadedAt: Date;
-    uploadedBy: PersonResponseWithRowVersion;
+    uploadedBy: PersonResponse;
 };
 
 type ProjectResponse = {
@@ -141,15 +143,6 @@ interface McPkgResponse {
 }
 
 interface PersonResponse {
-    id: number;
-    azureOid: string;
-    userName: string;
-    firstName: string;
-    lastName: string;
-    email: string;
-}
-
-interface PersonResponseWithRowVersion {
     id: number;
     azureOid: string;
     userName: string;
@@ -230,23 +223,26 @@ export type PersonDto = {
     azureOid: string | null;
     email: string;
     required: boolean;
+    rowVersion?: string;
 };
 
 export type FunctionalRoleDto = {
     id?: number;
     code: string;
     persons: PersonDto[] | null;
+    rowVersion?: string;
 };
 
 export type ExternalEmailDto = {
     id: number | null;
     email: string;
+    rowVersion: string | null;
 };
 
 export type ParticipantDto = {
     organization: string;
     sortKey: number;
-    rowVersion?: string;
+    rowVersion?: string; // TODO: is this needed??
     externalEmail: ExternalEmailDto | null;
     person: PersonDto | null;
     functionalRole: FunctionalRoleDto | null;

--- a/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
+++ b/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
@@ -92,7 +92,6 @@ type PersonInvitationResponse = {
     userName: string;
     azureOid: string;
     email: string;
-    required: boolean;
 };
 
 type ExternalEmailInvitationResponse = {

--- a/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
+++ b/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
@@ -232,6 +232,7 @@ export type PersonDto = {
     azureOid: string | null;
     email: string;
     required: boolean;
+    rowVersion?: string;
 };
 
 export type PersonInRoleDto = {
@@ -252,12 +253,12 @@ export type FunctionalRoleDto = {
 export type ExternalEmailDto = {
     id: number | null;
     email: string;
+    rowVersion?: string;
 };
 
 export type ParticipantDto = {
     organization: string;
     sortKey: number;
-    rowVersion?: string;
     externalEmail: ExternalEmailDto | null;
     person: PersonDto | null;
     functionalRole: FunctionalRoleDto | null;

--- a/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
+++ b/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
@@ -74,9 +74,15 @@ type FunctionalRoleInvitationResponse = {
 };
 
 type PersonInvitationResponse = {
-    person: PersonResponse;
     response?: string;
+    id: number;
+    firstName: string;
+    lastName: string;
+    userName: string;
+    azureOid: string;
+    email: string;
     required: boolean;
+    rowVersion: string;
 };
 
 type ExternalEmailInvitationResponse = {

--- a/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
+++ b/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
@@ -242,7 +242,7 @@ export type ExternalEmailDto = {
 export type ParticipantDto = {
     organization: string;
     sortKey: number;
-    rowVersion?: string; // TODO: is this needed??
+    rowVersion?: string;
     externalEmail: ExternalEmailDto | null;
     person: PersonDto | null;
     functionalRole: FunctionalRoleDto | null;

--- a/src/modules/InvitationForPunchOut/types.d.ts
+++ b/src/modules/InvitationForPunchOut/types.d.ts
@@ -26,11 +26,13 @@ export type Person = {
     azureOid: string;
     name: string;
     email: string;
+    rowVersion?: string;
     radioOption: string | null;
 };
 
 export type RoleParticipant = {
     id?: number;
+    rowVersion?: string;
     code: string;
     description: string;
     usePersonalEmail: boolean;
@@ -41,6 +43,7 @@ export type RoleParticipant = {
 type ExternalEmail = {
     id: number | null;
     email: string;
+    rowVersion: string | null;
 };
 
 export type Participant = {

--- a/src/modules/InvitationForPunchOut/types.d.ts
+++ b/src/modules/InvitationForPunchOut/types.d.ts
@@ -26,24 +26,30 @@ export type Person = {
     azureOid: string;
     name: string;
     email: string;
+    radioOption: string | null;
+};
+
+export type PersonInRole = {
+    id?: number;
+    azureOid: string;
+    name: string;
+    email: string;
     rowVersion?: string;
     radioOption: string | null;
 };
 
 export type RoleParticipant = {
     id?: number;
-    rowVersion?: string;
     code: string;
     description: string;
     usePersonalEmail: boolean;
     notify: boolean;
-    persons: Person[];
+    persons: PersonInRole[];
 };
 
 type ExternalEmail = {
     id: number | null;
     email: string;
-    rowVersion: string | null;
 };
 
 export type Participant = {

--- a/src/modules/InvitationForPunchOut/types.d.ts
+++ b/src/modules/InvitationForPunchOut/types.d.ts
@@ -26,13 +26,11 @@ export type Person = {
     azureOid: string;
     name: string;
     email: string;
-    rowVersion?: string;
     radioOption: string | null;
 };
 
 export type RoleParticipant = {
     id?: number;
-    rowVersion?: string;
     code: string;
     description: string;
     usePersonalEmail: boolean;
@@ -43,13 +41,13 @@ export type RoleParticipant = {
 type ExternalEmail = {
     id: number | null;
     email: string;
-    rowVersion: string | null;
 };
 
 export type Participant = {
     organization: SelectItem;
     sortKey: number | null;
     type: string;
+    rowVersion?: string;
     externalEmail: ExternalEmail | null;
     person: Person | null;
     role: RoleParticipant | null;

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateIPO.tsx
@@ -224,7 +224,6 @@ const CreateIPO = (): JSX.Element => {
             id: participant.person.id,
             azureOid: participant.person.azureOid,
             email: participant.person.email,
-            rowVersion: participant.person.rowVersion,
             required: participant.person.radioOption == 'to',
         };
     };
@@ -238,7 +237,6 @@ const CreateIPO = (): JSX.Element => {
                 id: p.id,
                 azureOid: p.azureOid,
                 email: p.email,
-                rowVersion: p.rowVersion,
                 required: p.radioOption == 'to' || role.usePersonalEmail,
             };
         });
@@ -252,7 +250,6 @@ const CreateIPO = (): JSX.Element => {
         }
         return {
             id: participant.role.id,
-            rowVersion: participant.role.rowVersion,
             code: participant.role.code,
             persons: getPersons(participant.role),
         };

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
@@ -13,6 +13,7 @@ import {
 import { CenterContainer, Container } from './CreateAndEditIPO.style';
 import { ComponentName, IpoCustomEvents } from '../enums';
 import {
+    ExternalEmailDto,
     FunctionalRoleDto,
     ParticipantDto,
     PersonDto,
@@ -204,6 +205,7 @@ const EditIPO = (): JSX.Element => {
             azureOid: participant.person.azureOid,
             email: participant.person.email,
             required: participant.person.radioOption == 'to',
+            rowVersion: participant.rowVersion,
         };
     };
 
@@ -232,6 +234,18 @@ const EditIPO = (): JSX.Element => {
             id: participant.role.id,
             code: participant.role.code,
             persons: getPersons(participant.role),
+            rowVersion: participant.rowVersion,
+        };
+    };
+
+    const getExternalEmail = (
+        participant: Participant
+    ): ExternalEmailDto | null => {
+        if (!participant.externalEmail) return null;
+        return {
+            id: participant.externalEmail.id,
+            email: participant.externalEmail.email,
+            rowVersion: participant.rowVersion,
         };
     };
 
@@ -240,8 +254,7 @@ const EditIPO = (): JSX.Element => {
             return {
                 organization: p.organization.value,
                 sortKey: i,
-                rowVersion: p.rowVersion,
-                externalEmail: p.externalEmail,
+                externalEmail: getExternalEmail(p),
                 person: getPerson(p),
                 functionalRole: getFunctionalRole(p),
             };

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
@@ -6,6 +6,7 @@ import {
     McScope,
     Participant,
     Person,
+    PersonInRole,
     RoleParticipant,
     Step,
 } from '../../types';
@@ -15,6 +16,7 @@ import {
     FunctionalRoleDto,
     ParticipantDto,
     PersonDto,
+    PersonInRoleDto,
 } from '../../http/InvitationForPunchOutApiClient';
 import React, { useCallback, useEffect, useState } from 'react';
 
@@ -202,11 +204,10 @@ const EditIPO = (): JSX.Element => {
             azureOid: participant.person.azureOid,
             email: participant.person.email,
             required: participant.person.radioOption == 'to',
-            rowVersion: participant.person.rowVersion,
         };
     };
 
-    const getPersons = (role: RoleParticipant): PersonDto[] | null => {
+    const getPersons = (role: RoleParticipant): PersonInRoleDto[] | null => {
         if (!role.persons || role.persons.length == 0) {
             return null;
         }
@@ -231,7 +232,6 @@ const EditIPO = (): JSX.Element => {
             id: participant.role.id,
             code: participant.role.code,
             persons: getPersons(participant.role),
-            rowVersion: participant.role.rowVersion,
         };
     };
 
@@ -452,13 +452,12 @@ const EditIPO = (): JSX.Element => {
                         azureOid: participant.person.azureOid,
                         name: `${participant.person.firstName} ${participant.person.lastName}`,
                         email: participant.person.email,
-                        rowVersion: participant.person.rowVersion,
                         radioOption: null,
                     };
                 } else if (participant.functionalRole) {
                     participantType = 'Functional role';
 
-                    const persons: Person[] = [];
+                    const persons: PersonInRole[] = [];
                     participant.functionalRole.persons.forEach((person) => {
                         persons.push({
                             id: person.id,
@@ -491,7 +490,6 @@ const EditIPO = (): JSX.Element => {
                     externalEmail = {
                         id: participant.externalEmail.id,
                         email: participant.externalEmail.externalEmail,
-                        rowVersion: participant.externalEmail.rowVersion,
                     };
                 }
                 const organizationText = OrganizationMap.get(

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
@@ -201,7 +201,6 @@ const EditIPO = (): JSX.Element => {
             id: participant.person.id,
             azureOid: participant.person.azureOid,
             email: participant.person.email,
-            rowVersion: participant.person.rowVersion,
             required: participant.person.radioOption == 'to',
         };
     };
@@ -215,7 +214,6 @@ const EditIPO = (): JSX.Element => {
                 id: p.id,
                 azureOid: p.azureOid,
                 email: p.email,
-                rowVersion: p.rowVersion,
                 required: p.radioOption == 'to' || role.usePersonalEmail,
             };
         });
@@ -229,7 +227,6 @@ const EditIPO = (): JSX.Element => {
         }
         return {
             id: participant.role.id,
-            rowVersion: participant.role.rowVersion,
             code: participant.role.code,
             persons: getPersons(participant.role),
         };
@@ -240,6 +237,7 @@ const EditIPO = (): JSX.Element => {
             return {
                 organization: p.organization.value,
                 sortKey: i,
+                rowVersion: p.rowVersion,
                 externalEmail: p.externalEmail,
                 person: getPerson(p),
                 functionalRole: getFunctionalRole(p),
@@ -448,7 +446,6 @@ const EditIPO = (): JSX.Element => {
                     participantType = 'Person';
                     person = {
                         id: participant.person.person.id,
-                        rowVersion: participant.person.person.rowVersion,
                         azureOid: participant.person.person.azureOid,
                         name: `${participant.person.person.firstName} ${participant.person.person.lastName}`,
                         email: participant.person.person.email,
@@ -461,7 +458,6 @@ const EditIPO = (): JSX.Element => {
                     participant.functionalRole.persons.forEach((person) => {
                         persons.push({
                             id: person.person.id,
-                            rowVersion: person.person.rowVersion,
                             azureOid: person.person.azureOid,
                             name: `${person.person.firstName} ${person.person.lastName}`,
                             email: person.person.email,
@@ -477,7 +473,6 @@ const EditIPO = (): JSX.Element => {
                         : null;
                     roleParticipant = {
                         id: participant.functionalRole.id,
-                        rowVersion: participant.functionalRole.rowVersion,
                         code: participant.functionalRole.code,
                         description: funcRole ? funcRole.description : '',
                         usePersonalEmail: funcRole
@@ -491,7 +486,6 @@ const EditIPO = (): JSX.Element => {
                     externalEmail = {
                         id: participant.externalEmail.id,
                         email: participant.externalEmail.externalEmail,
-                        rowVersion: participant.externalEmail.rowVersion,
                     };
                 }
                 const organizationText = OrganizationMap.get(
@@ -504,6 +498,7 @@ const EditIPO = (): JSX.Element => {
                     },
                     sortKey: participant.sortKey,
                     type: participantType,
+                    rowVersion: participant.rowVersion,
                     externalEmail: externalEmail,
                     person: person,
                     role: roleParticipant,

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
@@ -202,6 +202,7 @@ const EditIPO = (): JSX.Element => {
             azureOid: participant.person.azureOid,
             email: participant.person.email,
             required: participant.person.radioOption == 'to',
+            rowVersion: participant.person.rowVersion,
         };
     };
 
@@ -215,6 +216,7 @@ const EditIPO = (): JSX.Element => {
                 azureOid: p.azureOid,
                 email: p.email,
                 required: p.radioOption == 'to' || role.usePersonalEmail,
+                rowVersion: p.rowVersion,
             };
         });
     };
@@ -229,6 +231,7 @@ const EditIPO = (): JSX.Element => {
             id: participant.role.id,
             code: participant.role.code,
             persons: getPersons(participant.role),
+            rowVersion: participant.role.rowVersion,
         };
     };
 
@@ -445,10 +448,11 @@ const EditIPO = (): JSX.Element => {
                 if (participant.person) {
                     participantType = 'Person';
                     person = {
-                        id: participant.person.person.id,
-                        azureOid: participant.person.person.azureOid,
-                        name: `${participant.person.person.firstName} ${participant.person.person.lastName}`,
-                        email: participant.person.person.email,
+                        id: participant.person.id,
+                        azureOid: participant.person.azureOid,
+                        name: `${participant.person.firstName} ${participant.person.lastName}`,
+                        email: participant.person.email,
+                        rowVersion: participant.person.rowVersion,
                         radioOption: null,
                     };
                 } else if (participant.functionalRole) {
@@ -457,10 +461,11 @@ const EditIPO = (): JSX.Element => {
                     const persons: Person[] = [];
                     participant.functionalRole.persons.forEach((person) => {
                         persons.push({
-                            id: person.person.id,
-                            azureOid: person.person.azureOid,
-                            name: `${person.person.firstName} ${person.person.lastName}`,
-                            email: person.person.email,
+                            id: person.id,
+                            azureOid: person.azureOid,
+                            name: `${person.firstName} ${person.lastName}`,
+                            email: person.email,
+                            rowVersion: person.rowVersion,
                             radioOption: person.required ? 'to' : 'cc',
                         });
                     });
@@ -486,6 +491,7 @@ const EditIPO = (): JSX.Element => {
                     externalEmail = {
                         id: participant.externalEmail.id,
                         email: participant.externalEmail.externalEmail,
+                        rowVersion: participant.externalEmail.rowVersion,
                     };
                 }
                 const organizationText = OrganizationMap.get(

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Participants/Participants.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Participants/Participants.tsx
@@ -197,7 +197,6 @@ const Participants = ({
             participantsCopy[index].externalEmail = {
                 id: null,
                 email: value,
-                rowVersion: null,
             };
             return participantsCopy;
         });

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Participants/Participants.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Participants/Participants.tsx
@@ -196,7 +196,6 @@ const Participants = ({
             participantsCopy[index].person = null;
             participantsCopy[index].externalEmail = {
                 id: null,
-                rowVersion: null,
                 email: value,
             };
             return participantsCopy;

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Participants/Participants.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Participants/Participants.tsx
@@ -197,6 +197,7 @@ const Participants = ({
             participantsCopy[index].externalEmail = {
                 id: null,
                 email: value,
+                rowVersion: null,
             };
             return participantsCopy;
         });

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/CustomPopover/__tests___/CustomPopover.test.jsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/CustomPopover/__tests___/CustomPopover.test.jsx
@@ -23,26 +23,22 @@ const participants = [
             email: 'funcitonalRole@asd.com',
             persons: [
                 {
-                    person: {
-                        id: 1,
-                        firstName: 'First',
-                        lastName: 'ASdsklandasnd',
-                        azureOid: 'azure1',
-                        email: 'asdadasd@dwwdwd.com',
-                        rowVersion: '123123',
-                    },
+                    id: 1,
+                    firstName: 'First',
+                    lastName: 'ASdsklandasnd',
+                    azureOid: 'azure1',
+                    email: 'asdadasd@dwwdwd.com',
+                    rowVersion: '123123',
                     required: true,
                     response: OutlookResponseType.ATTENDING,
                 },
                 {
-                    person: {
-                        id: 2,
-                        firstName: 'Second',
-                        lastName: 'ASdsklandasnd',
-                        azureOid: 'azure2',
-                        email: 'asdadasd2@dwwdwd.com',
-                        rowVersion: '1231234',
-                    },
+                    id: 2,
+                    firstName: 'Second',
+                    lastName: 'ASdsklandasnd',
+                    azureOid: 'azure2',
+                    email: 'asdadasd2@dwwdwd.com',
+                    rowVersion: '1231234',
                     required: true,
                     response: OutlookResponseType.NONE,
                 },
@@ -52,6 +48,7 @@ const participants = [
         },
         note: '',
         attended: true,
+        rowVersion: '123123',
     },
 ];
 
@@ -76,10 +73,10 @@ describe('<CustomPopover />', () => {
             fireEvent.click(button);
         });
         participants[0].functionalRole.persons.forEach((person) => {
-            const response = getByTestId(person.person.id.toString() + 'row', {
+            const response = getByTestId(person.id.toString() + 'row', {
                 exact: false,
             });
-            expect(response).toHaveTextContent(person.person.firstName);
+            expect(response).toHaveTextContent(person.firstName);
             expect(response).toHaveTextContent(person.response);
         });
     });

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/CustomPopover/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/CustomPopover/index.tsx
@@ -51,19 +51,14 @@ const CustomPopover = ({ participant }: CustomPopoverProps): JSX.Element => {
                         {participant.functionalRole.persons.map((person) => {
                             return (
                                 <TableRow
-                                    key={person.person.id}
-                                    data-testid={
-                                        person.person.id.toString() + 'row'
-                                    }
+                                    key={person.id}
+                                    data-testid={person.id.toString() + 'row'}
                                 >
                                     <TableCell>
-                                        {' '}
-                                        {person.person.firstName}{' '}
-                                        {person.person.lastName}{' '}
+                                        {person.firstName} {person.lastName}
                                     </TableCell>
                                     <TableCellRight>
-                                        {' '}
-                                        {person.response}{' '}
+                                        {person.response}
                                     </TableCellRight>
                                 </TableRow>
                             );

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/__tests__/ParticipantsTable.test.jsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/__tests__/ParticipantsTable.test.jsx
@@ -37,6 +37,7 @@ const participants = [
         },
         attended: false,
         note: '',
+        rowVersion: '12312ss3',
     },
     {
         organization: OrganizationsEnum.TechnicalIntegrity,
@@ -56,20 +57,19 @@ const participants = [
         signedBy: 'signer3',
         signedAtUtc: new Date(2020, 11, 6, 11),
         note: '',
+        rowVersion: '12312333',
     },
     {
         organization: OrganizationsEnum.Contractor,
         sortKey: 0,
         canSign: false,
         person: {
-            person: {
-                id: 123,
-                firstName: 'Adwa',
-                lastName: 'ASdsklandasnd',
-                azureOid: 'azure1',
-                email: 'asdadasd@dwwdwd.com',
-                rowVersion: '123123',
-            },
+            id: 123,
+            firstName: 'Adwa',
+            lastName: 'ASdsklandasnd',
+            azureOid: 'azure1',
+            email: 'asdadasd@dwwdwd.com',
+            rowVersion: '123123',
             required: true,
             response: OutlookResponseType.ATTENDING,
         },
@@ -87,20 +87,19 @@ const participants = [
         signedAtUtc: new Date(2020, 11, 6, 11),
         attended: true,
         note: '',
+        rowVersion: '123123',
     },
     {
         organization: OrganizationsEnum.ConstructionCompany,
         sortKey: 1,
         canSign: false,
         person: {
-            person: {
-                id: 234,
-                firstName: 'Oakjfcv',
-                lastName: 'Alkjljsdf',
-                azureOid: 'azure2',
-                email: 'lkjlkjsdf@dwwdwd.com',
-                rowVersion: '123123',
-            },
+            id: 234,
+            firstName: 'Oakjfcv',
+            lastName: 'Alkjljsdf',
+            azureOid: 'azure2',
+            email: 'lkjlkjsdf@dwwdwd.com',
+            rowVersion: '123123',
             required: true,
             response: OutlookResponseType.ATTENDING,
         },
@@ -118,6 +117,7 @@ const participants = [
         signedAtUtc: new Date(2020, 11, 6, 12),
         attended: true,
         note: '',
+        rowVersion: '1231dd23',
     },
     {
         organization: OrganizationsEnum.Contractor,
@@ -131,26 +131,22 @@ const participants = [
             email: 'funcitonalRole@asd.com',
             persons: [
                 {
-                    person: {
-                        id: 1,
-                        firstName: 'First',
-                        lastName: 'ASdsklandasnd',
-                        azureOid: 'azure1',
-                        email: 'asdadasd@dwwdwd.com',
-                        rowVersion: '123123',
-                    },
+                    id: 1,
+                    firstName: 'First',
+                    lastName: 'ASdsklandasnd',
+                    azureOid: 'azure1',
+                    email: 'asdadasd@dwwdwd.com',
+                    rowVersion: '123123',
                     required: true,
                     response: OutlookResponseType.NONE,
                 },
                 {
-                    person: {
-                        id: 2,
-                        firstName: 'Second',
-                        lastName: 'ASdsklandasnd',
-                        azureOid: 'azure2',
-                        email: 'asdadasd2@dwwdwd.com',
-                        rowVersion: '1231234',
-                    },
+                    id: 2,
+                    firstName: 'Second',
+                    lastName: 'ASdsklandasnd',
+                    azureOid: 'azure2',
+                    email: 'asdadasd2@dwwdwd.com',
+                    rowVersion: '1231234',
                     required: true,
                     response: OutlookResponseType.NONE,
                 },
@@ -160,6 +156,7 @@ const participants = [
         },
         note: '',
         attended: false,
+        rowVersion: '12312333',
     },
 ];
 
@@ -169,14 +166,12 @@ const participants_canSign = [
         sortKey: 0,
         canSign: true,
         person: {
-            person: {
-                id: 123,
-                firstName: 'Adwa',
-                lastName: 'ASdsklandasnd',
-                azureOid: 'azure1',
-                email: 'asdadasd@dwwdwd.com',
-                rowVersion: '123123',
-            },
+            id: 123,
+            firstName: 'Adwa',
+            lastName: 'ASdsklandasnd',
+            azureOid: 'azure1',
+            email: 'asdadasd@dwwdwd.com',
+            rowVersion: '123123',
             required: true,
             response: OutlookResponseType.ATTENDING,
         },
@@ -194,20 +189,19 @@ const participants_canSign = [
         signedAtUtc: new Date(2020, 11, 6, 11),
         attended: true,
         note: '',
+        rowVersion: '12333123',
     },
     {
         organization: OrganizationsEnum.ConstructionCompany,
         sortKey: 1,
         canSign: true,
         person: {
-            person: {
-                id: 234,
-                firstName: 'Oakjfcv',
-                lastName: 'Alkjljsdf',
-                azureOid: 'azure2',
-                email: 'lkjlkjsdf@dwwdwd.com',
-                rowVersion: '123123',
-            },
+            id: 234,
+            firstName: 'Oakjfcv',
+            lastName: 'Alkjljsdf',
+            azureOid: 'azure2',
+            email: 'lkjlkjsdf@dwwdwd.com',
+            rowVersion: '123123',
             required: true,
             response: OutlookResponseType.ATTENDING,
         },
@@ -225,6 +219,7 @@ const participants_canSign = [
         signedAtUtc: new Date(2020, 11, 6, 12),
         attended: true,
         note: '',
+        rowVersion: '123333123',
     },
 ];
 
@@ -263,23 +258,15 @@ describe('<ParticipantsTable />', () => {
 
         expect(
             queryByText(
-                `${
-                    participants[ParticipantIndex.COMPLETER].person.person
-                        .firstName
-                } ${
-                    participants[ParticipantIndex.COMPLETER].person.person
-                        .lastName
+                `${participants[ParticipantIndex.COMPLETER].person.firstName} ${
+                    participants[ParticipantIndex.COMPLETER].person.lastName
                 }`
             )
         ).toBeInTheDocument();
         expect(
             queryByText(
-                `${
-                    participants[ParticipantIndex.ACCEPTER].person.person
-                        .firstName
-                } ${
-                    participants[ParticipantIndex.ACCEPTER].person.person
-                        .lastName
+                `${participants[ParticipantIndex.ACCEPTER].person.firstName} ${
+                    participants[ParticipantIndex.ACCEPTER].person.lastName
                 }`
             )
         ).toBeInTheDocument();

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
@@ -88,7 +88,7 @@ const ParticipantsTable = ({
             id: x.id,
             attended: attendedStatus,
             note: p.note ? p.note : '',
-            rowVersion: x.rowVersion,
+            rowVersion: p.rowVersion,
         };
     });
     const [loading, setLoading] = useState<boolean>(false);

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
@@ -68,7 +68,7 @@ const ParticipantsTable = ({
 }: ParticipantsTableProps): JSX.Element => {
     const cleanData = participants.map((p) => {
         const x = p.person
-            ? p.person.person
+            ? p.person
             : p.functionalRole
             ? p.functionalRole
             : p.externalEmail;
@@ -503,7 +503,7 @@ const ParticipantsTable = ({
                     {participants.map(
                         (participant: Participant, index: number) => {
                             const representative = participant.person
-                                ? `${participant.person.person.firstName} ${participant.person.person.lastName}`
+                                ? `${participant.person.firstName} ${participant.person.lastName}`
                                 : participant.functionalRole
                                 ? participant.functionalRole.code
                                 : participant.externalEmail.externalEmail;
@@ -523,7 +523,7 @@ const ParticipantsTable = ({
                                 : '';
 
                             const id = participant.person
-                                ? participant.person.person.id
+                                ? participant.person.id
                                 : participant.functionalRole
                                 ? participant.functionalRole.id
                                 : participant.externalEmail.id;

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
@@ -252,7 +252,7 @@ const ViewIPO = (): JSX.Element => {
         attNoteData: AttNoteData[]
     ): Promise<any> => {
         const signer = participant.person
-            ? participant.person.person
+            ? participant.person
             : participant.functionalRole
             ? participant.functionalRole
             : undefined;
@@ -281,7 +281,7 @@ const ViewIPO = (): JSX.Element => {
         participant: Participant
     ): Promise<any> => {
         const signer = participant.person
-            ? participant.person.person
+            ? participant.person
             : participant.functionalRole
             ? participant.functionalRole
             : undefined;
@@ -311,7 +311,7 @@ const ViewIPO = (): JSX.Element => {
         attNoteData: AttNoteData[]
     ): Promise<any> => {
         const signer = participant.person
-            ? participant.person.person
+            ? participant.person
             : participant.functionalRole
             ? participant.functionalRole
             : undefined;
@@ -339,7 +339,7 @@ const ViewIPO = (): JSX.Element => {
 
     const unacceptPunchOut = async (participant: Participant): Promise<any> => {
         const signer = participant.person
-            ? participant.person.person
+            ? participant.person
             : participant.functionalRole
             ? participant.functionalRole
             : undefined;
@@ -366,7 +366,7 @@ const ViewIPO = (): JSX.Element => {
 
     const signPunchOut = async (participant: Participant): Promise<any> => {
         const signer = participant.person
-            ? participant.person.person
+            ? participant.person
             : participant.functionalRole
             ? participant.functionalRole
             : undefined;

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
@@ -262,7 +262,7 @@ const ViewIPO = (): JSX.Element => {
         try {
             await apiClient.completePunchOut(params.ipoId, {
                 invitationRowVersion: invitation.rowVersion,
-                participantRowVersion: signer.rowVersion,
+                participantRowVersion: participant.rowVersion,
                 participants: attNoteData,
             });
             analytics.trackUserAction(IpoCustomEvents.COMPLETED, {
@@ -292,7 +292,7 @@ const ViewIPO = (): JSX.Element => {
             await apiClient.uncompletePunchOut(
                 params.ipoId,
                 invitation.rowVersion,
-                signer.rowVersion
+                participant.rowVersion
             );
             analytics.trackUserAction(IpoCustomEvents.UNCOMPLETED, {
                 project: invitation.projectName,
@@ -320,7 +320,7 @@ const ViewIPO = (): JSX.Element => {
 
         const acceptDetails: AcceptIPODto = {
             invitationRowVersion: invitation.rowVersion,
-            participantRowVersion: signer.rowVersion,
+            participantRowVersion: participant.rowVersion,
             participants: attNoteData,
         };
         try {
@@ -350,7 +350,7 @@ const ViewIPO = (): JSX.Element => {
             await apiClient.unacceptPunchOut(
                 params.ipoId,
                 invitation.rowVersion,
-                signer.rowVersion
+                participant.rowVersion
             );
             analytics.trackUserAction(IpoCustomEvents.UNACCEPTED, {
                 project: invitation.projectName,
@@ -375,7 +375,7 @@ const ViewIPO = (): JSX.Element => {
 
         const signDetails: SignIPODto = {
             participantId: signer.id,
-            participantRowVersion: signer.rowVersion,
+            participantRowVersion: participant.rowVersion,
         };
 
         try {

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/types.d.ts
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/types.d.ts
@@ -37,21 +37,21 @@ type FunctionalRole = {
 };
 
 type Person = {
-    person: {
-        id: number;
-        firstName: string;
-        lastName: string;
-        azureOid: string;
-        email: string;
-    };
     response?: string;
+    id: number;
+    firstName: string;
+    lastName: string;
+    azureOid: string;
+    email: string;
     required: boolean;
+    rowVersion?: string;
 };
 
 type ExternalEmail = {
     id: number;
     externalEmail: string;
     response?: string;
+    rowVersion: string | null;
 };
 
 export type Invitation = {

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/types.d.ts
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/types.d.ts
@@ -16,6 +16,7 @@ type Participant = {
     organization: string;
     sortKey: number;
     canSign: boolean;
+    rowVersion: string;
     externalEmail: ExternalEmail;
     person: Person;
     functionalRole: FunctionalRole;
@@ -33,7 +34,6 @@ type FunctionalRole = {
     email: string;
     persons: Person[];
     response?: string;
-    rowVersion: string;
 };
 
 type Person = {
@@ -43,7 +43,6 @@ type Person = {
         lastName: string;
         azureOid: string;
         email: string;
-        rowVersion: string;
     };
     response?: string;
     required: boolean;
@@ -53,7 +52,6 @@ type ExternalEmail = {
     id: number;
     externalEmail: string;
     response?: string;
-    rowVersion: string;
 };
 
 export type Invitation = {

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/types.d.ts
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/types.d.ts
@@ -32,11 +32,21 @@ type FunctionalRole = {
     id: number;
     code: string;
     email: string;
-    persons: Person[];
+    persons: PersonInRole[];
     response?: string;
 };
 
 type Person = {
+    response?: string;
+    id: number;
+    firstName: string;
+    lastName: string;
+    azureOid: string;
+    email: string;
+    required: boolean;
+};
+
+type PersonInRole = {
     response?: string;
     id: number;
     firstName: string;
@@ -51,7 +61,6 @@ type ExternalEmail = {
     id: number;
     externalEmail: string;
     response?: string;
-    rowVersion: string | null;
 };
 
 export type Invitation = {

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/types.d.ts
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/types.d.ts
@@ -43,7 +43,6 @@ type Person = {
     lastName: string;
     azureOid: string;
     email: string;
-    required: boolean;
 };
 
 type PersonInRole = {


### PR DESCRIPTION
# Description

Changed to using the participant row version instead of the row version of the person or external email when completing, uncompleting, accepting, unaccepting and signing an IPO. And when changing attended status.
Removed rowVersion from person, functional role and external email, but not from persons in a functional role.

Also changed the invitation type to not use person.person and persons.person anymore, as the info in the person.person  and persons.person object has been added to the person and persons object. The person.person and persons.person object will soon be removed from the output of the get invitations/{id} endpoint.

Completes: [AB#88664](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/88664)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
