### PR TITLE
Show/hide IPO-cancel based on canCancel attr.

### DIFF
--- a/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
+++ b/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
@@ -16,6 +16,7 @@ export class IpoApiError extends ProCoSysApiError {
 
 type InvitationResponse = {
     canEdit: boolean;
+    canCancel: boolean;
     projectName: string;
     title: string;
     description: string;
@@ -373,7 +374,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             );
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -396,7 +397,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             );
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -430,7 +431,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             );
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -460,7 +461,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             );
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -483,7 +484,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             );
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -504,7 +505,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             const result = await this.client.get(endpoint, settings);
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -549,7 +550,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             );
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -595,7 +596,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             );
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -616,7 +617,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             const result = await this.client.get(endpoint, settings);
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -644,7 +645,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             );
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -664,7 +665,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             const result = await this.client.get(endpoint, settings);
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -685,7 +686,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             const result = await this.client.get(endpoint, settings);
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -707,7 +708,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             const result = await this.client.get(endpoint, settings);
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -732,7 +733,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             });
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -765,7 +766,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             const result = await this.client.post(endpoint, formData, settings);
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -793,7 +794,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             );
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -821,7 +822,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             );
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -852,7 +853,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             );
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -879,7 +880,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             });
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -909,7 +910,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             );
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -936,7 +937,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             });
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -959,7 +960,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             });
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -985,7 +986,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             });
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -1010,7 +1011,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             );
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -1035,7 +1036,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
                 settings
             );
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -1063,7 +1064,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             );
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
     /**
@@ -1094,7 +1095,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
                 settings
             );
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -1126,7 +1127,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
                 settings
             );
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -1148,7 +1149,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
                 data: { rowVersion: rowVersion },
             });
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 
@@ -1186,7 +1187,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
             const result = await this.client.get<BlobPart>(endpoint, settings);
             return result.data;
         } catch (error) {
-            throw new IpoApiError(error);
+            throw new IpoApiError(error as AxiosError);
         }
     }
 }

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/__tests__/EditIPO.test.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/__tests__/EditIPO.test.tsx
@@ -1,10 +1,19 @@
-import { configure, render, waitFor } from '@testing-library/react';
+import { configure, getByText, render, waitFor } from '@testing-library/react';
 
 import EditIPO from '../EditIPO';
 import { Invitation } from '../../ViewIPO/types';
 import React from 'react';
+import { act } from 'react-dom/test-utils';
+import ViewIPOHeader from '../../ViewIPO/ViewIPOHeader';
+import { Step } from '@procosys/modules/InvitationForPunchOut/types';
 
 configure({ testIdAttribute: 'id' }); // makes id attibute data-testid for subsequent tests
+
+const initialSteps: Step[] = [
+    { title: 'Invitation for punch-out sent', isCompleted: true },
+    { title: 'Punch-out completed', isCompleted: false },
+    { title: 'Punch-out accepted by company', isCompleted: false },
+];
 
 const mockRoles = [
     {
@@ -26,6 +35,7 @@ const mockRoles = [
 
 const mockInvitation: Invitation = {
     canEdit: false,
+    canCancel: true,
     projectName: 'projectName',
     title: 'titleA',
     description: 'descriptionA',
@@ -126,5 +136,57 @@ describe('<EditIPO />', () => {
             expect(getByLabelText('Start')).toHaveValue('00:57')
         );
         await waitFor(() => expect(getByLabelText('End')).toHaveValue('00:59'));
+    });
+
+    it('Should not display "Cancel IPO"-button when canCancel is false', async () => {
+        const { queryByText } = render(
+            <ViewIPOHeader
+                ipoId={1}
+                steps={initialSteps}
+                currentStep={1}
+                title={'test'}
+                organizer="test"
+                participants={[]}
+                isEditable={true}
+                showEditButton={true}
+                canCancel={false}
+                cancelPunchOut={(): void => {
+                    /*mock*/
+                }}
+                isAdmin={false}
+                isUsingAdminRights={false}
+                setIsUsingAdminRights={(): void => {
+                    /*mock*/
+                }}
+            />
+        );
+
+        expect(queryByText('Cancel IPO')).not.toBeInTheDocument();
+    });
+
+    it('Should display "Cancel IPO"-button when canCancel is true', async () => {
+        const { queryByText } = render(
+            <ViewIPOHeader
+                ipoId={1}
+                steps={initialSteps}
+                currentStep={1}
+                title={'test'}
+                organizer="test"
+                participants={[]}
+                isEditable={true}
+                showEditButton={true}
+                canCancel={true}
+                cancelPunchOut={(): void => {
+                    /*mock*/
+                }}
+                isAdmin={false}
+                isUsingAdminRights={false}
+                setIsUsingAdminRights={(): void => {
+                    /*mock*/
+                }}
+            />
+        );
+
+        expect(queryByText('Cancel IPO')).toBeInTheDocument();
     });
 });

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/ViewIPOHeader.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/ViewIPOHeader.tsx
@@ -25,7 +25,7 @@ type ProgressBarProps = {
     organizer: string;
     isEditable: boolean;
     showEditButton: boolean;
-    isCancelable: boolean;
+    canCancel: boolean;
     cancelPunchOut: () => void;
     isAdmin: boolean;
     isUsingAdminRights: boolean;
@@ -41,7 +41,7 @@ const ViewIPOHeader = ({
     organizer,
     isEditable,
     showEditButton,
-    isCancelable,
+    canCancel,
     cancelPunchOut,
     isAdmin,
     isUsingAdminRights,
@@ -70,13 +70,14 @@ const ViewIPOHeader = ({
                     <Typography variant="h2">{`IPO-${ipoId}: ${title}`}</Typography>
                 </ButtonContainer>
                 <ButtonContainer>
-                    <Button
-                        disabled={!isCancelable}
-                        variant="outlined"
-                        onClick={(): void => confirmCancelIpo()}
-                    >
-                        <EdsIcon name="calendar_reject" /> Cancel IPO
-                    </Button>
+                    {canCancel && (
+                        <Button
+                            variant="outlined"
+                            onClick={(): void => confirmCancelIpo()}
+                        >
+                            <EdsIcon name="calendar_reject" /> Cancel IPO
+                        </Button>
+                    )}
                     {showEditButton && (
                         <>
                             <ButtonSpacer />

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
@@ -479,10 +479,7 @@ const ViewIPO = (): JSX.Element => {
                         participants={invitation.participants}
                         isEditable={invitation.status == IpoStatusEnum.PLANNED}
                         showEditButton={invitation.canEdit}
-                        isCancelable={
-                            invitation.status == IpoStatusEnum.PLANNED ||
-                            invitation.status == IpoStatusEnum.COMPLETED
-                        }
+                        canCancel={invitation.canCancel}
                         cancelPunchOut={cancelPunchOut}
                         isAdmin={isAdmin}
                         isUsingAdminRights={isUsingAdminRights}

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/types.d.ts
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/types.d.ts
@@ -64,6 +64,7 @@ type ExternalEmail = {
 
 export type Invitation = {
     canEdit: boolean;
+    canCancel: boolean;
     projectName: string;
     title: string;
     description: string;


### PR DESCRIPTION
# Description

Cancel IPO-button should be displayed or hidden based on canCancel attribute of IPO.

Completes: [AB#81009](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/81009)

# Checklist:

- [X] I have performed a self-review of my own code.
- [X] I have linked my DevOps task using the AB# tag.
- [X] My code is easy to read, and comments are added where needed.
- [X] My code is covered by tests.
