### PR TITLE
bug/98467 - IPO - not possible to scroll through functional role list to see outlook response

### DIFF
--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/CustomPopover/CustomPopover.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/CustomPopover/CustomPopover.tsx
@@ -65,7 +65,7 @@ const CustomPopover = ({ participant }: CustomPopoverProps): JSX.Element => {
                         />
                     </Button>
                 </Popover.Header>
-                <Popover.Content>
+                <Popover.Content style={{ overflow: 'scroll' }}>
                     <CustomTable>
                         {participant.functionalRole.persons.map((person) => {
                             return (

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/CustomPopover/CustomPopover.tsx
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/CustomPopover/CustomPopover.tsx
@@ -1,6 +1,7 @@
 import {
     CustomTable,
     FloatingPopover,
+    PopoverContent,
     TableCell,
     TableCellRight,
     TableRow,
@@ -12,7 +13,6 @@ import EdsIcon from '@procosys/components/EdsIcon';
 import { Participant } from '../../../types';
 import { Popover } from '@equinor/eds-core-react';
 import { tokens } from '@equinor/eds-tokens';
-import { Icon } from '@equinor/eds-core-react';
 
 interface CustomPopoverProps {
     participant: Participant;
@@ -65,7 +65,7 @@ const CustomPopover = ({ participant }: CustomPopoverProps): JSX.Element => {
                         />
                     </Button>
                 </Popover.Header>
-                <Popover.Content style={{ overflow: 'scroll' }}>
+                <PopoverContent>
                     <CustomTable>
                         {participant.functionalRole.persons.map((person) => {
                             return (
@@ -83,7 +83,7 @@ const CustomPopover = ({ participant }: CustomPopoverProps): JSX.Element => {
                             );
                         })}
                     </CustomTable>
-                </Popover.Content>
+                </PopoverContent>
             </FloatingPopover>
         </>
     );

--- a/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/CustomPopover/style.ts
+++ b/src/modules/InvitationForPunchOut/views/ViewIPO/GeneralInfo/ParticipantsTable/CustomPopover/style.ts
@@ -20,4 +20,9 @@ export const TableCellRight = styled(TableCell)`
 
 export const FloatingPopover = styled(Popover)`
     margin-left: auto;
+    max-height: 300px;
+`;
+
+export const PopoverContent = styled(Popover.Content)`
+    overflow: auto;
 `;


### PR DESCRIPTION
# Description

Added overflow scroll for response popup

Completes: [AB#98467](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/98467)

# Checklist:

- [ ] I have performed a self-review of my own code.
- [ ] I have linked my DevOps task using the AB# tag.
- [ ] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
