### PR TITLE
All projects option added to IPO project ddown

### DIFF
--- a/src/modules/InvitationForPunchOut/context/InvitationForPunchOutContext.tsx
+++ b/src/modules/InvitationForPunchOut/context/InvitationForPunchOutContext.tsx
@@ -51,17 +51,25 @@ export const InvitationForPunchOutContextProvider: React.FC = ({
 
         if (availableProjects.length === 0) {
             setCurrentProjectInContext({
-                id: -1,
+                id: -10,
                 name: 'No projects available',
                 description: 'No projects available',
             });
             return;
         }
 
+        if (projectId === -1) {
+            setCurrentProjectInContext({
+                id: -1,
+                name: 'All projects',
+                description: 'All projects in plant',
+            });
+        }
+
         const project = availableProjects.find((el) => el.id === projectId);
         if (project) {
             setCurrentProjectInContext(project);
-        } else {
+        } else if (projectId !== -1) {
             throw new InvalidProjectException();
         }
     };
@@ -106,7 +114,7 @@ export const InvitationForPunchOutContextProvider: React.FC = ({
                 availableProjects &&
                 availableProjects.length > 0
             ) {
-                setCurrentProject(availableProjects[0].id);
+                setCurrentProject(-1);
             }
         }
     }, [availableProjects]);

--- a/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
+++ b/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
@@ -197,6 +197,7 @@ interface IPO {
     additionalConstructionCompanyReps: string[];
     mcPkgNos?: string[];
     commPkgNos?: string[];
+    projectName: string;
 }
 
 type IPOFilter = {
@@ -340,7 +341,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
      * @param setRequestCanceller Returns a function that can be called to cancel the request
      */
     async getIPOs(
-        projectName: string,
+        projectName: string | null,
         page: number,
         pageSize: number,
         orderBy: string | null,
@@ -349,6 +350,8 @@ class InvitationForPunchOutApiClient extends ApiClient {
         setRequestCanceller?: RequestCanceler
     ): Promise<IPOsResponse> {
         const endpoint = '/Invitations';
+
+        projectName = projectName == 'All projects' ? null : projectName;
         const settings: AxiosRequestConfig = {
             params: {
                 projectName: projectName,
@@ -1196,13 +1199,15 @@ class InvitationForPunchOutApiClient extends ApiClient {
      * @param setRequestCanceller Returns a function that can be called to cancel the request
      */
     async exportInvitationsToExcel(
-        projectName: string,
+        projectName: string | null,
         sortProperty: string | null,
         sortDirection: string | null,
         iPOFilter: IPOFilter,
         setRequestCanceller?: RequestCanceler
     ): Promise<BlobPart> {
         const endpoint = '/Invitations/ExportInvitationsToExcel';
+
+        projectName = projectName == 'All projects' ? null : projectName;
 
         const settings: AxiosRequestConfig = {
             params: {

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/Filter/__tests__/Filter.test.jsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/Filter/__tests__/Filter.test.jsx
@@ -181,7 +181,7 @@ describe('<InvitationsFilter />', () => {
                 exportInvitationsToExcel={exportInvitationsToExcel}
             />
         );
-        expect(getByTitle('Export filtered tags to Excel')).toBeInTheDocument();
+        expect(getByTitle('Export filtered IPOs to Excel')).toBeInTheDocument();
     });
 
     it('Should call the export to excel function when excel button is clicked', async () => {
@@ -201,7 +201,7 @@ describe('<InvitationsFilter />', () => {
             />
         );
         expect(exportInvitationsToExcel).toHaveBeenCalledTimes(0);
-        getByTitle('Export filtered tags to Excel').click();
+        getByTitle('Export filtered IPOs to Excel').click();
         expect(exportInvitationsToExcel).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/Filter/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/Filter/index.tsx
@@ -300,7 +300,7 @@ const InvitationsFilter = ({
                 <div style={{ display: 'flex' }}>
                     <Button
                         variant="ghost"
-                        title="Export filtered tags to Excel"
+                        title="Export filtered IPOs to Excel"
                         onClick={exportInvitationsToExcel}
                     >
                         {ExcelIcon}

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/Table/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/Table/index.tsx
@@ -106,6 +106,22 @@ const InvitationsTable = ({
         return <CustomLink to={`/${data}`}>{data}</CustomLink>;
     };
 
+    const getProjectNameColumn = (row: TableOptions<IPO>): JSX.Element => {
+        const data = (row.value as IPO).projectName;
+        return (
+            <div className="controlOverflow">
+                <Tooltip
+                    title={data || ''}
+                    arrow={true}
+                    enterDelay={200}
+                    enterNextDelay={100}
+                >
+                    <Typography>{data}</Typography>
+                </Tooltip>
+            </div>
+        );
+    };
+
     const getTitleColum = (row: TableOptions<IPO>): JSX.Element => {
         const data = (row.value as IPO).title;
         return (
@@ -302,6 +318,12 @@ const InvitationsTable = ({
             id: 'ipoNo',
             accessor: (d: UseTableRowProps<IPO>): UseTableRowProps<IPO> => d,
             Cell: getIdColumn,
+        },
+        {
+            Header: 'Project',
+            id: 'projectName',
+            accessor: (d: UseTableRowProps<IPO>): UseTableRowProps<IPO> => d,
+            Cell: getProjectNameColumn,
         },
         {
             Header: 'Title',

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/index.tsx
@@ -168,6 +168,14 @@ const SearchIPO = (): JSX.Element => {
     }, []);
 
     useEffect(() => {
+        const allProjects: ProjectDetails = {
+            id: -1,
+            name: 'All projects',
+            description: 'All projects in plant',
+        };
+
+        availableProjects.unshift(allProjects);
+
         if (filterForProjects.length <= 0) {
             setFilteredProjects(availableProjects);
             return;

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/index.tsx
@@ -174,7 +174,13 @@ const SearchIPO = (): JSX.Element => {
             description: 'All projects in plant',
         };
 
-        availableProjects.unshift(allProjects);
+        if (availableProjects.length > 0) {
+            if (availableProjects[0].id !== -1) {
+                availableProjects.unshift(allProjects);
+            }
+        } else {
+            availableProjects.push(allProjects);
+        }
 
         if (filterForProjects.length <= 0) {
             setFilteredProjects(availableProjects);

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/types.d.ts
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/types.d.ts
@@ -18,6 +18,7 @@ export interface IPO {
     additionalConstructionCompanyReps: string[];
     mcPkgNos?: string[];
     commPkgNos?: string[];
+    projectName: string;
 }
 
 export interface IPOs {


### PR DESCRIPTION
# Description
User should be able to see IPOs across all projects that he/she has access to in a plant. 
Add new option to dropdown -> "All projects"
Also include Project name in results table.

"All projects" should be default if the user has not filtered on a specific project prior.

Note: [AB#94186](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/94186) Must be completed first.

Completes: [AB#94187](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/94187)
# Checklist:

- [X] I have performed a self-review of my own code.
- [X] I have linked my DevOps task using the AB# tag.
- [X] My code is easy to read, and comments are added where needed.
