### PR TITLE
Bug/88829 ipo cannot use more than one signing button without refreshing

### DIFF
--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
@@ -66,31 +66,6 @@ const ParticipantsTable = ({
     unaccept,
     uncomplete,
 }: ParticipantsTableProps): JSX.Element => {
-    const cleanData = participants.map((p) => {
-        const x = p.person
-            ? p.person
-            : p.functionalRole
-            ? p.functionalRole
-            : p.externalEmail;
-        const attendedStatus =
-            status === IpoStatusEnum.PLANNED
-                ? p.person
-                    ? p.person.response
-                        ? p.person.response === OutlookResponseType.ATTENDING
-                        : false
-                    : (x as FunctionalRole | ExternalEmail).response
-                    ? (x as FunctionalRole | ExternalEmail).response ===
-                      OutlookResponseType.ATTENDING
-                    : false
-                : p.attended;
-
-        return {
-            id: x.id,
-            attended: attendedStatus,
-            note: p.note ? p.note : '',
-            rowVersion: p.rowVersion,
-        };
-    });
     const [loading, setLoading] = useState<boolean>(false);
     const [editAttendedDisabled, setEditAttendedDisabled] =
         useState<boolean>(true);
@@ -100,7 +75,8 @@ const ParticipantsTable = ({
     const btnAcceptRef = useRef<HTMLButtonElement>();
     const btnUnAcceptRef = useRef<HTMLButtonElement>();
     const btnUpdateRef = useRef<HTMLButtonElement>();
-    const [attNoteData, setAttNoteData] = useState<AttNoteData[]>(cleanData);
+    const [attNoteData, setAttNoteData] = useState<AttNoteData[]>([]);
+    const [cleanData, setCleanData] = useState<AttNoteData[]>([]);
     const { setDirtyStateFor, unsetDirtyStateFor } = useDirtyContext();
     const btnSignRef = useRef<HTMLButtonElement>();
 
@@ -137,6 +113,37 @@ const ParticipantsTable = ({
                 btnUpdateRef.current.setAttribute('disabled', 'disabled');
         }
     }, [attNoteData]);
+
+    useEffect(() => {
+        const newCleanData = participants.map((participant) => {
+            const x = participant.person
+                ? participant.person
+                : participant.functionalRole
+                ? participant.functionalRole
+                : participant.externalEmail;
+            const attendedStatus =
+                status === IpoStatusEnum.PLANNED
+                    ? participant.person
+                        ? participant.person.response
+                            ? participant.person.response ===
+                              OutlookResponseType.ATTENDING
+                            : false
+                        : (x as FunctionalRole | ExternalEmail).response
+                        ? (x as FunctionalRole | ExternalEmail).response ===
+                          OutlookResponseType.ATTENDING
+                        : false
+                    : participant.attended;
+
+            return {
+                id: x.id,
+                attended: attendedStatus,
+                note: participant.note ? participant.note : '',
+                rowVersion: participant.rowVersion,
+            };
+        });
+        setCleanData(newCleanData);
+        setAttNoteData(newCleanData);
+    }, [participants]);
 
     const getCompleteButton = (
         completePunchout: (index: number) => void
@@ -584,12 +591,18 @@ const ParticipantsTable = ({
                                             disabled={editAttendedDisabled}
                                             default
                                             label={
-                                                attNoteData[index].attended
-                                                    ? 'Attended'
-                                                    : 'Did not attend'
+                                                attNoteData[index]
+                                                    ? attNoteData[index]
+                                                          .attended
+                                                        ? 'Attended'
+                                                        : 'Did not attend'
+                                                    : null
                                             }
                                             checked={
-                                                attNoteData[index].attended
+                                                attNoteData[index]
+                                                    ? attNoteData[index]
+                                                          .attended
+                                                    : null
                                             }
                                             onChange={(): void =>
                                                 handleEditAttended(id)
@@ -608,7 +621,9 @@ const ParticipantsTable = ({
                                             id={`textfield${id}`}
                                             disabled={editNotesDisabled}
                                             defaultValue={
-                                                attNoteData[index].note
+                                                participant.note
+                                                    ? participant.note
+                                                    : ''
                                             }
                                             onChange={(e: any): void =>
                                                 handleEditNotes(e, id)

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
@@ -602,7 +602,7 @@ const ParticipantsTable = ({
                                                 attNoteData[index]
                                                     ? attNoteData[index]
                                                           .attended
-                                                    : null
+                                                    : false
                                             }
                                             onChange={(): void =>
                                                 handleEditAttended(id)

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/index.tsx
@@ -13,7 +13,7 @@ import {
     getFormattedTime,
 } from '@procosys/core/services/DateService';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Typography } from '@equinor/eds-core-react';
 
 interface GeneralInfoProps {
@@ -35,9 +35,14 @@ const GeneralInfo = ({
     unaccept,
     uncomplete,
 }: GeneralInfoProps): JSX.Element => {
-    const participants = invitation.participants.sort(
-        (p1, p2): number => p1.sortKey - p2.sortKey
-    );
+    const [participants, setParticipants] = useState<Participant[]>([]);
+
+    useEffect(() => {
+        const newParticipants = invitation.participants.sort(
+            (p1, p2): number => p1.sortKey - p2.sortKey
+        );
+        setParticipants(newParticipants);
+    }, [invitation]);
 
     return (
         <Container>


### PR DESCRIPTION
# Description

AttNoteData and CleanData wasn't updated with the new rowVersion when one of the signing buttons or the update button was used, this caused an issue when backend started checking row versions properly.

The AttNoteData and CleanData are now updated whenever the participant list is updated. The participant list is updated when the invitation is updated, and the invitation was already updated whenever one of the signing endpoints or the update endpoint was called.

Completes: [AB#88829](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/88829)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
