### PR TITLE
Increased z-index for quicksearch div

### DIFF
--- a/src/modules/QuickSearch/style.ts
+++ b/src/modules/QuickSearch/style.ts
@@ -273,7 +273,7 @@ export const QuickSearchResultsContainer = styled.div`
     background: white;
     border: 1px solid lightgray;
     border-radius: 4px;
-    z-index: 20;
+    z-index: 300;
     padding-top: 8px;
     padding-bottom: 8px;
     overflow: auto;


### PR DESCRIPTION
# Description
QuickSearch results appeared behind other divs. Has to be on top.

Completes: [AB#95265](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/95265)

# Checklist:

- [X] I have performed a self-review of my own code.
- [X] I have linked my DevOps task using the AB# tag.
- [X] My code is easy to read, and comments are added where needed.
- [X] My code is covered by tests.
