### PR TITLE
Bug/102715 preservation attachment on requirements saves to the wrong requirement

### DIFF
--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/RequirementAttachmentField.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/RequirementAttachmentField.tsx
@@ -64,7 +64,6 @@ const RequirementAttachmentField = ({
 
     const recordAttachment = async (file: File): Promise<void> => {
         try {
-            console.log('adding file to ' + requirementId);
             setIsLoading(true);
             await apiClient.recordAttachmentOnTagRequirement(
                 tagId,
@@ -117,7 +116,6 @@ const RequirementAttachmentField = ({
     };
 
     const handleSubmitFile = (e: any): void => {
-        console.log('handled submit file on ' + requirementId);
         e.preventDefault();
         const file = e.target.files[0];
         recordAttachment(file);

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/RequirementAttachmentField.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/RequirementAttachmentField.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import { TagRequirementField } from '../types';
 import { usePreservationContext } from '@procosys/modules/Preservation/context/PreservationContext';
@@ -64,6 +64,7 @@ const RequirementAttachmentField = ({
 
     const recordAttachment = async (file: File): Promise<void> => {
         try {
+            console.log('adding file to ' + requirementId);
             setIsLoading(true);
             await apiClient.recordAttachmentOnTagRequirement(
                 tagId,
@@ -116,9 +117,18 @@ const RequirementAttachmentField = ({
     };
 
     const handleSubmitFile = (e: any): void => {
+        console.log('handled submit file on ' + requirementId);
         e.preventDefault();
         const file = e.target.files[0];
         recordAttachment(file);
+    };
+
+    const inputFileRef = useRef<HTMLInputElement>(null);
+
+    const handleAddFile = (): void => {
+        if (inputFileRef.current) {
+            inputFileRef.current.click();
+        }
     };
 
     if (isLoading) {
@@ -144,13 +154,14 @@ const RequirementAttachmentField = ({
             <div style={{ display: 'flex', flexDirection: 'row' }}>
                 <div style={{ marginTop: 'var(--grid-unit)' }}>
                     <form>
-                        <label htmlFor="uploadFile">
-                            <SelectFileButton>Select file</SelectFileButton>
-                        </label>
+                        <SelectFileButton onClick={handleAddFile}>
+                            Select file
+                        </SelectFileButton>
                         <input
                             id="uploadFile"
                             style={{ display: 'none' }}
                             type="file"
+                            ref={inputFileRef}
                             onChange={handleSubmitFile}
                         />
                     </form>

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
@@ -265,8 +265,6 @@ const Requirements = ({
         requirementId: number,
         field: TagRequirementField
     ): JSX.Element => {
-        console.log('field for ' + requirementId);
-        console.log('field: ' + field.id);
         switch (field.fieldType.toLowerCase()) {
             case 'info':
                 return (
@@ -310,7 +308,6 @@ const Requirements = ({
         <div>
             {requirements.map((requirement) => {
                 const isOverdue = requirement.nextDueWeeks < 0;
-                console.log(requirement.id);
                 return (
                     <Container key={requirement.id}>
                         <Section>

--- a/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/TagFlyout/PreservationTab/Requirements.tsx
@@ -265,6 +265,8 @@ const Requirements = ({
         requirementId: number,
         field: TagRequirementField
     ): JSX.Element => {
+        console.log('field for ' + requirementId);
+        console.log('field: ' + field.id);
         switch (field.fieldType.toLowerCase()) {
             case 'info':
                 return (
@@ -308,7 +310,7 @@ const Requirements = ({
         <div>
             {requirements.map((requirement) => {
                 const isOverdue = requirement.nextDueWeeks < 0;
-
+                console.log(requirement.id);
                 return (
                     <Container key={requirement.id}>
                         <Section>


### PR DESCRIPTION
# Description

Added a ref to allow browser to remember which input the user used to upload an attachment. Otherwise it uses the first one, which caused some issues in preservation.

Completes: [AB#102715](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/102715)

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
