### PR TITLE
Allow saving IPO-filter with no project

### DIFF
--- a/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
+++ b/src/modules/InvitationForPunchOut/http/InvitationForPunchOutApiClient.ts
@@ -1114,7 +1114,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
      * @param setRequestCanceller Returns a function that can be called to cancel the request
      */
     async getSavedIPOFilters(
-        projectName: string,
+        projectName: string | null,
         setRequestCanceller?: RequestCanceler
     ): Promise<SavedIPOFilterResponse[]> {
         const endpoint = '/Persons/SavedFilters';
@@ -1141,7 +1141,7 @@ class InvitationForPunchOutApiClient extends ApiClient {
      * @param setRequestCanceller Returns a function that can be called to cancel the request
      */
     async addSavedIPOFilter(
-        projectName: string,
+        projectName: string | null,
         title: string,
         defaultFilter: boolean,
         criteria: string,

--- a/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateIPO.tsx
+++ b/src/modules/InvitationForPunchOut/views/CreateAndEditIPO/CreateIPO.tsx
@@ -121,8 +121,11 @@ const initialParticipants: Participant[] = [
 
 const CreateIPO = (): JSX.Element => {
     const user = useCurrentUser();
-    const params =
-        useParams<{ ipoId: any; projectName: any; commPkgNo: any }>();
+    const params = useParams<{
+        ipoId: any;
+        projectName: any;
+        commPkgNo: any;
+    }>();
 
     const initialSteps: Step[] = [
         { title: 'General info', isCompleted: false },

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/Filter/SavedFilters/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/Filter/SavedFilters/index.tsx
@@ -54,7 +54,7 @@ const SavedFilters = (props: SavedFiltersProps): JSX.Element => {
         }
         try {
             await apiClient.addSavedIPOFilter(
-                props.project.name,
+                props.project.id === -1 ? null : props.project.name,
                 newFilterTitle,
                 newFilterIsDefault,
                 JSON.stringify(props.ipoFilter)

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/Filter/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/Filter/index.tsx
@@ -177,7 +177,7 @@ const InvitationsFilter = ({
                 setSelectedFilterIndex(filterIndex);
                 if (
                     JSON.stringify(localFilter) !=
-                    savedFilters[filterIndex].criteria
+                    savedFilters[filterIndex]?.criteria
                 ) {
                     setSelectedSavedFilterTitle(null);
                     setSelectedFilterIndex(null);

--- a/src/modules/InvitationForPunchOut/views/SearchIPO/index.tsx
+++ b/src/modules/InvitationForPunchOut/views/SearchIPO/index.tsx
@@ -88,7 +88,9 @@ const SearchIPO = (): JSX.Element => {
             return;
         }
         try {
-            const response = await apiClient.getSavedIPOFilters(project.name);
+            const response = await apiClient.getSavedIPOFilters(
+                project.name === 'All projects' ? null : project.name
+            );
             setSavedFilters(response);
         } catch (error) {
             console.error(
@@ -102,9 +104,7 @@ const SearchIPO = (): JSX.Element => {
     };
 
     useEffect((): void => {
-        if (project && project.id != -1) {
-            updateSavedFilters();
-        }
+        updateSavedFilters();
     }, [project]);
 
     const getDefaultFilter = (): SavedIPOFilter | undefined => {
@@ -119,8 +119,6 @@ const SearchIPO = (): JSX.Element => {
 
     useEffect((): void => {
         if (hasProjectChanged) {
-            if (project && project.id === -1) return;
-
             if (savedFilters) {
                 const defaultFilter = getDefaultFilter();
                 if (defaultFilter) {


### PR DESCRIPTION
# Description
Allow users to save IPO-filter without choosing a project first.

Completes: [AB#102356](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/102356)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [x] My code is covered by tests.
