### PR TITLE
Feature flag for hiding old manufacturer/model search

### DIFF
--- a/src/core/ProCoSysSettings.ts
+++ b/src/core/ProCoSysSettings.ts
@@ -16,6 +16,7 @@ interface FeatureFlags {
     preservation: boolean;
     main: boolean;
     quickSearch: boolean;
+    ManufacturerModelEnabled: boolean;
 }
 
 interface ConfigResponse {
@@ -147,6 +148,7 @@ class ProCoSysSettings {
             main: true,
             library: true,
             quickSearch: true,
+            ManufacturerModelEnabled: true,
         };
         this.settingsConfigurationApiClient = new SettingsApiClient(
             localSettings.configurationEndpoint
@@ -232,6 +234,8 @@ class ProCoSysSettings {
                 configurationResponse.featureFlags.preservation;
             this.featureFlags.quickSearch =
                 configurationResponse.featureFlags.quickSearch;
+            this.featureFlags.ManufacturerModelEnabled =
+                configurationResponse.featureFlags.ManufacturerModelEnabled;
         } catch (error) {
             console.error(
                 'Failed to parse Configuration from remote server',
@@ -301,6 +305,9 @@ class ProCoSysSettings {
             localSettings.featureFlags.quickSearch != undefined &&
                 (this.featureFlags.quickSearch =
                     localSettings.featureFlags.quickSearch);
+            localSettings.featureFlags.ManufacturerModelEnabled != undefined &&
+                (this.featureFlags.ManufacturerModelEnabled =
+                    localSettings.featureFlags.ManufacturerModelEnabled);
         }
     }
 }

--- a/src/http/SettingsApiClient.ts
+++ b/src/http/SettingsApiClient.ts
@@ -24,6 +24,7 @@ interface ConfigResponse {
         preservation: boolean;
         main: boolean;
         quickSearch: boolean;
+        ManufacturerModelEnabled: boolean;
     };
 }
 

--- a/src/modules/Header/index.tsx
+++ b/src/modules/Header/index.tsx
@@ -417,11 +417,17 @@ const Header: React.FC = (): JSX.Element => {
                             >
                                 <DropdownItem>Libraries</DropdownItem>
                             </a>
-                            <a
-                                href={`/${params.plant}/Search?searchType=Manufacturer%2FModel`}
-                            >
-                                <DropdownItem>Manufacturer/Model</DropdownItem>
-                            </a>
+                            {ProCoSysSettings.featureIsEnabled(
+                                'ManufacturerModelEnabled'
+                            ) && (
+                                <a
+                                    href={`/${params.plant}/Search?searchType=Manufacturer%2FModel`}
+                                >
+                                    <DropdownItem>
+                                        Manufacturer/Model
+                                    </DropdownItem>
+                                </a>
+                            )}
                             <a
                                 href={`/${params.plant}/Search?searchType=MC%20Packages`}
                             >


### PR DESCRIPTION
# Description
Show or hide manufacturer/model search from React-frontend using feature flag ManufacturerModelEnabled.

Completes: [AB#91348](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/91348)

# Checklist:

- [X] I have performed a self-review of my own code.
- [X] I have linked my DevOps task using the AB# tag.
- [X] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
