### PR TITLE
Bug/89634 failed to load remote configuration

### DIFF
--- a/src/auth/AuthService.tsx
+++ b/src/auth/AuthService.tsx
@@ -1,4 +1,4 @@
-import { Configuration, UserAgentApplication } from 'msal';
+import { AuthError, Configuration, UserAgentApplication } from 'msal';
 
 import AuthUser from './AuthUser';
 import ProCoSysSettings from '@procosys/core/ProCoSysSettings';
@@ -96,6 +96,10 @@ export default class AuthService implements IAuthService {
                 expiresAt: response.expiresOn,
             };
         } catch (authError) {
+            if (!(authError instanceof AuthError)) {
+                //throw 'Unknown error in getAccessToken';
+                console.log('Unknown error in getAccessToken'); // TODO: remove once bug is fixed
+            }
             // Normally, 'login_required' should be handled with a login call
             // But due to 3rd party cookie blocking, from Safari
             // the user always gets this response on a silent request, so we need to handle
@@ -108,7 +112,9 @@ export default class AuthService implements IAuthService {
                     'login_required',
                 ].indexOf(authError.errorCode) !== -1
             ) {
+                console.log('Consent issue'); // TODO: remove once bug is fixed
                 this.aquireConcent(resource);
+                console.log('Consent accuired'); // TODO: remove once bug is fixed
             }
         }
         throw 'Failed to login';

--- a/src/core/ProCoSysSettings.ts
+++ b/src/core/ProCoSysSettings.ts
@@ -166,7 +166,7 @@ class ProCoSysSettings {
         } catch (error) {
             this.authConfigState = AsyncState.ERROR;
             console.error(
-                'Failed to load configuration from remote source',
+                'Failed to load auth configuration from remote source',
                 error
             );
         }


### PR DESCRIPTION
# Description

Added some console logs. They are a way to check a few things during debugging on mobile.
Also changed an error message to be able to differentiate between config and auth config errors.

Completes: [AB#89634](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/89634)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
