### PR TITLE
fix: allow for paginating of attachments

### DIFF
--- a/src/components/AttachmentList/index.tsx
+++ b/src/components/AttachmentList/index.tsx
@@ -293,11 +293,8 @@ const AttachmentList = ({
                     clientSorting={true}
                     rowSelect={false}
                     maxRowCount={large ? attachments.length : undefined}
-                    pageCount={
-                        large ? Math.ceil(attachments.length / 25) : undefined
-                    }
+                    pageCount={large ? Math.ceil(attachments.length / 25) : undefined}
                     toolbar={determineToolbarButtonRender()}
-                    disablePagination
                 />
             </TableContainer>
         </Container>


### PR DESCRIPTION
# Description

This pull request makes a minor change to the `AttachmentList` component by removing the `disablePagination` prop from the table configuration. This will allow pagination to be enabled when appropriate.

> [!NOTE]
> it will also have impact on not only IPO but for Preservation.

Closes equinor/cc-toolbox#1256

# Checklist:

- [x] I have performed a self-review of my own code.
- [ ] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read, and comments are added where needed.
- [ ] My code is covered by tests.
