### PR TITLE
Feature/89434 admin can edit participant list

### DIFF
--- a/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
+++ b/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
@@ -600,6 +600,34 @@ class InvitationForPunchOutApiClient extends ApiClient {
     }
 
     /**
+     * Update IPO participants
+     *
+     * @param setRequestCanceller Returns a function that can be called to cancel the request
+     */
+    async updateIpoParticipants(
+        ipoId: number,
+        participants: ParticipantDto[],
+        setRequestCanceller?: RequestCanceler
+    ): Promise<number> {
+        const endpoint = `/Invitations/${ipoId}/Participants`;
+        const settings: AxiosRequestConfig = {};
+        this.setupRequestCanceler(settings, setRequestCanceller);
+
+        try {
+            const result = await this.client.put(
+                endpoint,
+                {
+                    updatedParticipants: participants,
+                },
+                settings
+            );
+            return result.data;
+        } catch (error) {
+            throw new IpoApiError(error as AxiosError);
+        }
+    }
+
+    /**
      * Get comments
      *
      * @param setRequestCanceller Returns a function that can be called to cancel the request

--- a/src/modules/InvitationForPunchOut/types.d.ts
+++ b/src/modules/InvitationForPunchOut/types.d.ts
@@ -58,6 +58,7 @@ export type Participant = {
     externalEmail: ExternalEmail | null;
     person: Person | null;
     role: RoleParticipant | null;
+    signedAt: Date | null | undefined;
 };
 
 export type Attachment = {

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateAndEditIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateAndEditIPO.tsx
@@ -17,6 +17,7 @@ import Participants from './Participants/Participants';
 import SelectScope from './SelectScope/SelectScope';
 import Summary from './Summary/Summary';
 import { isEmptyObject } from './utils';
+import { IpoStatusEnum } from '../enums';
 
 const validateGeneralInfo = (
     info: GeneralInfoDetails,
@@ -115,6 +116,7 @@ interface CreateAndEditProps {
     ipoId?: number | null;
     isEditMode?: boolean;
     commPkgNoFromMain?: string | null;
+    status?: string;
 }
 
 const CreateAndEditIPO = ({
@@ -138,6 +140,7 @@ const CreateAndEditIPO = ({
     ipoId = null,
     isEditMode = false,
     commPkgNoFromMain = null,
+    status,
 }: CreateAndEditProps): JSX.Element => {
     const [currentStep, setCurrentStep] = useState<number>(
         StepsEnum.GeneralInfo
@@ -283,6 +286,9 @@ const CreateAndEditIPO = ({
                     confirmationChecked={confirmationChecked}
                     setConfirmationChecked={setConfirmationChecked}
                     errors={generalInfoErrors}
+                    isDisabled={
+                        status ? !(status == IpoStatusEnum.PLANNED) : false
+                    }
                 />
             )}
             {currentStep == StepsEnum.Scope &&

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateAndEditIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateAndEditIPO.tsx
@@ -315,6 +315,7 @@ const CreateAndEditIPO = ({
                     participants={participants}
                     setParticipants={setParticipants}
                     availableRoles={availableRoles ? availableRoles : []}
+                    invitationStarted={invitationStarted}
                 />
             )}
             {currentStep == StepsEnum.UploadAttachments && (

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateAndEditIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateAndEditIPO.tsx
@@ -150,6 +150,13 @@ const CreateAndEditIPO = ({
         string,
         string
     > | null>(null);
+    const [invitationStarted, setInvitationStarted] = useState<boolean>(false);
+
+    useEffect(() => {
+        setInvitationStarted(
+            status ? !(status == IpoStatusEnum.PLANNED) : false
+        );
+    }, [status]);
 
     const goToNextStep = (): void => {
         if (currentStep === StepsEnum.GeneralInfo) {
@@ -286,9 +293,7 @@ const CreateAndEditIPO = ({
                     confirmationChecked={confirmationChecked}
                     setConfirmationChecked={setConfirmationChecked}
                     errors={generalInfoErrors}
-                    isDisabled={
-                        status ? !(status == IpoStatusEnum.PLANNED) : false
-                    }
+                    isDisabled={invitationStarted}
                 />
             )}
             {currentStep == StepsEnum.Scope &&
@@ -302,6 +307,7 @@ const CreateAndEditIPO = ({
                         selectedMcPkgScope={selectedMcPkgScope}
                         setSelectedMcPkgScope={setSelectedMcPkgScope}
                         projectName={generalInfo.projectName}
+                        isDisabled={invitationStarted}
                     />
                 )}
             {currentStep == StepsEnum.Participants && (

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateIPO.tsx
@@ -52,6 +52,7 @@ const initialParticipants: Participant[] = [
         externalEmail: null,
         person: null,
         role: null,
+        signedAt: null,
     },
     {
         organization: {
@@ -65,6 +66,7 @@ const initialParticipants: Participant[] = [
         externalEmail: null,
         person: null,
         role: null,
+        signedAt: null,
     },
     {
         organization: {
@@ -78,6 +80,7 @@ const initialParticipants: Participant[] = [
         externalEmail: null,
         person: null,
         role: null,
+        signedAt: null,
     },
     {
         organization: {
@@ -89,6 +92,7 @@ const initialParticipants: Participant[] = [
         externalEmail: null,
         person: null,
         role: null,
+        signedAt: null,
     },
     {
         organization: {
@@ -102,6 +106,7 @@ const initialParticipants: Participant[] = [
         externalEmail: null,
         person: null,
         role: null,
+        signedAt: null,
     },
 ];
 

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
@@ -11,7 +11,7 @@ import {
     Step,
 } from '../../types';
 import { CenterContainer, Container } from './CreateAndEditIPO.style';
-import { ComponentName, IpoCustomEvents } from '../enums';
+import { ComponentName, IpoCustomEvents, IpoStatusEnum } from '../enums';
 import {
     ExternalEmailDto,
     FunctionalRoleDto,
@@ -342,21 +342,28 @@ const EditIPO = (): JSX.Element => {
                 const mcPkgScope = getMcScope();
                 const ipoParticipants = getParticipants();
 
-                // TODO: check status, and use correct API function
-
-                await apiClient.updateIpo(
-                    params.ipoId,
-                    generalInfo.title,
-                    generalInfo.poType.value,
-                    generalInfo.startTime as Date,
-                    generalInfo.endTime as Date,
-                    generalInfo.description ? generalInfo.description : null,
-                    generalInfo.location ? generalInfo.location : null,
-                    ipoParticipants,
-                    mcPkgScope,
-                    commPkgScope,
-                    invitation.rowVersion
-                );
+                if (invitation?.status != IpoStatusEnum.PLANNED) {
+                    await apiClient.updateIpoParticipants(
+                        params.ipoId,
+                        ipoParticipants
+                    );
+                } else {
+                    await apiClient.updateIpo(
+                        params.ipoId,
+                        generalInfo.title,
+                        generalInfo.poType.value,
+                        generalInfo.startTime as Date,
+                        generalInfo.endTime as Date,
+                        generalInfo.description
+                            ? generalInfo.description
+                            : null,
+                        generalInfo.location ? generalInfo.location : null,
+                        ipoParticipants,
+                        mcPkgScope,
+                        commPkgScope,
+                        invitation.rowVersion
+                    );
+                }
                 analystics.trackUserAction(IpoCustomEvents.EDITED, {
                     project: generalInfo.projectName,
                     type: generalInfo.poType.value,

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
@@ -342,6 +342,8 @@ const EditIPO = (): JSX.Element => {
                 const mcPkgScope = getMcScope();
                 const ipoParticipants = getParticipants();
 
+                // TODO: check status, and use correct API function
+
                 await apiClient.updateIpo(
                     params.ipoId,
                     generalInfo.title,
@@ -543,6 +545,7 @@ const EditIPO = (): JSX.Element => {
                     externalEmail: externalEmail,
                     person: person,
                     role: roleParticipant,
+                    signedAt: participant.signedAtUtc,
                 };
                 participants.push(newParticipant);
             });

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/EditIPO.tsx
@@ -614,6 +614,7 @@ const EditIPO = (): JSX.Element => {
             setConfirmationChecked={setConfirmationChecked}
             isEditMode={true}
             ipoId={params.ipoId}
+            status={invitation?.status}
         />
     );
 };

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/GeneralInfo/GeneralInfo.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/GeneralInfo/GeneralInfo.tsx
@@ -47,6 +47,7 @@ interface GeneralInfoProps {
     confirmationChecked: boolean;
     setConfirmationChecked: React.Dispatch<React.SetStateAction<boolean>>;
     errors: Record<string, string> | null;
+    isDisabled: boolean;
 }
 
 const GeneralInfo = ({
@@ -58,12 +59,12 @@ const GeneralInfo = ({
     confirmationChecked,
     setConfirmationChecked,
     errors,
+    isDisabled,
 }: GeneralInfoProps): JSX.Element => {
-    const { apiClient, availableProjects } = useInvitationForPunchOutContext();
+    const { availableProjects } = useInvitationForPunchOutContext();
     const [filteredProjects, setFilteredProjects] =
         useState<ProjectDetails[]>(availableProjects);
     const [filterForProjects, setFilterForProjects] = useState<string>('');
-    const [isLoading, setIsLoading] = useState<boolean>(false);
 
     useEffect(() => {
         if (filterForProjects.length <= 0) {
@@ -176,15 +177,9 @@ const GeneralInfo = ({
                     variant="form"
                     text={generalInfo.projectName || 'Select'}
                     onFilter={setFilterForProjects}
-                    disabled={fromMain || isEditMode}
+                    disabled={fromMain || isEditMode || isDisabled}
                 >
-                    {isLoading && (
-                        <div style={{ margin: 'calc(var(--grid-unit))' }}>
-                            <Spinner medium />
-                        </div>
-                    )}
-                    {!isLoading &&
-                        filteredProjects &&
+                    {filteredProjects &&
                         filteredProjects.map((projectItem, index) => {
                             return (
                                 <DropdownItem
@@ -223,6 +218,7 @@ const GeneralInfo = ({
                         onChange={setPoTypeForm}
                         data={poTypes}
                         label={'Type of punch round'}
+                        disabled={isDisabled}
                     >
                         {(generalInfo.poType && generalInfo.poType.text) ||
                             'Select'}
@@ -258,6 +254,7 @@ const GeneralInfo = ({
                             return { ...gi, title: e.target.value };
                         });
                     }}
+                    disabled={isDisabled}
                 />
                 {errors && errors['title'] && (
                     <ErrorContainer>
@@ -290,6 +287,7 @@ const GeneralInfo = ({
                             return { ...gi, description: e.target.value };
                         });
                     }}
+                    disabled={isDisabled}
                 />
                 {errors && errors['description'] && (
                     <ErrorContainer>
@@ -329,6 +327,7 @@ const GeneralInfo = ({
                                 HTMLInputElement | HTMLTextAreaElement
                             >
                         ): void => handleSetDate(event.target.value)}
+                        disabled={isDisabled}
                     />
                 </div>
                 <div>
@@ -351,6 +350,7 @@ const GeneralInfo = ({
                                 HTMLInputElement | HTMLTextAreaElement
                             >
                         ): void => handleSetTime('start', event.target.value)}
+                        disabled={isDisabled}
                     />
                 </div>
                 <div>
@@ -373,6 +373,7 @@ const GeneralInfo = ({
                                 HTMLInputElement | HTMLTextAreaElement
                             >
                         ): void => handleSetTime('end', event.target.value)}
+                        disabled={isDisabled}
                     />
                 </div>
                 {errors && errors['time'] && (
@@ -408,6 +409,7 @@ const GeneralInfo = ({
                                 return { ...gi, location: e.target.value };
                             });
                         }}
+                        disabled={isDisabled}
                     />
                 </LocationContainer>
                 {errors && errors['location'] && (

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Participants/Participants.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Participants/Participants.tsx
@@ -73,12 +73,14 @@ interface ParticipantsProps {
     participants: Participant[];
     setParticipants: React.Dispatch<React.SetStateAction<Participant[]>>;
     availableRoles: RoleParticipant[];
+    invitationStarted?: boolean;
 }
 
 const Participants = ({
     participants,
     setParticipants,
     availableRoles,
+    invitationStarted,
 }: ParticipantsProps): JSX.Element => {
     const [filteredPersons, setFilteredPersons] = useState<SelectItem[]>([]);
     const [personsFilter, setPersonsFilter] = useState<SelectItem>({
@@ -272,6 +274,7 @@ const Participants = ({
             externalEmail: null,
             person: null,
             role: null,
+            signedAt: null,
         };
         setParticipants([...participants, newParticipant]);
     };
@@ -394,8 +397,11 @@ const Participants = ({
                                         data={ParticipantType}
                                         label={'Type'}
                                         disabled={
+                                            (invitationStarted &&
+                                                p.signedAt &&
+                                                index < 2) ||
                                             p.organization.value ==
-                                            OrganizationsEnum.External
+                                                OrganizationsEnum.External
                                         }
                                     >
                                         {p.type}
@@ -432,6 +438,15 @@ const Participants = ({
                                                 label={'Person'}
                                                 maxHeight="300px"
                                                 variant="form"
+                                                disabled={
+                                                    index < 2
+                                                        ? invitationStarted
+                                                            ? p.signedAt
+                                                                ? true
+                                                                : false
+                                                            : false
+                                                        : false
+                                                }
                                                 onFilter={(
                                                     input: string
                                                 ): void =>
@@ -495,6 +510,15 @@ const Participants = ({
                                             }
                                             roles={getRolesCopy()}
                                             label={'Role'}
+                                            disabled={
+                                                index < 2
+                                                    ? invitationStarted
+                                                        ? p.signedAt
+                                                            ? true
+                                                            : false
+                                                        : false
+                                                    : false
+                                            }
                                         >
                                             {p.role ? (
                                                 <Tooltip

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Participants/Participants.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/Participants/Participants.tsx
@@ -370,6 +370,11 @@ const Participants = ({
             <FormContainer>
                 <ParticipantRowsContainer>
                     {participants.map((p, index) => {
+                        const disableEditing: boolean = invitationStarted
+                            ? p.signedAt
+                                ? true
+                                : false
+                            : false;
                         return (
                             <React.Fragment key={`participant_${index}`}>
                                 <div>
@@ -379,7 +384,7 @@ const Participants = ({
                                         }
                                         data={Organizations}
                                         label={'Organization'}
-                                        disabled={index < 2}
+                                        disabled={index < 2 || disableEditing}
                                     >
                                         {p.organization.text
                                             ? getOrganizationText(
@@ -397,9 +402,7 @@ const Participants = ({
                                         data={ParticipantType}
                                         label={'Type'}
                                         disabled={
-                                            (invitationStarted &&
-                                                p.signedAt &&
-                                                index < 2) ||
+                                            disableEditing ||
                                             p.organization.value ==
                                                 OrganizationsEnum.External
                                         }
@@ -438,15 +441,7 @@ const Participants = ({
                                                 label={'Person'}
                                                 maxHeight="300px"
                                                 variant="form"
-                                                disabled={
-                                                    index < 2
-                                                        ? invitationStarted
-                                                            ? p.signedAt
-                                                                ? true
-                                                                : false
-                                                            : false
-                                                        : false
-                                                }
+                                                disabled={disableEditing}
                                                 onFilter={(
                                                     input: string
                                                 ): void =>
@@ -510,15 +505,7 @@ const Participants = ({
                                             }
                                             roles={getRolesCopy()}
                                             label={'Role'}
-                                            disabled={
-                                                index < 2
-                                                    ? invitationStarted
-                                                        ? p.signedAt
-                                                            ? true
-                                                            : false
-                                                        : false
-                                                    : false
-                                            }
+                                            disabled={disableEditing}
                                         >
                                             {p.role ? (
                                                 <Tooltip
@@ -540,7 +527,7 @@ const Participants = ({
                                     </div>
                                 )}
                                 <div>
-                                    {index > 1 && (
+                                    {index > 1 && !disableEditing && (
                                         <>
                                             <Button
                                                 title="Delete"

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/SelectScope/SelectScope.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/SelectScope/SelectScope.tsx
@@ -24,6 +24,7 @@ interface SelectScopeProps {
     setSelectedMcPkgScope: React.Dispatch<React.SetStateAction<McScope>>;
     commPkgNo: string | null;
     projectName: string;
+    isDisabled?: boolean;
 }
 
 const SelectScope = ({
@@ -34,6 +35,7 @@ const SelectScope = ({
     setSelectedMcPkgScope,
     commPkgNo,
     projectName,
+    isDisabled,
 }: SelectScopeProps): JSX.Element => {
     const [currentCommPkg, setCurrentCommPkg] = useState<string | null>(null);
     const commPkgRef = useRef<any>();
@@ -92,57 +94,70 @@ const SelectScope = ({
 
     return (
         <Container>
-            <SelectComponent>
-                <Header>
-                    {currentCommPkg != null && commPkgNo == null && (
-                        <Button
-                            id="backButton"
-                            onClick={(): void => setCurrentCommPkg(null)}
-                            variant="ghost_icon"
-                        >
-                            <EdsIcon name="arrow_back" />
-                        </Button>
-                    )}
-                    <Typography variant="h2">
-                        {currentCommPkg == null
-                            ? type === 'DP'
-                                ? 'Click on the arrow next to a comm pkg to open MC scope'
-                                : 'Select commissioning packages'
-                            : type === 'DP'
-                            ? 'Select MC packages in comm pkg ' + currentCommPkg
-                            : 'Scope has been preselected'}
-                    </Typography>
-                </Header>
-                {(currentCommPkg == null ||
-                    (commPkgNo != null && type == 'MDP')) && (
-                    <div>
-                        <CommPkgTable
-                            ref={commPkgRef}
-                            selectedCommPkgScope={selectedCommPkgScope}
-                            setSelectedCommPkgScope={setSelectedCommPkgScope}
-                            selectedMcPkgScope={selectedMcPkgScope.selected}
-                            setCurrentCommPkg={setCurrentCommPkg}
-                            type={type}
-                            projectName={projectName}
-                            filter={commPkgFilter}
-                            setFilter={setCommPkgFilter}
-                            commPkgNo={commPkgNo}
-                        />
-                    </div>
-                )}
-                {currentCommPkg != null &&
-                    (commPkgNo == null ||
-                        (commPkgNo != null && type == 'DP')) && (
-                        <McPkgTable
-                            ref={mcPkgRef}
-                            selectedMcPkgScope={selectedMcPkgScope}
-                            setSelectedMcPkgScope={setSelectedMcPkgScope}
-                            projectName={projectName}
-                            commPkgNo={currentCommPkg}
-                        />
-                    )}
-            </SelectComponent>
-            <Divider />
+            {!isDisabled && (
+                <>
+                    <SelectComponent>
+                        <Header>
+                            {currentCommPkg != null && commPkgNo == null && (
+                                <Button
+                                    id="backButton"
+                                    onClick={(): void =>
+                                        setCurrentCommPkg(null)
+                                    }
+                                    variant="ghost_icon"
+                                >
+                                    <EdsIcon name="arrow_back" />
+                                </Button>
+                            )}
+                            <Typography variant="h2">
+                                {currentCommPkg == null
+                                    ? type === 'DP'
+                                        ? 'Click on the arrow next to a comm pkg to open MC scope'
+                                        : 'Select commissioning packages'
+                                    : type === 'DP'
+                                    ? 'Select MC packages in comm pkg ' +
+                                      currentCommPkg
+                                    : 'Scope has been preselected'}
+                            </Typography>
+                        </Header>
+                        {(currentCommPkg == null ||
+                            (commPkgNo != null && type == 'MDP')) && (
+                            <div>
+                                <CommPkgTable
+                                    ref={commPkgRef}
+                                    selectedCommPkgScope={selectedCommPkgScope}
+                                    setSelectedCommPkgScope={
+                                        setSelectedCommPkgScope
+                                    }
+                                    selectedMcPkgScope={
+                                        selectedMcPkgScope.selected
+                                    }
+                                    setCurrentCommPkg={setCurrentCommPkg}
+                                    type={type}
+                                    projectName={projectName}
+                                    filter={commPkgFilter}
+                                    setFilter={setCommPkgFilter}
+                                    commPkgNo={commPkgNo}
+                                />
+                            </div>
+                        )}
+                        {currentCommPkg != null &&
+                            (commPkgNo == null ||
+                                (commPkgNo != null && type == 'DP')) && (
+                                <McPkgTable
+                                    ref={mcPkgRef}
+                                    selectedMcPkgScope={selectedMcPkgScope}
+                                    setSelectedMcPkgScope={
+                                        setSelectedMcPkgScope
+                                    }
+                                    projectName={projectName}
+                                    commPkgNo={currentCommPkg}
+                                />
+                            )}
+                    </SelectComponent>
+                    <Divider />
+                </>
+            )}
             <SelectedScope
                 selectedCommPkgs={selectedCommPkgScope}
                 removeCommPkg={(commPkgNo: string): void =>
@@ -153,6 +168,7 @@ const SelectScope = ({
                     handleRemoveMcPkg(mcPkgNo)
                 }
                 multipleDisciplines={selectedMcPkgScope.multipleDisciplines}
+                isDisabled={isDisabled}
             />
         </Container>
     );

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/SelectScope/SelectedScope.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/SelectScope/SelectedScope.tsx
@@ -25,6 +25,7 @@ interface SelectedScopeProps {
     removeCommPkg: (commPkgNo: string) => void;
     removeMcPkg: (mcPkgNo: string) => void;
     multipleDisciplines: boolean;
+    isDisabled?: boolean;
 }
 
 const SelectedScope = ({
@@ -33,6 +34,7 @@ const SelectedScope = ({
     selectedMcPkgs = [],
     removeMcPkg,
     multipleDisciplines,
+    isDisabled,
 }: SelectedScopeProps): JSX.Element => {
     const numberOfPackagesSelected = (): number => {
         if (selectedMcPkgs.length > 0) {
@@ -48,12 +50,16 @@ const SelectedScope = ({
             <Accordion.Item key={commPkg.commPkgNo}>
                 <Accordion.Header>
                     {commPkg.commPkgNo}
-                    <Button
-                        variant="ghost_icon"
-                        onClick={(): void => removeCommPkg(commPkg.commPkgNo)}
-                    >
-                        <EdsIcon name="delete_to_trash"></EdsIcon>
-                    </Button>
+                    {!isDisabled && (
+                        <Button
+                            variant="ghost_icon"
+                            onClick={(): void =>
+                                removeCommPkg(commPkg.commPkgNo)
+                            }
+                        >
+                            <EdsIcon name="delete_to_trash"></EdsIcon>
+                        </Button>
+                    )}
                 </Accordion.Header>
                 <Accordion.Panel>
                     <AccordionContent>
@@ -84,12 +90,14 @@ const SelectedScope = ({
             <Accordion.Item key={mcPkg.mcPkgNo}>
                 <Accordion.Header>
                     {mcPkg.mcPkgNo}
-                    <Button
-                        variant="ghost_icon"
-                        onClick={(): void => removeMcPkg(mcPkg.mcPkgNo)}
-                    >
-                        <EdsIcon name="delete_to_trash"></EdsIcon>
-                    </Button>
+                    {!isDisabled && (
+                        <Button
+                            variant="ghost_icon"
+                            onClick={(): void => removeMcPkg(mcPkg.mcPkgNo)}
+                        >
+                            <EdsIcon name="delete_to_trash"></EdsIcon>
+                        </Button>
+                    )}
                 </Accordion.Header>
                 <Accordion.Panel>
                     <AccordionContent>

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/__tests__/EditIPO.test.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/__tests__/EditIPO.test.tsx
@@ -225,37 +225,6 @@ describe('<EditIPO />', () => {
         expect(queryByText('Delete IPO')).toBeInTheDocument();
     });
 
-    it('Should display "Delete IPO"-button when isCancelled is true, isUsingAdminRights is true and canDelete is false', async () => {
-        const { queryByText } = render(
-            <ViewIPOHeader
-                ipoId={1}
-                steps={initialSteps}
-                isCancelled={true}
-                currentStep={1}
-                title={'test'}
-                organizer="test"
-                participants={[]}
-                isEditable={true}
-                showEditButton={true}
-                canDelete={false}
-                deletePunchOut={(): void => {
-                    /*mock*/
-                }}
-                canCancel={true}
-                cancelPunchOut={(): void => {
-                    /*mock*/
-                }}
-                isAdmin={false}
-                isUsingAdminRights={true}
-                setIsUsingAdminRights={(): void => {
-                    /*mock*/
-                }}
-            />
-        );
-
-        expect(queryByText('Delete IPO')).toBeInTheDocument();
-    });
-
     it('Should not display "Delete IPO"-button when isCancelled is true, isUsingAdminRights is false and canDelete is false', async () => {
         const { queryByText } = render(
             <ViewIPOHeader

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/ViewIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/ViewIPO.tsx
@@ -514,9 +514,20 @@ const ViewIPO = (): JSX.Element => {
                         title={invitation.title}
                         organizer={`${invitation.createdBy.firstName} ${invitation.createdBy.lastName}`}
                         participants={invitation.participants}
-                        isEditable={invitation.status == IpoStatusEnum.PLANNED}
-                        showEditButton={invitation.canEdit}
-                        canDelete={invitation.canDelete}
+                        isEditable={
+                            invitation.status == IpoStatusEnum.PLANNED ||
+                            (isAdmin && isUsingAdminRights)
+                        }
+                        showEditButton={
+                            invitation.canEdit ||
+                            (isAdmin && isUsingAdminRights)
+                        }
+                        canDelete={
+                            invitation.canDelete ||
+                            (invitation.status === IpoStatusEnum.CANCELED &&
+                                isAdmin &&
+                                isUsingAdminRights)
+                        }
                         canCancel={invitation.canCancel}
                         deletePunchOut={deletePunchOut}
                         cancelPunchOut={cancelPunchOut}

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/ViewIPOHeader.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/ViewIPOHeader.tsx
@@ -89,7 +89,7 @@ const ViewIPOHeader = ({
                     <Typography variant="h2">{`IPO-${ipoId}: ${title}`}</Typography>
                 </ButtonContainer>
                 <ButtonContainer>
-                    {(canDelete || (isCancelled && isUsingAdminRights)) && (
+                    {canDelete && (
                         <>
                             <Button
                                 variant="outlined"


### PR DESCRIPTION
# Description

Allowing admins to edit IPOs they aren't invited to, even if the IPO is started.

Completes: [AB#89434](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/89434)

# Checklist:

- [ ] I have performed a self-review of my own code.
- [ ] I have linked my DevOps task using the AB# tag.
- [ ] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
