### PR TITLE
76108/preservationUI-Voidede-tags-er-grå-i-transfer-dialog

### DIFF
--- a/src/modules/Preservation/views/ScopeOverview/Dialogs/SharedCode/DialogTable.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/Dialogs/SharedCode/DialogTable.tsx
@@ -3,24 +3,35 @@ import { PreservedTag } from '../../types';
 import { Container } from './DialogTable.style';
 import ProcosysTable from '@procosys/components/Table';
 
-interface TableProps {
+interface RequiredTableProps {
     tags: PreservedTag[];
     columns: any[];
     toolbarText?: string;
     toolbarColor?: string;
 }
 
+interface OptionalTableProps {
+    textColor: string;
+}
+
+interface TableProps extends RequiredTableProps, OptionalTableProps {}
+
+const defaultProps: OptionalTableProps = {
+    textColor: 'black',
+};
+
 const DialogTable = ({
     tags,
     columns,
     toolbarText,
     toolbarColor,
+    textColor,
 }: TableProps): JSX.Element => {
     const numTags = tags.length;
 
     return (
         <Container>
-            <div>
+            <div style={{ color: textColor }}>
                 <ProcosysTable
                     columns={columns}
                     data={tags}
@@ -37,5 +48,7 @@ const DialogTable = ({
         </Container>
     );
 };
+
+DialogTable.defaultProps = defaultProps;
 
 export default DialogTable;

--- a/src/modules/Preservation/views/ScopeOverview/Dialogs/SharedCode/DialogTable.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/Dialogs/SharedCode/DialogTable.tsx
@@ -3,35 +3,24 @@ import { PreservedTag } from '../../types';
 import { Container } from './DialogTable.style';
 import ProcosysTable from '@procosys/components/Table';
 
-interface RequiredTableProps {
+interface TableProps {
     tags: PreservedTag[];
     columns: any[];
     toolbarText?: string;
     toolbarColor?: string;
 }
 
-interface OptionalTableProps {
-    textColor: string;
-}
-
-interface TableProps extends RequiredTableProps, OptionalTableProps {}
-
-const defaultProps: OptionalTableProps = {
-    textColor: 'black',
-};
-
 const DialogTable = ({
     tags,
     columns,
     toolbarText,
     toolbarColor,
-    textColor,
 }: TableProps): JSX.Element => {
     const numTags = tags.length;
 
     return (
         <Container>
-            <div style={{ color: textColor }}>
+            <div>
                 <ProcosysTable
                     columns={columns}
                     data={tags}
@@ -48,7 +37,5 @@ const DialogTable = ({
         </Container>
     );
 };
-
-DialogTable.defaultProps = defaultProps;
 
 export default DialogTable;

--- a/src/modules/Preservation/views/ScopeOverview/Dialogs/TransferDialog.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/Dialogs/TransferDialog.tsx
@@ -14,9 +14,11 @@ interface TransferDialogProps {
     nonTransferableTags: PreservedTag[];
 }
 
-const OverflowColumn = styled.div`
+const OverflowColumn = styled.div<{ isVoided: boolean }>`
     text-overflow: ellipsis;
     overflow: hidden;
+    color: inherit;
+    opacity: ${(props): string => (props.isVoided ? '0.5' : '1')};
 `;
 
 const getRequirementIcons = (row: TableOptions<PreservedTag>): JSX.Element => {
@@ -33,14 +35,7 @@ const getTagNoCell = (row: TableOptions<PreservedTag>): JSX.Element => {
             enterDelay={200}
             enterNextDelay={100}
         >
-            <OverflowColumn
-                style={{
-                    color: 'inherit',
-                    opacity: tag.isVoided ? '0.5' : '1',
-                }}
-            >
-                {tag.tagNo}
-            </OverflowColumn>
+            <OverflowColumn isVoided={tag.isVoided}>{tag.tagNo}</OverflowColumn>
         </Tooltip>
     );
 };
@@ -54,7 +49,9 @@ const getDescriptionCell = (row: TableOptions<PreservedTag>): JSX.Element => {
             enterDelay={200}
             enterNextDelay={100}
         >
-            <OverflowColumn>{tag.description}</OverflowColumn>
+            <OverflowColumn isVoided={tag.isVoided}>
+                {tag.description}
+            </OverflowColumn>
         </Tooltip>
     );
 };
@@ -68,7 +65,7 @@ const getModeCell = (row: TableOptions<PreservedTag>): JSX.Element => {
             enterDelay={200}
             enterNextDelay={100}
         >
-            <OverflowColumn>{tag.mode}</OverflowColumn>
+            <OverflowColumn isVoided={tag.isVoided}>{tag.mode}</OverflowColumn>
         </Tooltip>
     );
 };
@@ -82,7 +79,9 @@ const getResponsibleCell = (row: TableOptions<PreservedTag>): JSX.Element => {
             enterDelay={200}
             enterNextDelay={100}
         >
-            <OverflowColumn>{tag.responsibleCode}</OverflowColumn>
+            <OverflowColumn isVoided={tag.isVoided}>
+                {tag.responsibleCode}
+            </OverflowColumn>
         </Tooltip>
     );
 };
@@ -96,7 +95,9 @@ const getNextModeCell = (row: TableOptions<PreservedTag>): JSX.Element => {
             enterDelay={200}
             enterNextDelay={100}
         >
-            <OverflowColumn>{tag.nextMode}</OverflowColumn>
+            <OverflowColumn isVoided={tag.isVoided}>
+                {tag.nextMode}
+            </OverflowColumn>
         </Tooltip>
     );
 };
@@ -112,7 +113,9 @@ const getNextResponsibleCell = (
             enterDelay={200}
             enterNextDelay={100}
         >
-            <OverflowColumn>{tag.nextResponsibleCode}</OverflowColumn>
+            <OverflowColumn isVoided={tag.isVoided}>
+                {tag.nextResponsibleCode}
+            </OverflowColumn>
         </Tooltip>
     );
 };
@@ -126,7 +129,9 @@ const getStatusCell = (row: TableOptions<PreservedTag>): JSX.Element => {
             enterDelay={200}
             enterNextDelay={100}
         >
-            <OverflowColumn>{tag.status}</OverflowColumn>
+            <OverflowColumn isVoided={tag.isVoided}>
+                {tag.status}
+            </OverflowColumn>
         </Tooltip>
     );
 };

--- a/src/modules/Preservation/views/ScopeOverview/Dialogs/TransferDialog.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/Dialogs/TransferDialog.tsx
@@ -202,6 +202,9 @@ const TransferDialog = ({
                         toolbarColor={
                             tokens.colors.interactive.danger__text.rgba
                         }
+                        textColor={
+                            tokens.colors.interactive.disabled__text.rgba
+                        }
                     />
                 </TableContainer>
             )}

--- a/src/modules/Preservation/views/ScopeOverview/Dialogs/TransferDialog.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/Dialogs/TransferDialog.tsx
@@ -33,7 +33,14 @@ const getTagNoCell = (row: TableOptions<PreservedTag>): JSX.Element => {
             enterDelay={200}
             enterNextDelay={100}
         >
-            <OverflowColumn>{tag.tagNo}</OverflowColumn>
+            <OverflowColumn
+                style={{
+                    color: 'inherit',
+                    opacity: tag.isVoided ? '0.5' : '1',
+                }}
+            >
+                {tag.tagNo}
+            </OverflowColumn>
         </Tooltip>
     );
 };
@@ -201,9 +208,6 @@ const TransferDialog = ({
                         toolbarText="tag(s) cannot be transferred"
                         toolbarColor={
                             tokens.colors.interactive.danger__text.rgba
-                        }
-                        textColor={
-                            tokens.colors.interactive.disabled__text.rgba
                         }
                     />
                 </TableContainer>


### PR DESCRIPTION
# Description

Added textColour as optional colour in DialogTable and standard as black

Completes: [AB#76108](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/76108)

# Checklist:

- [ ] I have performed a self-review of my own code.
- [ ] I have linked my DevOps task using the AB# tag.
- [ ] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
