### PR TITLE
Feature/93412 remember project when navigating between ipo modules

### DIFF
--- a/src/modules/InvitationForPunchOut/cache/InvitationForPunchOutCache.ts
+++ b/src/modules/InvitationForPunchOut/cache/InvitationForPunchOutCache.ts
@@ -1,0 +1,23 @@
+import CacheService from '../../../core/services/CacheService';
+import { ProjectDetails } from '../types';
+
+enum storageKeys {
+    IPO = 'IPO',
+    PROJECT = 'PROJECT',
+}
+
+const localStorageCache = new CacheService(storageKeys.IPO, localStorage);
+
+const setDefaultProject = (project: ProjectDetails): void => {
+    localStorageCache.setCache(storageKeys.PROJECT, project);
+};
+
+const getDefaultProject = (): ProjectDetails | null => {
+    const cache = localStorageCache.getCache(storageKeys.PROJECT);
+    return (cache && cache.data) || null;
+};
+
+export default {
+    setDefaultProject,
+    getDefaultProject,
+};

--- a/src/modules/InvitationForPunchOut/context/InvitationForPunchOutContext.tsx
+++ b/src/modules/InvitationForPunchOut/context/InvitationForPunchOutContext.tsx
@@ -1,11 +1,18 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import propTypes from 'prop-types';
 import InvitationForPunchOutApiClient from '../http/InvitationForPunchOutApiClient';
 import { useCurrentPlant } from '../../../core/PlantContext';
 import { useProcosysContext } from '../../../core/ProcosysContext';
+import { ProjectDetails } from '../types';
+import { Canceler } from '@procosys/http/HttpClient';
+import Loading from '@procosys/components/Loading';
+import invitationForPunchOutCache from '../cache/InvitationForPunchOutCache';
 
 type InvitationForPunchOutContextProps = {
     apiClient: InvitationForPunchOutApiClient;
+    project: ProjectDetails;
+    setCurrentProject: (projectId: number) => void;
+    availableProjects: ProjectDetails[];
 };
 
 const InvitationForPunchOutContext =
@@ -13,24 +20,113 @@ const InvitationForPunchOutContext =
         {} as InvitationForPunchOutContextProps
     );
 
