### PR TITLE
Admins can delete IPOs that are cancelled

### DIFF
--- a/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
+++ b/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
@@ -17,6 +17,7 @@ export class IpoApiError extends ProCoSysApiError {
 type InvitationResponse = {
     canEdit: boolean;
     canCancel: boolean;
+    canDelete: boolean;
     projectName: string;
     title: string;
     description: string;
@@ -1009,6 +1010,29 @@ class InvitationForPunchOutApiClient extends ApiClient {
                 { rowVersion: rowVersion },
                 settings
             );
+            return result.data;
+        } catch (error) {
+            throw new IpoApiError(error as AxiosError);
+        }
+    }
+
+    /**
+     * Delete PunchOut
+     *
+     * @param setRequestCanceller Returns a function that can be called to cancel the request
+     */
+    async deletePunchOut(
+        id: number,
+        rowVersion: string,
+        setRequestCanceller?: RequestCanceler
+    ): Promise<void> {
+        const endpoint = `/Invitations/${id}/Delete`;
+        const settings: AxiosRequestConfig = {};
+        this.setupRequestCanceler(settings, setRequestCanceller);
+        try {
+            const result = await this.client.delete(endpoint, {
+                data: { rowVersion: rowVersion },
+            });
             return result.data;
         } catch (error) {
             throw new IpoApiError(error as AxiosError);

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/__tests__/EditIPO.test.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/__tests__/EditIPO.test.tsx
@@ -36,6 +36,7 @@ const mockRoles = [
 const mockInvitation: Invitation = {
     canEdit: false,
     canCancel: true,
+    canDelete: true,
     projectName: 'projectName',
     title: 'titleA',
     description: 'descriptionA',
@@ -143,12 +144,17 @@ describe('<EditIPO />', () => {
             <ViewIPOHeader
                 ipoId={1}
                 steps={initialSteps}
+                isCancelled={false}
                 currentStep={1}
                 title={'test'}
                 organizer="test"
                 participants={[]}
                 isEditable={true}
                 showEditButton={true}
+                canDelete={false}
+                deletePunchOut={(): void => {
+                    /*mock*/
+                }}
                 canCancel={false}
                 cancelPunchOut={(): void => {
                     /*mock*/
@@ -169,12 +175,17 @@ describe('<EditIPO />', () => {
             <ViewIPOHeader
                 ipoId={1}
                 steps={initialSteps}
+                isCancelled={false}
                 currentStep={1}
                 title={'test'}
                 organizer="test"
                 participants={[]}
                 isEditable={true}
                 showEditButton={true}
+                canDelete={false}
+                deletePunchOut={(): void => {
+                    /*mock*/
+                }}
                 canCancel={true}
                 cancelPunchOut={(): void => {
                     /*mock*/
@@ -188,5 +199,98 @@ describe('<EditIPO />', () => {
         );
 
         expect(queryByText('Cancel IPO')).toBeInTheDocument();
+    });
+
+    it('Should display "Delete IPO"-button when canDelete is true', async () => {
+        const { queryByText } = render(
+            <ViewIPOHeader
+                ipoId={1}
+                steps={initialSteps}
+                isCancelled={false}
+                currentStep={1}
+                title={'test'}
+                organizer="test"
+                participants={[]}
+                isEditable={true}
+                showEditButton={true}
+                canDelete={true}
+                deletePunchOut={(): void => {
+                    /*mock*/
+                }}
+                canCancel={true}
+                cancelPunchOut={(): void => {
+                    /*mock*/
+                }}
+                isAdmin={false}
+                isUsingAdminRights={false}
+                setIsUsingAdminRights={(): void => {
+                    /*mock*/
+                }}
+            />
+        );
+
+        expect(queryByText('Delete IPO')).toBeInTheDocument();
+    });
+
+    it('Should display "Delete IPO"-button when isCancelled is true, isUsingAdminRights is true and canDelete is false', async () => {
+        const { queryByText } = render(
+            <ViewIPOHeader
+                ipoId={1}
+                steps={initialSteps}
+                isCancelled={true}
+                currentStep={1}
+                title={'test'}
+                organizer="test"
+                participants={[]}
+                isEditable={true}
+                showEditButton={true}
+                canDelete={false}
+                deletePunchOut={(): void => {
+                    /*mock*/
+                }}
+                canCancel={true}
+                cancelPunchOut={(): void => {
+                    /*mock*/
+                }}
+                isAdmin={false}
+                isUsingAdminRights={true}
+                setIsUsingAdminRights={(): void => {
+                    /*mock*/
+                }}
+            />
+        );
+
+        expect(queryByText('Delete IPO')).toBeInTheDocument();
+    });
+
+    it('Should not display "Delete IPO"-button when isCancelled is true, isUsingAdminRights is false and canDelete is false', async () => {
+        const { queryByText } = render(
+            <ViewIPOHeader
+                ipoId={1}
+                steps={initialSteps}
+                isCancelled={true}
+                currentStep={1}
+                title={'test'}
+                organizer="test"
+                participants={[]}
+                isEditable={true}
+                showEditButton={true}
+                canDelete={false}
+                deletePunchOut={(): void => {
+                    /*mock*/
+                }}
+                canCancel={true}
+                cancelPunchOut={(): void => {
+                    /*mock*/
+                }}
+                isAdmin={false}
+                isUsingAdminRights={false}
+                setIsUsingAdminRights={(): void => {
+                    /*mock*/
+                }}
+            />
+        );
+
+        expect(queryByText('Delete IPO')).not.toBeInTheDocument();
     });
 });

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/ViewIPOHeader.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/ViewIPOHeader.tsx
@@ -26,7 +26,10 @@ type ProgressBarProps = {
     isEditable: boolean;
     showEditButton: boolean;
     canCancel: boolean;
+    canDelete: boolean;
     cancelPunchOut: () => void;
+    deletePunchOut: () => void;
+    isCancelled: boolean;
     isAdmin: boolean;
     isUsingAdminRights: boolean;
     setIsUsingAdminRights: (b: React.SetStateAction<boolean>) => void;
@@ -42,7 +45,10 @@ const ViewIPOHeader = ({
     isEditable,
     showEditButton,
     canCancel,
+    canDelete,
     cancelPunchOut,
+    deletePunchOut,
+    isCancelled,
     isAdmin,
     isUsingAdminRights,
     setIsUsingAdminRights,
@@ -63,6 +69,19 @@ const ViewIPOHeader = ({
         );
     };
 
+    const confirmDeleteIpo = (): void => {
+        showModalDialog(
+            'Delete IPO',
+            <div>Are you sure you want to delete the IPO?</div>,
+            '18vw',
+            'No',
+            null,
+            'Yes',
+            deletePunchOut,
+            true
+        );
+    };
+
     return (
         <Container>
             <HeaderContainer>
@@ -70,13 +89,27 @@ const ViewIPOHeader = ({
                     <Typography variant="h2">{`IPO-${ipoId}: ${title}`}</Typography>
                 </ButtonContainer>
                 <ButtonContainer>
+                    {(canDelete || (isCancelled && isUsingAdminRights)) && (
+                        <>
+                            <Button
+                                variant="outlined"
+                                color="danger"
+                                onClick={(): void => confirmDeleteIpo()}
+                            >
+                                <EdsIcon name="delete_forever" /> Delete IPO
+                            </Button>
+                        </>
+                    )}
                     {canCancel && (
-                        <Button
-                            variant="outlined"
-                            onClick={(): void => confirmCancelIpo()}
-                        >
-                            <EdsIcon name="calendar_reject" /> Cancel IPO
-                        </Button>
+                        <>
+                            <ButtonSpacer />
+                            <Button
+                                variant="outlined"
+                                onClick={(): void => confirmCancelIpo()}
+                            >
+                                <EdsIcon name="calendar_reject" /> Cancel IPO
+                            </Button>
+                        </>
                     )}
                     {showEditButton && (
                         <>

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/index.tsx
@@ -36,6 +36,7 @@ import { useAnalytics } from '@procosys/core/services/Analytics/AnalyticsContext
 import { useInvitationForPunchOutContext } from '../../context/InvitationForPunchOutContext';
 import { useParams } from 'react-router-dom';
 import { useCurrentPlant } from '@procosys/core/PlantContext';
+import { useHistory } from 'react-router-dom';
 
 const initialSteps: Step[] = [
     { title: 'Invitation for punch-out sent', isCompleted: true },
@@ -74,6 +75,7 @@ const ViewIPO = (): JSX.Element => {
         useState<boolean>(false);
     const [isAdmin, setIsAdmin] = useState<boolean>(false);
     const { permissions } = useCurrentPlant();
+    const history = useHistory();
 
     const moduleContainerRef = useRef<HTMLDivElement>(null);
 
@@ -462,6 +464,29 @@ const ViewIPO = (): JSX.Element => {
         }
     };
 
+    const deletePunchOut = async (): Promise<any> => {
+        if (invitation) {
+            try {
+                await apiClient.deletePunchOut(
+                    params.ipoId,
+                    invitation.rowVersion
+                );
+                analytics.trackUserAction(IpoCustomEvents.DELETED, {
+                    project: invitation.projectName,
+                    type: invitation.type,
+                });
+                showSnackbarNotification(
+                    'Invitation for punch-out is deleted.'
+                );
+                history.push('/');
+            } catch (error) {
+                if (!(error instanceof IpoApiError)) return;
+                console.error(error.message, error.data);
+                showSnackbarNotification(error.message);
+            }
+        }
+    };
+
     return (
         <Container ref={moduleContainerRef}>
             {loading ? (
@@ -473,13 +498,18 @@ const ViewIPO = (): JSX.Element => {
                     <ViewIPOHeader
                         ipoId={params.ipoId}
                         steps={steps}
+                        isCancelled={
+                            invitation.status === IpoStatusEnum.CANCELED
+                        }
                         currentStep={currentStep}
                         title={invitation.title}
                         organizer={`${invitation.createdBy.firstName} ${invitation.createdBy.lastName}`}
                         participants={invitation.participants}
                         isEditable={invitation.status == IpoStatusEnum.PLANNED}
                         showEditButton={invitation.canEdit}
+                        canDelete={invitation.canDelete}
                         canCancel={invitation.canCancel}
+                        deletePunchOut={deletePunchOut}
                         cancelPunchOut={cancelPunchOut}
                         isAdmin={isAdmin}
                         isUsingAdminRights={isUsingAdminRights}

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/types.d.ts
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/types.d.ts
@@ -65,6 +65,7 @@ type ExternalEmail = {
 export type Invitation = {
     canEdit: boolean;
     canCancel: boolean;
+    canDelete: boolean;
     projectName: string;
     title: string;
     description: string;

--- a/src/modules/InvitationForPunchOut/views/enums.ts
+++ b/src/modules/InvitationForPunchOut/views/enums.ts
@@ -28,6 +28,7 @@ export enum IpoCustomEvents {
     CREATED = 'IPO_Created',
     EDITED = 'IPO_Edited',
     CANCELED = 'IPO_Canceled',
+    DELETED = 'IPO_Deleted',
     COMPLETED = 'IPO_Completed',
     UNCOMPLETED = 'IPO_Uncompleted',
     ACCEPTED = 'IPO_Accepted',


### PR DESCRIPTION
# Description

Delete IPO button is now displayed when the following is true:
 - canDelete-property is true
 - IPO is cancelled and user is an admin AND the toggle admin mode button is  on

Completes: [AB#89287](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/89287)

# Checklist:

- [X] I have performed a self-review of my own code.
- [X] I have linked my DevOps task using the AB# tag.
- [X] My code is easy to read, and comments are added where needed.
- [X] My code is covered by tests.
