### PR TITLE
Feature/89019 change ipo signed by to name

### DIFF
--- a/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
+++ b/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
@@ -51,6 +51,7 @@ type CommPkgPagingResponse = {
 };
 
 type ParticipantInvitationResponse = {
+    id: number;
     organization: string;
     sortKey: number;
     canSign: boolean;
@@ -65,7 +66,6 @@ type ParticipantInvitationResponse = {
 };
 
 type FunctionalRoleInvitationResponse = {
-    id: number;
     code: string;
     email: string;
     persons: PersonInFunctionalRoleResponse[];
@@ -86,7 +86,6 @@ type PersonInFunctionalRoleResponse = {
 
 type PersonInvitationResponse = {
     response?: string;
-    id: number;
     firstName: string;
     lastName: string;
     userName: string;
@@ -95,7 +94,6 @@ type PersonInvitationResponse = {
 };
 
 type ExternalEmailInvitationResponse = {
-    id: number;
     externalEmail: string;
     response?: string;
 };
@@ -250,7 +248,7 @@ export type FunctionalRoleDto = {
 };
 
 export type ExternalEmailDto = {
-    id: number | null;
+    id?: number | null;
     email: string;
     rowVersion?: string;
 };

--- a/src/modules/InvitationForPunchOut/types.d.ts
+++ b/src/modules/InvitationForPunchOut/types.d.ts
@@ -22,7 +22,6 @@ export type GeneralInfoDetails = {
 };
 
 export type Person = {
-    id?: number;
     azureOid: string;
     name: string;
     email: string;
@@ -39,7 +38,6 @@ export type PersonInRole = {
 };
 
 export type RoleParticipant = {
-    id?: number;
     code: string;
     description: string;
     usePersonalEmail: boolean;
@@ -48,11 +46,11 @@ export type RoleParticipant = {
 };
 
 type ExternalEmail = {
-    id: number | null;
     email: string;
 };
 
 export type Participant = {
+    id?: number; // TODO: make optional
     organization: SelectItem;
     sortKey: number | null;
     type: string;

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateIPO.tsx
@@ -221,7 +221,7 @@ const CreateIPO = (): JSX.Element => {
             return null;
         }
         return {
-            id: participant.person.id,
+            id: participant.id,
             azureOid: participant.person.azureOid,
             email: participant.person.email,
             required: participant.person.radioOption == 'to',
@@ -249,7 +249,7 @@ const CreateIPO = (): JSX.Element => {
             return null;
         }
         return {
-            id: participant.role.id,
+            id: participant.id,
             code: participant.role.code,
             persons: getPersons(participant.role),
         };

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
@@ -15,6 +15,7 @@ import { ComponentName, IpoCustomEvents } from '../enums';
 import {
     ExternalEmailDto,
     FunctionalRoleDto,
+    IpoApiError,
     ParticipantDto,
     PersonDto,
     PersonInRoleDto,
@@ -180,6 +181,11 @@ const EditIPO = (): JSX.Element => {
                     );
                 setAvailableRoles(functionalRoles);
             } catch (error) {
+                if (!(error instanceof IpoApiError)) {
+                    console.error(error);
+                    showSnackbarNotification('Unknown error');
+                    return;
+                }
                 console.error(error.message, error.data);
                 showSnackbarNotification(error.message);
             }
@@ -287,6 +293,11 @@ const EditIPO = (): JSX.Element => {
                         );
                     }
                 } catch (error) {
+                    if (!(error instanceof IpoApiError)) {
+                        console.error(error);
+                        showSnackbarNotification('Unknown error');
+                        return;
+                    }
                     console.error(
                         'Upload or delete of attachment failed: ',
                         error.message,
@@ -308,6 +319,11 @@ const EditIPO = (): JSX.Element => {
             );
             setAttachments(response);
         } catch (error) {
+            if (!(error instanceof IpoApiError)) {
+                console.error(error);
+                showSnackbarNotification('Unknown error');
+                return;
+            }
             console.error(error.message, error.data);
             showSnackbarNotification(error.message);
         }
@@ -354,6 +370,11 @@ const EditIPO = (): JSX.Element => {
                 ]);
                 history.push('/' + params.ipoId);
             } catch (error) {
+                if (!(error instanceof IpoApiError)) {
+                    console.error(error);
+                    showSnackbarNotification('Unknown error');
+                    return;
+                }
                 console.error(
                     'Save updated IPO failed: ',
                     error.message,
@@ -376,6 +397,11 @@ const EditIPO = (): JSX.Element => {
                 );
                 setInvitation(response);
             } catch (error) {
+                if (!(error instanceof IpoApiError)) {
+                    console.error(error);
+                    showSnackbarNotification('Unknown error');
+                    return;
+                }
                 console.error(error.message, error.data);
                 showSnackbarNotification(error.message);
             }

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
@@ -201,7 +201,7 @@ const EditIPO = (): JSX.Element => {
             return null;
         }
         return {
-            id: participant.person.id,
+            id: participant.id,
             azureOid: participant.person.azureOid,
             email: participant.person.email,
             required: participant.person.radioOption == 'to',
@@ -231,7 +231,7 @@ const EditIPO = (): JSX.Element => {
             return null;
         }
         return {
-            id: participant.role.id,
+            id: participant.id,
             code: participant.role.code,
             persons: getPersons(participant.role),
             rowVersion: participant.rowVersion,
@@ -243,7 +243,7 @@ const EditIPO = (): JSX.Element => {
     ): ExternalEmailDto | null => {
         if (!participant.externalEmail) return null;
         return {
-            id: participant.externalEmail.id,
+            id: participant.id,
             email: participant.externalEmail.email,
             rowVersion: participant.rowVersion,
         };
@@ -461,7 +461,6 @@ const EditIPO = (): JSX.Element => {
                 if (participant.person) {
                     participantType = 'Person';
                     person = {
-                        id: participant.person.id,
                         azureOid: participant.person.azureOid,
                         name: `${participant.person.firstName} ${participant.person.lastName}`,
                         email: participant.person.email,
@@ -489,7 +488,6 @@ const EditIPO = (): JSX.Element => {
                           )
                         : null;
                     roleParticipant = {
-                        id: participant.functionalRole.id,
                         code: participant.functionalRole.code,
                         description: funcRole ? funcRole.description : '',
                         usePersonalEmail: funcRole
@@ -501,7 +499,6 @@ const EditIPO = (): JSX.Element => {
                 } else if (participant.externalEmail) {
                     participantType = 'Person';
                     externalEmail = {
-                        id: participant.externalEmail.id,
                         email: participant.externalEmail.externalEmail,
                     };
                 }
@@ -509,6 +506,7 @@ const EditIPO = (): JSX.Element => {
                     participant.organization as Organization
                 );
                 const newParticipant: Participant = {
+                    id: participant.id,
                     organization: {
                         text: organizationText ? organizationText : 'Unknown',
                         value: participant.organization,

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Participants/Participants.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Participants/Participants.tsx
@@ -195,7 +195,6 @@ const Participants = ({
             participantsCopy[index].role = null;
             participantsCopy[index].person = null;
             participantsCopy[index].externalEmail = {
-                id: null,
                 email: value,
             };
             return participantsCopy;

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/__tests__/ParticipantsTable.test.jsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/__tests__/ParticipantsTable.test.jsx
@@ -271,11 +271,6 @@ describe('<ParticipantsTable />', () => {
             )
         ).toBeInTheDocument();
         expect(
-            queryByText(
-                `${participants[ParticipantIndex.COMPLETER].signedBy.userName}`
-            )
-        ).toBeInTheDocument();
-        expect(
             queryAllByText(
                 participants[ParticipantIndex.COMPLETER].person.response
             ).length
@@ -468,14 +463,6 @@ describe('<ParticipantsTable />', () => {
         await waitFor(() => {
             expect(
                 queryByText(
-                    newParticipants[ParticipantIndex.COMPLETER].signedBy
-                        .userName
-                )
-            ).toBeInTheDocument();
-        });
-        await waitFor(() => {
-            expect(
-                queryByText(
                     getFormattedDateAndTime(
                         newParticipants[ParticipantIndex.COMPLETER].signedAtUtc
                     )
@@ -497,7 +484,7 @@ describe('<ParticipantsTable />', () => {
             signedBy: null,
             canSign: true,
         };
-        const { queryByText, getByText } = renderWithTheme(
+        const { queryByText } = renderWithTheme(
             <ParticipantsTable
                 participants={newParticipants}
                 status={IpoStatusEnum.COMPLETED}
@@ -509,11 +496,6 @@ describe('<ParticipantsTable />', () => {
         expect(queryByText('Uncomplete')).not.toBeInTheDocument();
         expect(queryByText('Sign punch-out')).toBeInTheDocument();
         expect(queryByText('Accept punch-out')).not.toBeInTheDocument();
-        expect(
-            getByText(
-                newParticipants[ParticipantIndex.COMPLETER].signedBy.userName
-            )
-        ).toBeInTheDocument();
         expect(
             queryByText(
                 getFormattedDateAndTime(
@@ -550,11 +532,6 @@ describe('<ParticipantsTable />', () => {
         expect(queryByText('Uncomplete')).not.toBeInTheDocument();
         expect(queryByText('Sign punch-out')).not.toBeInTheDocument();
         expect(queryByText('Accept punch-out')).not.toBeInTheDocument();
-        expect(
-            queryByText(
-                `${participants[ParticipantIndex.COMPLETER].signedBy.userName}`
-            )
-        ).toBeInTheDocument();
         expect(queryByText('Unaccept punch-out')).not.toBeInTheDocument();
         expect(
             queryByText(
@@ -596,11 +573,6 @@ describe('<ParticipantsTable />', () => {
         expect(queryByText('Uncomplete')).not.toBeInTheDocument();
         expect(queryByText('Sign punch-out')).not.toBeInTheDocument();
         expect(queryByText('Accept punch-out')).not.toBeInTheDocument();
-        expect(
-            queryByText(
-                `${participants[ParticipantIndex.COMPLETER].signedBy.userName}`
-            )
-        ).toBeInTheDocument();
         expect(queryByText('Unaccept punch-out')).toBeInTheDocument();
         expect(
             queryByText(
@@ -626,7 +598,7 @@ describe('<ParticipantsTable />', () => {
             signedBy: null,
             canSign: true,
         };
-        const { queryByText, getByText } = renderWithTheme(
+        const { queryByText } = renderWithTheme(
             <ParticipantsTable
                 participants={newParticipants}
                 status={IpoStatusEnum.ACCEPTED}
@@ -638,11 +610,6 @@ describe('<ParticipantsTable />', () => {
         expect(queryByText('Uncomplete')).not.toBeInTheDocument();
         expect(queryByText('Sign punch-out')).toBeInTheDocument();
         expect(queryByText('Accept punch-out')).not.toBeInTheDocument();
-        expect(
-            getByText(
-                newParticipants[ParticipantIndex.COMPLETER].signedBy.userName
-            )
-        ).toBeInTheDocument();
         expect(queryByText('Unaccept punch-out')).not.toBeInTheDocument();
         expect(
             queryByText(

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/__tests__/ParticipantsTable.test.jsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/__tests__/ParticipantsTable.test.jsx
@@ -24,13 +24,13 @@ const ParticipantIndex = Object.freeze({
 
 const participants = [
     {
+        id: 0,
         organization: OrganizationsEnum.External,
         canSign: false,
         sortKey: 2,
         person: null,
         functionalRole: null,
         externalEmail: {
-            id: 0,
             externalEmail: 'asdasd@asdasd.com',
             response: OutlookResponseType.NONE,
             rowVersion: '00101',
@@ -40,12 +40,12 @@ const participants = [
         rowVersion: '12312ss3',
     },
     {
+        id: 1,
         organization: OrganizationsEnum.TechnicalIntegrity,
         sortKey: 3,
         canSign: false,
         person: null,
         functionalRole: {
-            id: 1,
             code: 'asdasdasd',
             email: 'funcitonalRole@asd.com',
             persons: [],
@@ -60,11 +60,11 @@ const participants = [
         rowVersion: '12312333',
     },
     {
+        id: 123,
         organization: OrganizationsEnum.Contractor,
         sortKey: 0,
         canSign: false,
         person: {
-            id: 123,
             firstName: 'Adwa',
             lastName: 'ASdsklandasnd',
             azureOid: 'azure1',
@@ -90,11 +90,11 @@ const participants = [
         rowVersion: '123123',
     },
     {
+        id: 234,
         organization: OrganizationsEnum.ConstructionCompany,
         sortKey: 1,
         canSign: false,
         person: {
-            id: 234,
             firstName: 'Oakjfcv',
             lastName: 'Alkjljsdf',
             azureOid: 'azure2',
@@ -120,13 +120,13 @@ const participants = [
         rowVersion: '1231dd23',
     },
     {
+        id: 12,
         organization: OrganizationsEnum.Contractor,
         sortKey: 4,
         canSign: false,
         externalEmail: null,
         person: null,
         functionalRole: {
-            id: 12,
             code: 'one',
             email: 'funcitonalRole@asd.com',
             persons: [

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
@@ -117,7 +117,7 @@ const ParticipantsTable = ({
                     : participant.attended;
 
             return {
-                id: x.id,
+                id: participant.id,
                 attended: attendedStatus,
                 note: participant.note ? participant.note : '',
                 rowVersion: participant.rowVersion,
@@ -278,11 +278,12 @@ const ParticipantsTable = ({
                                     : ''
                                 : '';
 
-                            const id = participant.person
-                                ? participant.person.id
-                                : participant.functionalRole
-                                ? participant.functionalRole.id
-                                : participant.externalEmail.id;
+                            // TODO: may need to use ID of person in func. role.
+                            // const id = participant.person
+                            //     ? participant.person
+                            //     : participant.functionalRole
+                            //     ? participant.functionalRole.id
+                            //     : participant.externalEmail.id;
 
                             const addPopover = participant.functionalRole
                                 ? participant.functionalRole.response
@@ -336,7 +337,7 @@ const ParticipantsTable = ({
                                         }}
                                     >
                                         <Switch
-                                            id={`attendance${id}`}
+                                            id={`attendance${participant.id}`}
                                             disabled={editAttendedDisabled}
                                             default
                                             label={
@@ -354,7 +355,9 @@ const ParticipantsTable = ({
                                                     : false
                                             }
                                             onChange={(): void =>
-                                                handleEditAttended(id)
+                                                handleEditAttended(
+                                                    participant.id
+                                                )
                                             }
                                         />
                                     </Table.Cell>
@@ -367,7 +370,7 @@ const ParticipantsTable = ({
                                         }}
                                     >
                                         <TextField
-                                            id={`textfield${id}`}
+                                            id={`textfield${participant.id}`}
                                             disabled={editNotesDisabled}
                                             defaultValue={
                                                 participant.note
@@ -375,7 +378,10 @@ const ParticipantsTable = ({
                                                     : ''
                                             }
                                             onChange={(e: any): void =>
-                                                handleEditNotes(e, id)
+                                                handleEditNotes(
+                                                    e,
+                                                    participant.id
+                                                )
                                             }
                                         />
                                     </Table.Cell>

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
@@ -406,7 +406,7 @@ const ParticipantsTable = ({
                                         <Typography variant="body_short">
                                             <span>
                                                 {participant.signedBy
-                                                    ? `${participant.signedBy.userName}`
+                                                    ? `${participant.signedBy.lastName}, ${participant.signedBy.firstName}`
                                                     : ''}
                                             </span>
                                         </Typography>

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
@@ -374,7 +374,7 @@ const ViewIPO = (): JSX.Element => {
         if (!signer || !invitation) return;
 
         const signDetails: SignIPODto = {
-            participantId: signer.id,
+            participantId: participant.id,
             participantRowVersion: participant.rowVersion,
         };
 
@@ -404,7 +404,7 @@ const ViewIPO = (): JSX.Element => {
         try {
             await apiClient.unsignPunchOut(
                 params.ipoId,
-                signer.id,
+                participant.id,
                 participant.rowVersion
             );
             analytics.trackUserAction(IpoCustomEvents.UNSIGNED, {

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/types.d.ts
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/types.d.ts
@@ -13,6 +13,7 @@ export type CommPkgScope = {
 };
 
 type Participant = {
+    id: number;
     organization: string;
     sortKey: number;
     canSign: boolean;
@@ -31,7 +32,6 @@ type Participant = {
 };
 
 type FunctionalRole = {
-    id: number;
     code: string;
     email: string;
     persons: PersonInRole[];
@@ -40,7 +40,6 @@ type FunctionalRole = {
 
 type Person = {
     response?: string;
-    id: number;
     firstName: string;
     lastName: string;
     azureOid: string;
@@ -59,7 +58,6 @@ type PersonInRole = {
 };
 
 type ExternalEmail = {
-    id: number;
     externalEmail: string;
     response?: string;
 };

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/types.d.ts
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/types.d.ts
@@ -23,6 +23,8 @@ type Participant = {
     signedAtUtc?: Date;
     signedBy?: {
         userName: string;
+        firstName: string;
+        lastName: string;
     };
     note: string;
     attended: boolean;


### PR DESCRIPTION
# Description

Changed the "signed by" value in the participants table to the name of the user instead of the shortname.
Removed tests for rendering of signed by value, as they don't add anything useful. (The way we write tests should be redone in this repo to be more like in the apps.)

Changed to using the id given in the participant in the get invitations/{id} endpoint, as the id used (on person, role or external email) is deprecated.

Added type checking on error in catch in the EditIPO file. This is needed after a change in typescript. If you don't like the way this was handled, or you know of an even better way then leave a comment.

Completes: [AB#89019](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/89019)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