+class InvalidProjectException extends Error {
+    constructor() {
+        super('Invalid project selection');
+        this.name = 'InvalidProject';
+        Object.setPrototypeOf(this, new.target.prototype);
+    }
+}
+
 export const InvitationForPunchOutContextProvider: React.FC = ({
     children,
 }): JSX.Element => {
-    const { auth } = useProcosysContext();
+    const { procosysApiClient, auth } = useProcosysContext();
     const { plant } = useCurrentPlant();
     const invitationForPunchOutApiClient = useMemo(
         () => new InvitationForPunchOutApiClient(auth),
         [auth]
     );
+    const [availableProjects, setAvailableProjects] = useState<
+        ProjectDetails[] | null
+    >(null);
+
+    const [currentProject, setCurrentProjectInContext] =
+        useState<ProjectDetails>();
+
+    const setCurrentProject = (projectId: number): void => {
+        if (!availableProjects || !projectId) {
+            return;
+        }
+
+        if (availableProjects.length === 0) {
+            setCurrentProjectInContext({
+                id: -1,
+                name: 'No projects available',
+                description: 'No projects available',
+            });
+            return;
+        }
+
+        const project = availableProjects.find((el) => el.id === projectId);
+        if (project) {
+            setCurrentProjectInContext(project);
+        } else {
+            throw new InvalidProjectException();
+        }
+    };
+
+    let requestCanceler: Canceler;
+
+    useEffect(() => {
+        (async (): Promise<void> => {
+            const allProjects = await procosysApiClient
+                .getAllProjectsForUserAsync(
+                    (cancelerCallback) => (requestCanceler = cancelerCallback)
+                )
+                .then((projects) =>
+                    projects.map((project): ProjectDetails => {
+                        return {
+                            id: project.id,
+                            name: project.name,
+                            description: project.description,
+                        };
+                    })
+                );
+            setAvailableProjects(allProjects);
+        })();
+        return (): void => requestCanceler && requestCanceler();
+    }, []);
 
     useMemo(() => {
         invitationForPunchOutApiClient.setCurrentPlant(plant.id);
     }, [plant]);
 
+    useEffect(() => {
+        const defaultProject = invitationForPunchOutCache.getDefaultProject();
+        try {
+            if (defaultProject) {
+                setCurrentProject(defaultProject.id);
+                return;
+            }
+            throw new InvalidProjectException();
+        } catch (error) {
+            if (
+                error instanceof InvalidProjectException &&
+                availableProjects &&
+                availableProjects.length > 0
+            ) {
+                setCurrentProject(availableProjects[0].id);
+            }
+        }
+    }, [availableProjects]);
+
+    useEffect(() => {
+        if (!currentProject) return;
+        invitationForPunchOutCache.setDefaultProject(currentProject);
+    }, [currentProject]);
+
+    if (!currentProject || !availableProjects) {
+        return <Loading title="Loading project information" />;
+    }
+
     return (
         <InvitationForPunchOutContext.Provider
             value={{
                 apiClient: invitationForPunchOutApiClient,
+                project: currentProject,
+                setCurrentProject,
+                availableProjects,
             }}
         >
             {children}

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/GeneralInfo/GeneralInfo.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/GeneralInfo/GeneralInfo.tsx
@@ -59,33 +59,11 @@ const GeneralInfo = ({
     setConfirmationChecked,
     errors,
 }: GeneralInfoProps): JSX.Element => {
-    const { apiClient } = useInvitationForPunchOutContext();
-    const [availableProjects, setAvailableProjects] = useState<
-        ProjectDetails[]
-    >([]);
-    const [filteredProjects, setFilteredProjects] = useState<ProjectDetails[]>(
-        []
-    );
+    const { apiClient, availableProjects } = useInvitationForPunchOutContext();
+    const [filteredProjects, setFilteredProjects] =
+        useState<ProjectDetails[]>(availableProjects);
     const [filterForProjects, setFilterForProjects] = useState<string>('');
     const [isLoading, setIsLoading] = useState<boolean>(false);
-
-    useEffect(() => {
-        let requestCanceler: Canceler;
-        (async (): Promise<void> => {
-            try {
-                setIsLoading(true);
-                const allProjects = await apiClient.getAllProjectsForUserAsync(
-                    (cancelerCallback) => (requestCanceler = cancelerCallback)
-                );
-                setAvailableProjects(allProjects);
-                setFilteredProjects(allProjects);
-            } catch (error) {
-                console.error(error);
-            }
-            setIsLoading(false);
-        })();
-        return (): void => requestCanceler && requestCanceler();
-    }, []);
 
     useEffect(() => {
         if (filterForProjects.length <= 0) {

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/GeneralInfo/GeneralInfo.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/GeneralInfo/GeneralInfo.tsx
@@ -184,6 +184,7 @@ const GeneralInfo = ({
                         </div>
                     )}
                     {!isLoading &&
+                        filteredProjects &&
                         filteredProjects.map((projectItem, index) => {
                             return (
                                 <DropdownItem

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/__tests__/CreateIPO.test.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/__tests__/CreateIPO.test.tsx
@@ -42,21 +42,24 @@ jest.mock('@procosys/hooks/useRouter', () =>
     }))
 );
 
+const mockProject = [
+    {
+        id: 123,
+        name: 'project.name',
+        description: 'project.description',
+    },
+];
+
 jest.mock('../../../context/InvitationForPunchOutContext', () => ({
     useInvitationForPunchOutContext: (): any => {
         return {
             apiClient: {
                 getFunctionalRolesAsync: (): any => Promise.resolve(mockRoles),
                 getAllProjectsForUserAsync: (_: any): any => {
-                    return Promise.resolve([
-                        {
-                            id: 123,
-                            name: 'project.name',
-                            description: 'project.description',
-                        },
-                    ]);
+                    return Promise.resolve(mockProject);
                 },
             },
+            availableProjects: mockProject,
         };
     },
 }));

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/__tests__/EditIPO.test.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/__tests__/EditIPO.test.tsx
@@ -11,7 +11,7 @@ configure({ testIdAttribute: 'id' }); // makes id attibute data-testid for subse
 
 const initialSteps: Step[] = [
     { title: 'Invitation for punch-out sent', isCompleted: true },
-    { title: 'Punch-out completed', isCompleted: false },
+    { title: 'Punch-out complete', isCompleted: false },
     { title: 'Punch-out accepted by company', isCompleted: false },
 ];
 

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/__tests__/SearchIPO.test.jsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/__tests__/SearchIPO.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 
 import React from 'react';
 import SearchIPO from '../../SearchIPO';
@@ -23,6 +23,7 @@ jest.mock('../../../context/InvitationForPunchOutContext', () => ({
                 getFunctionalRolesAsync: () => Promise.resolve([]),
                 getSavedIPOFilters: () => Promise.resolve([]),
             },
+            availableProjects: mockProject,
         };
     },
 }));
@@ -59,27 +60,6 @@ describe('<SearchIPO />', () => {
             expect(getByText('New IPO').closest('a')).toHaveAttribute(
                 'href',
                 '/CreateIPO'
-            )
-        );
-    });
-
-    it('Should change the link in the "New IPO" button when project is changed', async () => {
-        const history = createMemoryHistory();
-        const { getByText } = render(
-            <Router history={history}>
-                <SearchIPO />
-            </Router>
-        );
-        await waitFor(() =>
-            expect(getByText('Select project')).toBeInTheDocument()
-        );
-        fireEvent.click(getByText('Select project'));
-        await waitFor(() => expect(getByText('886')).toBeInTheDocument());
-        fireEvent.click(getByText('886'));
-        await waitFor(() =>
-            expect(getByText('New IPO').closest('a')).toHaveAttribute(
-                'href',
-                '/CreateIPO/886'
             )
         );
     });

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/index.tsx
@@ -46,14 +46,10 @@ const SearchIPO = (): JSX.Element => {
     const [pageSize, setPageSize] = useState<number>(25);
     const [filter, setFilter] = useState<IPOFilter>({ ...emptyFilter });
     const [resetTablePaging, setResetTablePaging] = useState<boolean>(false);
-    const { apiClient, project, setCurrentProject } =
+    const { apiClient, project, setCurrentProject, availableProjects } =
         useInvitationForPunchOutContext();
-    const [availableProjects, setAvailableProjects] = useState<
-        ProjectDetails[]
-    >([]);
-    const [filteredProjects, setFilteredProjects] = useState<ProjectDetails[]>(
-        []
-    );
+    const [filteredProjects, setFilteredProjects] =
+        useState<ProjectDetails[]>(availableProjects);
     const [filterForProjects, setFilterForProjects] = useState<string>('');
 
     const isFirstRender = useRef<boolean>(true);
@@ -169,24 +165,6 @@ const SearchIPO = (): JSX.Element => {
         } catch (error) {
             showSnackbarNotification(error.message);
         }
-    }, []);
-
-    useEffect(() => {
-        let requestCanceler: Canceler;
-        (async (): Promise<void> => {
-            try {
-                setIsLoading(true);
-                const allProjects = await apiClient.getAllProjectsForUserAsync(
-                    (cancelerCallback) => (requestCanceler = cancelerCallback)
-                );
-                setAvailableProjects(allProjects);
-                setFilteredProjects(allProjects);
-            } catch (error) {
-                console.error(error);
-            }
-            setIsLoading(false);
-        })();
-        return (): void => requestCanceler && requestCanceler();
     }, []);
 
     useEffect(() => {

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/index.tsx
@@ -381,6 +381,7 @@ const SearchIPO = (): JSX.Element => {
                                         </div>
                                     )}
                                     {!isLoading &&
+                                        filteredProjects &&
                                         filteredProjects.map(
                                             (projectItem, index) => {
                                                 return (

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/index.tsx
@@ -46,14 +46,14 @@ const SearchIPO = (): JSX.Element => {
     const [pageSize, setPageSize] = useState<number>(25);
     const [filter, setFilter] = useState<IPOFilter>({ ...emptyFilter });
     const [resetTablePaging, setResetTablePaging] = useState<boolean>(false);
-    const { apiClient } = useInvitationForPunchOutContext();
+    const { apiClient, project, setCurrentProject } =
+        useInvitationForPunchOutContext();
     const [availableProjects, setAvailableProjects] = useState<
         ProjectDetails[]
     >([]);
     const [filteredProjects, setFilteredProjects] = useState<ProjectDetails[]>(
         []
     );
-    const [project, setProject] = useState<ProjectDetails>();
     const [filterForProjects, setFilterForProjects] = useState<string>('');
 
     const isFirstRender = useRef<boolean>(true);
@@ -212,7 +212,7 @@ const SearchIPO = (): JSX.Element => {
     const changeProject = (event: React.MouseEvent, index: number): void => {
         event.preventDefault();
 
-        setProject(filteredProjects[index]);
+        setCurrentProject(filteredProjects[index].id);
         setResetTablePaging(true);
         setHasProjectChanged(true);
 

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/ViewIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/ViewIPO.tsx
@@ -40,7 +40,7 @@ import { useHistory } from 'react-router-dom';
 
 const initialSteps: Step[] = [
     { title: 'Invitation for punch-out sent', isCompleted: true },
-    { title: 'Punch-out completed', isCompleted: false },
+    { title: 'Punch-out complete', isCompleted: false },
     { title: 'Punch-out accepted by company', isCompleted: false },
 ];
 


### PR DESCRIPTION
# Description

Search IPO remembers previous project, just like preservation does

Also changed wording of 2nd step in viewIPO as requested by Equinor.

Completes: [AB#93412](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/93412)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
