### PR TITLE
fix: update route path

### DIFF
--- a/src/modules/Preservation/index.tsx
+++ b/src/modules/Preservation/index.tsx
@@ -17,7 +17,7 @@ const Preservation = (): JSX.Element => {
                 <ClosedProjectWarning />
                 <Routes>
                     <Route
-                        path="AddScope/:method/:duplicateTagId?"
+                        path="AddScope/:method/:duplicateTagId"
                         element={
                             <>
                                 <Helmet>

--- a/src/modules/Preservation/views/AddScope/AddScope.tsx
+++ b/src/modules/Preservation/views/AddScope/AddScope.tsx
@@ -288,7 +288,7 @@ const AddScope = (): JSX.Element => {
                     'Tag is successfully added to scope',
                     5000
                 );
-                navigate('/');
+                navigate(-1);
             } else {
                 if (stepId && requirements) {
                     switch (addScopeMethod) {

--- a/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
+++ b/src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx
@@ -1089,7 +1089,7 @@ const ScopeOverview: React.FC = (): JSX.Element => {
                                                       (selectedTags.length == 1
                                                           ? selectedTags[0].id.toString()
                                                           : '')
-                                                    : '/'
+                                                    : ''
                                             }
                                         >
                                             <DropdownItem


### PR DESCRIPTION
# Description

This pull request makes adjustments to navigation and routing behavior within the `Preservation` module to improve user experience and ensure consistency. The most important changes involve modifying route parameters, navigation logic, and default paths.

<details><summary>Routing and navigation update</summary>
<p>

* In `src/modules/Preservation/index.tsx`, removed the optional `:duplicateTagId?` parameter from the `AddScope` route, making it mandatory. This ensures that the route always expects a `duplicateTagId` when navigating to `AddScope`.

* In `src/modules/Preservation/views/AddScope/AddScope.tsx`, updated the navigation behavior to go back to the previous page (`navigate(-1)`) instead of redirecting to the root path (`'/'`) after successfully adding a tag to the scope. This improves user flow by keeping them in the context of their previous actions.

* In `src/modules/Preservation/views/ScopeOverview/ScopeOverview.tsx`, changed the fallback path for a dropdown item from `'/'` to an empty string (`''`) when no specific condition is met. This prevents unintended redirection to the root path.

</p>
</details> 


# Checklist:

- [ ] I have performed a self-review of my own code.
- [ ] I have linked my DevOps task using the AB# tag.
- [ ] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
