### PR TITLE
Bug/96128 ipo error message when creating ipo without sufficient access

### DIFF
--- a/src/core/ProCoSysApiError.ts
+++ b/src/core/ProCoSysApiError.ts
@@ -1,4 +1,5 @@
 import Axios, { AxiosError, AxiosResponse } from 'axios';
+import { isOfType } from './services/TypeGuard';
 
 interface ErrorResponse {
     ErrorCount: number;
@@ -7,6 +8,16 @@ interface ErrorResponse {
         ErrorMessage: string;
     }[];
 }
+
+export type Errors = {
+    IpoException: string[];
+    status: number;
+    title: string;
+};
+
+export type dataError = {
+    errors: Errors;
+};
 
 export class ProCoSysApiError extends Error {
     data: AxiosResponse | null;
@@ -31,7 +42,17 @@ export class ProCoSysApiError extends Error {
         } else if (error.response.status == 403) {
             super('You are not authorized to perform this operation.');
         } else if (error.response.status == 400) {
-            super(error.response.data ? `${error.response.data}` : undefined);
+            if (isOfType<dataError>(error.response.data, 'errors')) {
+                super(
+                    error.response.data
+                        ? `${error.response.data.errors.IpoException}`
+                        : undefined
+                );
+            } else {
+                super(
+                    error.response.data ? `${error.response.data}` : undefined
+                );
+            }
         } else {
             try {
                 const apiErrorResponse = error.response.data as ErrorResponse;

--- a/src/core/services/TypeGuard.ts
+++ b/src/core/services/TypeGuard.ts
@@ -1,0 +1,6 @@
+export const isOfType = <T>(
+    varToBeChecked: unknown,
+    propertyToCheckFor: keyof T
+): varToBeChecked is T => {
+    return (varToBeChecked as T)[propertyToCheckFor] !== undefined;
+};


### PR DESCRIPTION
# Description

Checking if ipoexception is part of error response
Added typeguard function

Completes: [AB#96128](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/96128)

# Checklist:

- [ ] I have performed a self-review of my own code.
- [ ] I have linked my DevOps task using the AB# tag.
- [ ] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
