### PR TITLE
Feature/89436 admins can unsign all signatures

### DIFF
--- a/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
+++ b/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
@@ -54,7 +54,7 @@ type ParticipantInvitationResponse = {
     id: number;
     organization: string;
     sortKey: number;
-    canSign: boolean;
+    isSigner: boolean;
     rowVersion: string;
     externalEmail: ExternalEmailInvitationResponse;
     person: PersonInvitationResponse;

--- a/src/modules/InvitationForPunchOut/types.d.ts
+++ b/src/modules/InvitationForPunchOut/types.d.ts
@@ -50,7 +50,7 @@ type ExternalEmail = {
 };
 
 export type Participant = {
-    id?: number; // TODO: make optional
+    id?: number;
     organization: SelectItem;
     sortKey: number | null;
     type: string;

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtons.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtons.tsx
@@ -134,7 +134,7 @@ const SignatureButtons = ({
     switch (participant.organization) {
         case OrganizationsEnum.Contractor:
             if (participant.sortKey === 0) {
-                if (participant.canSign && status === IpoStatusEnum.PLANNED) {
+                if (participant.isSigner && status === IpoStatusEnum.PLANNED) {
                     return (
                         <SignatureButtonWithTooltip
                             name={'Complete punch-out'}
@@ -151,19 +151,19 @@ const SignatureButtons = ({
                         />
                     );
                 } else if (
-                    (participant.canSign || isUsingAdminRights) &&
+                    (participant.isSigner || isUsingAdminRights) &&
                     status === IpoStatusEnum.COMPLETED
                 ) {
                     return getUnCompleteAndUpdateParticipantsButtons();
                 }
             } else {
                 if (
-                    (participant.canSign || isUsingAdminRights) &&
+                    (participant.isSigner || isUsingAdminRights) &&
                     participant.signedBy
                 ) {
                     return getUnsignButton();
                 } else if (
-                    participant.canSign &&
+                    participant.isSigner &&
                     status !== IpoStatusEnum.CANCELED
                 ) {
                     return getSignButton();
@@ -173,7 +173,7 @@ const SignatureButtons = ({
         case OrganizationsEnum.ConstructionCompany:
             if (participant.sortKey === 1) {
                 if (
-                    (participant.canSign || isUsingAdminRights) &&
+                    (participant.isSigner || isUsingAdminRights) &&
                     status === IpoStatusEnum.ACCEPTED
                 ) {
                     return (
@@ -188,7 +188,7 @@ const SignatureButtons = ({
                         />
                     );
                 } else if (
-                    participant.canSign &&
+                    participant.isSigner &&
                     status === IpoStatusEnum.COMPLETED
                 ) {
                     return (
@@ -209,11 +209,11 @@ const SignatureButtons = ({
                 }
             } else {
                 if (
-                    (participant.canSign || isUsingAdminRights) &&
+                    (participant.isSigner || isUsingAdminRights) &&
                     participant.signedBy
                 ) {
                     return getUnsignButton();
-                } else if (participant.canSign) {
+                } else if (participant.isSigner) {
                     return getSignButton();
                 }
             }
@@ -222,11 +222,11 @@ const SignatureButtons = ({
         case OrganizationsEnum.TechnicalIntegrity:
         case OrganizationsEnum.Commissioning:
             if (
-                (participant.canSign || isUsingAdminRights) &&
+                (participant.isSigner || isUsingAdminRights) &&
                 participant.signedBy
             ) {
                 return getUnsignButton();
-            } else if (participant.canSign) {
+            } else if (participant.isSigner) {
                 return getSignButton();
             }
     }

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtons.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/Buttons/SignatureButtons.tsx
@@ -40,6 +40,7 @@ interface SignatureButtonsProps {
     uncomplete: (p: Participant) => Promise<any>;
     unsign: (p: Participant) => Promise<any>;
     canUpdate: boolean;
+    isUsingAdminRights: boolean;
 }
 
 const SignatureButtons = ({
@@ -57,6 +58,7 @@ const SignatureButtons = ({
     uncomplete,
     unsign,
     canUpdate,
+    isUsingAdminRights,
 }: SignatureButtonsProps): JSX.Element => {
     const handleButtonClick = async (
         buttonAction: () => Promise<any>
@@ -149,13 +151,16 @@ const SignatureButtons = ({
                         />
                     );
                 } else if (
-                    participant.canSign &&
+                    (participant.canSign || isUsingAdminRights) &&
                     status === IpoStatusEnum.COMPLETED
                 ) {
                     return getUnCompleteAndUpdateParticipantsButtons();
                 }
             } else {
-                if (participant.signedBy) {
+                if (
+                    (participant.canSign || isUsingAdminRights) &&
+                    participant.signedBy
+                ) {
                     return getUnsignButton();
                 } else if (
                     participant.canSign &&
@@ -167,7 +172,10 @@ const SignatureButtons = ({
             break;
         case OrganizationsEnum.ConstructionCompany:
             if (participant.sortKey === 1) {
-                if (participant.canSign && status === IpoStatusEnum.ACCEPTED) {
+                if (
+                    (participant.canSign || isUsingAdminRights) &&
+                    status === IpoStatusEnum.ACCEPTED
+                ) {
                     return (
                         <SignatureButton
                             name={'Unaccept punch-out'}
@@ -200,7 +208,10 @@ const SignatureButtons = ({
                     );
                 }
             } else {
-                if (participant.signedBy) {
+                if (
+                    (participant.canSign || isUsingAdminRights) &&
+                    participant.signedBy
+                ) {
                     return getUnsignButton();
                 } else if (participant.canSign) {
                     return getSignButton();
@@ -210,10 +221,12 @@ const SignatureButtons = ({
         case OrganizationsEnum.Operation:
         case OrganizationsEnum.TechnicalIntegrity:
         case OrganizationsEnum.Commissioning:
-            if (!participant.canSign) break;
-            if (participant.signedBy) {
+            if (
+                (participant.canSign || isUsingAdminRights) &&
+                participant.signedBy
+            ) {
                 return getUnsignButton();
-            } else {
+            } else if (participant.canSign) {
                 return getSignButton();
             }
     }

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/__tests__/ParticipantsTable.test.jsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/__tests__/ParticipantsTable.test.jsx
@@ -26,7 +26,7 @@ const participants = [
     {
         id: 0,
         organization: OrganizationsEnum.External,
-        canSign: false,
+        isSigner: false,
         sortKey: 2,
         person: null,
         functionalRole: null,
@@ -43,7 +43,7 @@ const participants = [
         id: 1,
         organization: OrganizationsEnum.TechnicalIntegrity,
         sortKey: 3,
-        canSign: false,
+        isSigner: false,
         person: null,
         functionalRole: {
             code: 'asdasdasd',
@@ -63,7 +63,7 @@ const participants = [
         id: 123,
         organization: OrganizationsEnum.Contractor,
         sortKey: 0,
-        canSign: false,
+        isSigner: false,
         person: {
             firstName: 'Adwa',
             lastName: 'ASdsklandasnd',
@@ -93,7 +93,7 @@ const participants = [
         id: 234,
         organization: OrganizationsEnum.ConstructionCompany,
         sortKey: 1,
-        canSign: false,
+        isSigner: false,
         person: {
             firstName: 'Oakjfcv',
             lastName: 'Alkjljsdf',
@@ -123,7 +123,7 @@ const participants = [
         id: 12,
         organization: OrganizationsEnum.Contractor,
         sortKey: 4,
-        canSign: false,
+        isSigner: false,
         externalEmail: null,
         person: null,
         functionalRole: {
@@ -164,7 +164,7 @@ const participants_canSign = [
     {
         organization: OrganizationsEnum.Contractor,
         sortKey: 0,
-        canSign: true,
+        isSigner: true,
         person: {
             id: 123,
             firstName: 'Adwa',
@@ -194,7 +194,7 @@ const participants_canSign = [
     {
         organization: OrganizationsEnum.ConstructionCompany,
         sortKey: 1,
-        canSign: true,
+        isSigner: true,
         person: {
             id: 234,
             firstName: 'Oakjfcv',
@@ -253,6 +253,7 @@ describe('<ParticipantsTable />', () => {
                 status={IpoStatusEnum.ACCEPTED}
                 accept={acceptPunchOut}
                 complete={completePunchOut}
+                isUsingAdminRights={false}
             />
         );
 
@@ -290,6 +291,7 @@ describe('<ParticipantsTable />', () => {
                 status={IpoStatusEnum.PLANNED}
                 accept={acceptPunchOut}
                 complete={completePunchOut}
+                isUsingAdminRights={false}
             />
         );
 
@@ -312,7 +314,7 @@ describe('<ParticipantsTable />', () => {
             ...participants[ParticipantIndex.FUNCROLE],
             signedAtUtc: null,
             signedBy: null,
-            canSign: true,
+            isSigner: true,
         };
         newParticipants[ParticipantIndex.COMPLETER] = {
             ...participants[ParticipantIndex.COMPLETER],
@@ -330,6 +332,7 @@ describe('<ParticipantsTable />', () => {
                 status={IpoStatusEnum.PLANNED}
                 accept={acceptPunchOut}
                 complete={completePunchOut}
+                isUsingAdminRights={false}
             />
         );
 
@@ -347,7 +350,7 @@ describe('<ParticipantsTable />', () => {
             ...participants[ParticipantIndex.COMPLETER],
             signedAtUtc: null,
             signedBy: null,
-            canSign: true,
+            isSigner: true,
         };
         newParticipants[ParticipantIndex.ACCEPTER] = {
             ...participants[ParticipantIndex.ACCEPTER],
@@ -365,6 +368,7 @@ describe('<ParticipantsTable />', () => {
                 status={IpoStatusEnum.PLANNED}
                 accept={acceptPunchOut}
                 complete={completePunchOut}
+                isUsingAdminRights={false}
             />
         );
 
@@ -383,7 +387,7 @@ describe('<ParticipantsTable />', () => {
         const newParticipants = [...participants];
         newParticipants[ParticipantIndex.COMPLETER] = {
             ...participants[ParticipantIndex.COMPLETER],
-            canSign: true,
+            isSigner: true,
         };
         newParticipants[ParticipantIndex.ACCEPTER] = {
             ...participants[ParticipantIndex.ACCEPTER],
@@ -401,6 +405,7 @@ describe('<ParticipantsTable />', () => {
                 status={IpoStatusEnum.COMPLETED}
                 accept={acceptPunchOut}
                 complete={completePunchOut}
+                isUsingAdminRights={false}
             />
         );
 
@@ -433,7 +438,7 @@ describe('<ParticipantsTable />', () => {
             ...participants[ParticipantIndex.ACCEPTER],
             signedAtUtc: null,
             signedBy: null,
-            canSign: true,
+            isSigner: true,
         };
         newParticipants[ParticipantIndex.FUNCROLE] = {
             ...participants[ParticipantIndex.FUNCROLE],
@@ -446,6 +451,7 @@ describe('<ParticipantsTable />', () => {
                 status={IpoStatusEnum.COMPLETED}
                 accept={acceptPunchOut}
                 complete={completePunchOut}
+                isUsingAdminRights={false}
             />
         );
         await waitFor(() => {
@@ -482,7 +488,7 @@ describe('<ParticipantsTable />', () => {
             ...participants[ParticipantIndex.FUNCROLE],
             signedAtUtc: null,
             signedBy: null,
-            canSign: true,
+            isSigner: true,
         };
         const { queryByText } = renderWithTheme(
             <ParticipantsTable
@@ -490,6 +496,7 @@ describe('<ParticipantsTable />', () => {
                 status={IpoStatusEnum.COMPLETED}
                 accept={acceptPunchOut}
                 complete={completePunchOut}
+                isUsingAdminRights={false}
             />
         );
         expect(queryByText('Update')).not.toBeInTheDocument();
@@ -509,7 +516,7 @@ describe('<ParticipantsTable />', () => {
         const newParticipants = [...participants];
         newParticipants[ParticipantIndex.COMPLETER] = {
             ...participants[ParticipantIndex.COMPLETER],
-            canSign: true,
+            isSigner: true,
         };
         newParticipants[ParticipantIndex.ACCEPTER] = {
             ...participants[ParticipantIndex.ACCEPTER],
@@ -525,6 +532,7 @@ describe('<ParticipantsTable />', () => {
                 status={IpoStatusEnum.ACCEPTED}
                 accept={acceptPunchOut}
                 complete={completePunchOut}
+                isUsingAdminRights={false}
             />
         );
 
@@ -553,7 +561,7 @@ describe('<ParticipantsTable />', () => {
         const newParticipants = [...participants];
         newParticipants[ParticipantIndex.ACCEPTER] = {
             ...participants[ParticipantIndex.ACCEPTER],
-            canSign: true,
+            isSigner: true,
         };
         newParticipants[ParticipantIndex.FUNCROLE] = {
             ...participants[ParticipantIndex.FUNCROLE],
@@ -566,6 +574,7 @@ describe('<ParticipantsTable />', () => {
                 status={IpoStatusEnum.ACCEPTED}
                 accept={acceptPunchOut}
                 complete={completePunchOut}
+                isUsingAdminRights={false}
             />
         );
 
@@ -596,7 +605,7 @@ describe('<ParticipantsTable />', () => {
             ...participants[ParticipantIndex.FUNCROLE],
             signedAtUtc: null,
             signedBy: null,
-            canSign: true,
+            isSigner: true,
         };
         const { queryByText } = renderWithTheme(
             <ParticipantsTable
@@ -604,6 +613,7 @@ describe('<ParticipantsTable />', () => {
                 status={IpoStatusEnum.ACCEPTED}
                 accept={acceptPunchOut}
                 complete={completePunchOut}
+                isUsingAdminRights={false}
             />
         );
         expect(queryByText('Update')).not.toBeInTheDocument();
@@ -631,7 +641,7 @@ describe('<ParticipantsTable />', () => {
         const newParticipants = [...participants];
         newParticipants[ParticipantIndex.COMPLETER] = {
             ...participants[ParticipantIndex.COMPLETER],
-            canSign: true,
+            isSigner: true,
         };
         const { queryByText } = renderWithTheme(
             <ParticipantsTable
@@ -639,6 +649,7 @@ describe('<ParticipantsTable />', () => {
                 status="Canceled"
                 accept={acceptPunchOut}
                 complete={completePunchOut}
+                isUsingAdminRights={false}
             />
         );
 
@@ -656,6 +667,7 @@ describe('<ParticipantsTable />', () => {
                 status="Canceled"
                 accept={acceptPunchOut}
                 complete={completePunchOut}
+                isUsingAdminRights={false}
             />
         );
 
@@ -673,6 +685,7 @@ describe('<ParticipantsTable />', () => {
                 status="Planned"
                 accept={acceptPunchOut}
                 complete={completePunchOut}
+                isUsingAdminRights={false}
             />
         );
 
@@ -687,6 +700,7 @@ describe('<ParticipantsTable />', () => {
                 status="Completed"
                 accept={acceptPunchOut}
                 complete={completePunchOut}
+                isUsingAdminRights={false}
             />
         );
 
@@ -701,6 +715,7 @@ describe('<ParticipantsTable />', () => {
                 status="Planned"
                 accept={acceptPunchOut}
                 complete={completePunchOut}
+                isUsingAdminRights={false}
             />
         );
 
@@ -723,6 +738,7 @@ describe('<ParticipantsTable />', () => {
                 status="Planned"
                 accept={acceptPunchOut}
                 complete={completePunchOut}
+                isUsingAdminRights={false}
             />
         );
 
@@ -745,6 +761,7 @@ describe('<ParticipantsTable />', () => {
                 status="Planned"
                 accept={acceptPunchOut}
                 complete={completePunchOut}
+                isUsingAdminRights={false}
             />
         );
 
@@ -777,6 +794,7 @@ describe('<ParticipantsTable />', () => {
                 status={IpoStatusEnum.COMPLETED}
                 accept={acceptPunchOut}
                 complete={completePunchOut}
+                isUsingAdminRights={false}
             />
         );
         expect(queryByText('Accept punch-out')).toBeInTheDocument();
@@ -789,6 +807,7 @@ describe('<ParticipantsTable />', () => {
                 status={IpoStatusEnum.ACCEPTED}
                 accept={acceptPunchOut}
                 complete={completePunchOut}
+                isUsingAdminRights={false}
             />
         );
         expect(queryByText('Unaccept punch-out')).toBeInTheDocument();
@@ -802,6 +821,7 @@ describe('<ParticipantsTable />', () => {
                     status={IpoStatusEnum.ACCEPTED}
                     accept={acceptPunchOut}
                     complete={completePunchOut}
+                    isUsingAdminRights={false}
                 />
             );
             participants.forEach((participant) => {
@@ -821,6 +841,7 @@ describe('<ParticipantsTable />', () => {
                     status={IpoStatusEnum.ACCEPTED}
                     accept={acceptPunchOut}
                     complete={completePunchOut}
+                    isUsingAdminRights={false}
                 />
             );
             participants.forEach((participant) => {
@@ -843,6 +864,7 @@ describe('<ParticipantsTable />', () => {
                     status={IpoStatusEnum.ACCEPTED}
                     accept={acceptPunchOut}
                     complete={completePunchOut}
+                    isUsingAdminRights={false}
                 />
             );
             participants.forEach((participant) => {
@@ -857,6 +879,51 @@ describe('<ParticipantsTable />', () => {
                     expect(anchor).toBeInTheDocument();
                 }
             });
+        });
+    });
+
+    describe('<ParticipantsTable /> admin mode', () => {
+        afterEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it('Admin can unaccept', async () => {
+            const { queryByText } = renderWithTheme(
+                <ParticipantsTable
+                    participants={participants}
+                    status={IpoStatusEnum.ACCEPTED}
+                    accept={acceptPunchOut}
+                    complete={completePunchOut}
+                    isUsingAdminRights={true}
+                />
+            );
+            expect(queryByText('Unaccept punch-out')).toBeInTheDocument();
+        });
+
+        it('Admin can unSign', async () => {
+            const { queryByText } = renderWithTheme(
+                <ParticipantsTable
+                    participants={participants}
+                    status={IpoStatusEnum.ACCEPTED}
+                    accept={acceptPunchOut}
+                    complete={completePunchOut}
+                    isUsingAdminRights={true}
+                />
+            );
+            expect(queryByText('Unsign punch-out')).toBeInTheDocument();
+        });
+
+        it('Admin can uncomplete', async () => {
+            const { queryByText } = renderWithTheme(
+                <ParticipantsTable
+                    participants={participants}
+                    status={IpoStatusEnum.COMPLETED}
+                    accept={acceptPunchOut}
+                    complete={completePunchOut}
+                    isUsingAdminRights={true}
+                />
+            );
+            expect(queryByText('Uncomplete')).toBeInTheDocument();
         });
     });
 });

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
@@ -67,7 +67,7 @@ const ParticipantsTable = ({
     const { setDirtyStateFor, unsetDirtyStateFor } = useDirtyContext();
 
     useEffect(() => {
-        const participant = participants.find((p) => p.canSign);
+        const participant = participants.find((p) => p.isSigner);
         if (
             participant &&
             participant.sortKey === 0 &&

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/index.tsx
@@ -42,6 +42,7 @@ interface ParticipantsTableProps {
     unaccept: (p: Participant) => Promise<any>;
     uncomplete: (p: Participant) => Promise<any>;
     unsign: (p: Participant) => Promise<any>;
+    isUsingAdminRights: boolean;
 }
 
 const ParticipantsTable = ({
@@ -54,6 +55,7 @@ const ParticipantsTable = ({
     unaccept,
     uncomplete,
     unsign,
+    isUsingAdminRights,
 }: ParticipantsTableProps): JSX.Element => {
     const [loading, setLoading] = useState<boolean>(false);
     const [editAttendedDisabled, setEditAttendedDisabled] =
@@ -133,7 +135,8 @@ const ParticipantsTable = ({
             status: string,
             canUpdate: boolean,
             attNoteData: AttNoteData[],
-            loading: boolean
+            loading: boolean,
+            isUsingAdminRights
         ): JSX.Element => (
             <SignatureButtons
                 participant={participant}
@@ -150,6 +153,7 @@ const ParticipantsTable = ({
                 uncomplete={uncomplete}
                 unsign={unsign}
                 canUpdate={canUpdate}
+                isUsingAdminRights={isUsingAdminRights}
             />
         ),
         [status]
@@ -398,7 +402,8 @@ const ParticipantsTable = ({
                                                 status,
                                                 canUpdate,
                                                 attNoteData,
-                                                loading
+                                                loading,
+                                                isUsingAdminRights
                                             )}
                                         </Typography>
                                     </Table.Cell>

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/index.tsx
@@ -25,6 +25,7 @@ interface GeneralInfoProps {
     unaccept: (p: Participant) => Promise<any>;
     uncomplete: (p: Participant) => Promise<any>;
     unsign: (p: Participant) => Promise<any>;
+    isUsingAdminRights: boolean;
 }
 
 const GeneralInfo = ({
@@ -36,6 +37,7 @@ const GeneralInfo = ({
     unaccept,
     uncomplete,
     unsign,
+    isUsingAdminRights,
 }: GeneralInfoProps): JSX.Element => {
     const [participants, setParticipants] = useState<Participant[]>([]);
 
@@ -138,6 +140,7 @@ const GeneralInfo = ({
                 unaccept={unaccept}
                 uncomplete={uncomplete}
                 unsign={unsign}
+                isUsingAdminRights={isUsingAdminRights}
             />
         </Container>
     );

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/ViewIPOHeader.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/ViewIPOHeader.tsx
@@ -14,7 +14,7 @@ import { Participant } from './types';
 import ProgressBar from '@procosys/components/ProgressBar';
 import { Step } from '../../types';
 import { showModalDialog } from '@procosys/core/services/ModalDialogService';
-import { tokens } from '@equinor/eds-tokens';
+import { Switch } from '@equinor/eds-core-react';
 
 type ProgressBarProps = {
     ipoId: number;
@@ -27,9 +27,26 @@ type ProgressBarProps = {
     showEditButton: boolean;
     isCancelable: boolean;
     cancelPunchOut: () => void;
+    isAdmin: boolean;
+    isUsingAdminRights: boolean;
+    setIsUsingAdminRights: (b: React.SetStateAction<boolean>) => void;
 };
 
-const ViewIPOHeader = (props: ProgressBarProps): JSX.Element => {
+const ViewIPOHeader = ({
+    ipoId,
+    steps,
+    currentStep,
+    title,
+    participants,
+    organizer,
+    isEditable,
+    showEditButton,
+    isCancelable,
+    cancelPunchOut,
+    isAdmin,
+    isUsingAdminRights,
+    setIsUsingAdminRights,
+}: ProgressBarProps): JSX.Element => {
     const confirmCancelIpo = (): void => {
         showModalDialog(
             'Cancel IPO',
@@ -41,7 +58,7 @@ const ViewIPOHeader = (props: ProgressBarProps): JSX.Element => {
             'No',
             null,
             'Yes',
-            props.cancelPunchOut,
+            cancelPunchOut,
             true
         );
     };
@@ -50,22 +67,22 @@ const ViewIPOHeader = (props: ProgressBarProps): JSX.Element => {
         <Container>
             <HeaderContainer>
                 <ButtonContainer>
-                    <Typography variant="h2">{`IPO-${props.ipoId}: ${props.title}`}</Typography>
+                    <Typography variant="h2">{`IPO-${ipoId}: ${title}`}</Typography>
                 </ButtonContainer>
                 <ButtonContainer>
                     <Button
-                        disabled={!props.isCancelable}
+                        disabled={!isCancelable}
                         variant="outlined"
                         onClick={(): void => confirmCancelIpo()}
                     >
                         <EdsIcon name="calendar_reject" /> Cancel IPO
                     </Button>
-                    {props.showEditButton && (
+                    {showEditButton && (
                         <>
                             <ButtonSpacer />
-                            <Link to={`/EditIPO/${props.ipoId}`}>
+                            <Link to={`/EditIPO/${ipoId}`}>
                                 <Button
-                                    disabled={!props.isEditable}
+                                    disabled={!isEditable}
                                     variant="outlined"
                                 >
                                     <EdsIcon name="edit" /> Edit
@@ -73,13 +90,25 @@ const ViewIPOHeader = (props: ProgressBarProps): JSX.Element => {
                             </Link>
                         </>
                     )}
+                    {isAdmin && (
+                        <>
+                            <ButtonSpacer />
+                            <Switch
+                                default
+                                checked={isUsingAdminRights}
+                                onChange={(): void =>
+                                    setIsUsingAdminRights(
+                                        (prevValue: boolean) => !prevValue
+                                    )
+                                }
+                                label={'Admin mode'}
+                            />
+                        </>
+                    )}
                 </ButtonContainer>
             </HeaderContainer>
             <ProgressBarContainer>
-                <ProgressBar
-                    steps={props.steps}
-                    currentStep={props.currentStep}
-                />
+                <ProgressBar steps={steps} currentStep={currentStep} />
             </ProgressBarContainer>
         </Container>
     );

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
@@ -506,6 +506,9 @@ const ViewIPO = (): JSX.Element => {
                                                 unaccept={unacceptPunchOut}
                                                 uncomplete={uncompletePunchOut}
                                                 unsign={unsignPunchOut}
+                                                isUsingAdminRights={
+                                                    isUsingAdminRights
+                                                }
                                             />
                                         </Tabs.Panel>
                                         <Tabs.Panel>

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
@@ -1,5 +1,6 @@
 import {
     AcceptIPODto,
+    IpoApiError,
     SignIPODto,
 } from '../../http/InvitationForPunchOutApiClient';
 import {
@@ -162,6 +163,7 @@ const ViewIPO = (): JSX.Element => {
             );
             setInvitation(response);
         } catch (error) {
+            if (!(error instanceof IpoApiError)) return;
             console.error(error.message, error.data);
             showSnackbarNotification(error.message);
         }
@@ -177,6 +179,7 @@ const ViewIPO = (): JSX.Element => {
             );
             setComments(response);
         } catch (error) {
+            if (!(error instanceof IpoApiError)) return;
             console.error(error.message, error.data);
             showSnackbarNotification(error.message);
         }
@@ -207,6 +210,7 @@ const ViewIPO = (): JSX.Element => {
                 });
             await getComments();
         } catch (error) {
+            if (!(error instanceof IpoApiError)) return;
             console.error(error.message, error.data);
             showSnackbarNotification(error.message);
         }
@@ -253,6 +257,7 @@ const ViewIPO = (): JSX.Element => {
             await getInvitation();
             showSnackbarNotification('Participants updated');
         } catch (error) {
+            if (!(error instanceof IpoApiError)) return;
             console.error(error.message, error.data);
             showSnackbarNotification(error.message);
         }
@@ -283,6 +288,7 @@ const ViewIPO = (): JSX.Element => {
             await getInvitation();
             showSnackbarNotification('Punch-out completed');
         } catch (error) {
+            if (!(error instanceof IpoApiError)) return;
             console.error(error.message, error.data);
             showSnackbarNotification(error.message);
         }
@@ -312,6 +318,7 @@ const ViewIPO = (): JSX.Element => {
             await getInvitation();
             showSnackbarNotification('Punch-out uncompleted');
         } catch (error) {
+            if (!(error instanceof IpoApiError)) return;
             console.error(error.message, error.data);
             showSnackbarNotification(error.message);
         }
@@ -343,6 +350,7 @@ const ViewIPO = (): JSX.Element => {
             await getInvitation();
             showSnackbarNotification('Punch-out accepted');
         } catch (error) {
+            if (!(error instanceof IpoApiError)) return;
             console.error(error.message, error.data);
             showSnackbarNotification(error.message);
         }
@@ -370,6 +378,7 @@ const ViewIPO = (): JSX.Element => {
             await getInvitation();
             showSnackbarNotification('Punch-out unaccepted');
         } catch (error) {
+            if (!(error instanceof IpoApiError)) return;
             console.error(error.message, error.data);
             showSnackbarNotification(error.message);
         }
@@ -398,6 +407,7 @@ const ViewIPO = (): JSX.Element => {
             await getInvitation();
             showSnackbarNotification('Punch-out signed');
         } catch (error) {
+            if (!(error instanceof IpoApiError)) return;
             console.error(error.message, error.data);
             showSnackbarNotification(error.message);
         }
@@ -425,6 +435,7 @@ const ViewIPO = (): JSX.Element => {
             await getInvitation();
             showSnackbarNotification('Punch-out unsigned');
         } catch (error) {
+            if (!(error instanceof IpoApiError)) return;
             console.error(error.message, error.data);
             showSnackbarNotification(error.message);
         }
@@ -446,6 +457,7 @@ const ViewIPO = (): JSX.Element => {
                     'Invitation for punch-out is cancelled.'
                 );
             } catch (error) {
+                if (!(error instanceof IpoApiError)) return;
                 console.error(error.message, error.data);
                 showSnackbarNotification(error.message);
             }

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
@@ -148,9 +148,7 @@ const ViewIPO = (): JSX.Element => {
     }, [invitation]);
 
     useEffect(() => {
-        // TODO: change to actual value
-        //setIsAdmin(permissions.includes('IPO/ADMIN'));
-        setIsAdmin(true);
+        setIsAdmin(permissions.includes('IPO/ADMIN'));
     });
 
     const getInvitation = async (

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
@@ -14,7 +14,7 @@ import {
 } from './index.style';
 import { Invitation, IpoComment, Participant } from './types';
 import { IpoCustomEvents, IpoStatusEnum } from '../enums';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Tabs, Typography } from '@equinor/eds-core-react';
 
 import { AttNoteData } from './GeneralInfo/ParticipantsTable';
@@ -34,6 +34,7 @@ import { tokens } from '@equinor/eds-tokens';
 import { useAnalytics } from '@procosys/core/services/Analytics/AnalyticsContext';
 import { useInvitationForPunchOutContext } from '../../context/InvitationForPunchOutContext';
 import { useParams } from 'react-router-dom';
+import { useCurrentPlant } from '@procosys/core/PlantContext';
 
 const initialSteps: Step[] = [
     { title: 'Invitation for punch-out sent', isCompleted: true },
@@ -68,6 +69,10 @@ const ViewIPO = (): JSX.Element => {
     const [comments, setComments] = useState<IpoComment[]>([]);
     const [loadingComments, setLoadingComments] = useState<boolean>(false);
     const analytics = useAnalytics();
+    const [isUsingAdminRights, setIsUsingAdminRights] =
+        useState<boolean>(false);
+    const [isAdmin, setIsAdmin] = useState<boolean>(false);
+    const { permissions } = useCurrentPlant();
 
     const moduleContainerRef = useRef<HTMLDivElement>(null);
 
@@ -140,6 +145,12 @@ const ViewIPO = (): JSX.Element => {
             }
         }
     }, [invitation]);
+
+    useEffect(() => {
+        // TODO: change to actual value
+        //setIsAdmin(permissions.includes('IPO/ADMIN'));
+        setIsAdmin(true);
+    });
 
     const getInvitation = async (
         requestCanceller?: (cancelCallback: Canceler) => void
@@ -463,6 +474,9 @@ const ViewIPO = (): JSX.Element => {
                             invitation.status == IpoStatusEnum.COMPLETED
                         }
                         cancelPunchOut={cancelPunchOut}
+                        isAdmin={isAdmin}
+                        isUsingAdminRights={isUsingAdminRights}
+                        setIsUsingAdminRights={setIsUsingAdminRights}
                     />
                     <InvitationContentContainer>
                         <TabsContainer>

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/types.d.ts
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/types.d.ts
@@ -16,7 +16,7 @@ type Participant = {
     id: number;
     organization: string;
     sortKey: number;
-    canSign: boolean;
+    isSigner: boolean;
     rowVersion: string;
     externalEmail: ExternalEmail;
     person: Person;


### PR DESCRIPTION
# Description

Allowing admins to unsign, uncomplete and unaccept IPOs when the newly added admin mode toggle is turned on.

Is a draft until back end is finished.

Completes: [AB#89436](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/89436)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [x] My code is covered by tests.
